### PR TITLE
Add player character and movement

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,10 +1,78 @@
-import { loadMap, renderMap } from './mapLoader.js';
+import { loadMap, renderMap, getCurrentGrid } from './mapLoader.js';
+
+function findFirstWalkable(grid) {
+  for (let y = 0; y < grid.length; y++) {
+    for (let x = 0; x < grid[y].length; x++) {
+      if (grid[y][x] === 'G') {
+        return { x, y };
+      }
+    }
+  }
+  return { x: 0, y: 0 };
+}
+
+function drawPlayer(player, container, cols) {
+  container.querySelectorAll('.player').forEach(el => el.classList.remove('player'));
+  const index = player.y * cols + player.x;
+  const tile = container.children[index];
+  if (tile) {
+    tile.classList.add('player');
+  }
+}
+
+function handleKey(e, player, container, cols) {
+  const grid = getCurrentGrid();
+  let dx = 0;
+  let dy = 0;
+  switch (e.key) {
+    case 'ArrowUp':
+      dy = -1;
+      break;
+    case 'ArrowDown':
+      dy = 1;
+      break;
+    case 'ArrowLeft':
+      dx = -1;
+      break;
+    case 'ArrowRight':
+      dx = 1;
+      break;
+    default:
+      return;
+  }
+  e.preventDefault();
+  const newX = player.x + dx;
+  const newY = player.y + dy;
+  if (
+    newY < 0 ||
+    newY >= grid.length ||
+    newX < 0 ||
+    newX >= grid[0].length ||
+    grid[newY][newX] !== 'G'
+  ) {
+    return;
+  }
+  player.x = newX;
+  player.y = newY;
+  drawPlayer(player, container, cols);
+}
 
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('game-grid');
+  const player = { x: 0, y: 0 };
+  let cols = 0;
+
   try {
     const grid = await loadMap('map01');
+    cols = grid[0].length;
     renderMap(grid, container);
+
+    const start = findFirstWalkable(grid);
+    player.x = start.x;
+    player.y = start.y;
+    drawPlayer(player, container, cols);
+
+    document.addEventListener('keydown', e => handleKey(e, player, container, cols));
   } catch (err) {
     console.error(err);
   }

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -1,10 +1,17 @@
+let currentGrid = null;
+
 export async function loadMap(name) {
   const response = await fetch(`data/maps/${name}.json`);
   if (!response.ok) {
     throw new Error(`Failed to load map ${name}`);
   }
   const data = await response.json();
-  return data.grid;
+  currentGrid = data.grid.map(row => [...row]);
+  return currentGrid;
+}
+
+export function getCurrentGrid() {
+  return currentGrid;
 }
 
 export function renderMap(grid, container) {

--- a/style/main.css
+++ b/style/main.css
@@ -39,3 +39,7 @@
   padding: 5px 10px;
   cursor: pointer;
 }
+
+.tile.player {
+  background: #3498db;
+}


### PR DESCRIPTION
## Summary
- expose current grid from `mapLoader`
- create a player entity that starts on the first walkable tile
- add keyboard movement constrained to ground tiles
- highlight the player's tile with a new `.player` style

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845b2781634833185c8f26f25c2b819