### PR TITLE
Add chest interaction logic

### DIFF
--- a/scripts/gameEngine.js
+++ b/scripts/gameEngine.js
@@ -1,0 +1,41 @@
+// Game engine state management for interactive objects such as chests.
+
+const openedChests = new Set();
+
+/**
+ * Clears all tracked chest state. Intended to be called when a new map is
+ * loaded.
+ */
+export function resetChestState() {
+  openedChests.clear();
+}
+
+/**
+ * Determines if the chest at the provided coordinates has already been opened.
+ *
+ * @param {number} x
+ * @param {number} y
+ * @returns {boolean}
+ */
+export function isChestOpened(x, y) {
+  return openedChests.has(`${x},${y}`);
+}
+
+/**
+ * Marks the chest at the given coordinates as opened and returns an item if it
+ * wasn't opened before. If the chest has already been opened this function
+ * returns null.
+ *
+ * @param {number} x
+ * @param {number} y
+ * @returns {string|null} the item granted or null if already opened
+ */
+export function openChestAt(x, y) {
+  if (isChestOpened(x, y)) {
+    return null;
+  }
+  openedChests.add(`${x},${y}`);
+  // In the future this could look up items based on map data. For now each
+  // chest grants a single hard-coded item.
+  return 'Mysterious Key';
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,8 @@
 import { loadMap, renderMap, getCurrentGrid } from './mapLoader.js';
+import { openChestAt, isChestOpened, resetChestState } from './gameEngine.js';
+
+// Simple inventory array that stores items received during play.
+export const inventory = [];
 
 function findFirstWalkable(grid) {
   for (let y = 0; y < grid.length; y++) {
@@ -22,6 +26,12 @@ function drawPlayer(player, container, cols) {
 
 function handleKey(e, player, container, cols) {
   const grid = getCurrentGrid();
+
+  if (e.code === 'Space') {
+    attemptOpenChest(player, container, grid, cols);
+    return;
+  }
+
   let dx = 0;
   let dy = 0;
   switch (e.key) {
@@ -57,6 +67,43 @@ function handleKey(e, player, container, cols) {
   drawPlayer(player, container, cols);
 }
 
+function attemptOpenChest(player, container, grid, cols) {
+  const directions = [
+    { x: 1, y: 0 },
+    { x: -1, y: 0 },
+    { x: 0, y: 1 },
+    { x: 0, y: -1 },
+  ];
+
+  for (const dir of directions) {
+    const x = player.x + dir.x;
+    const y = player.y + dir.y;
+    if (
+      y >= 0 &&
+      y < grid.length &&
+      x >= 0 &&
+      x < grid[0].length &&
+      grid[y][x] === 'C'
+    ) {
+      if (!isChestOpened(x, y)) {
+        const item = openChestAt(x, y);
+        if (item) {
+          inventory.push(item);
+          console.log(`Obtained ${item} from chest at (${x}, ${y})`);
+
+          const index = y * cols + x;
+          const tile = container.children[index];
+          if (tile) {
+            tile.classList.remove('chest');
+            tile.classList.add('chest-opened');
+          }
+        }
+      }
+      break;
+    }
+  }
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('game-grid');
   const player = { x: 0, y: 0 };
@@ -66,6 +113,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const grid = await loadMap('map01');
     cols = grid[0].length;
     renderMap(grid, container);
+    resetChestState();
 
     const start = findFirstWalkable(grid);
     player.x = start.x;

--- a/style/main.css
+++ b/style/main.css
@@ -18,6 +18,10 @@
   background: #b5651d;
 }
 
+.chest-opened {
+  background: #8b4513;
+}
+
 .enemy {
   background: #e74c3c;
 }


### PR DESCRIPTION
## Summary
- implement chest state tracking in `gameEngine.js`
- add inventory and interaction logic in `main.js`
- style opened chests with new `.chest-opened` class in `main.css`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6845b7b626f08331a6a3aee62855baee