### PR TITLE
Add player skills and combat log

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -26,10 +26,8 @@ export function startCombat(enemy) {
       <div class="name">${enemy.name}</div>
       <div class="hp-bar"><div class="hp"></div></div>
     </div>
-    <div class="actions">
-      <button id="attack-btn">Attack</button>
-      <button id="defend-btn">Defend</button>
-    </div>`;
+    <div class="actions"></div>
+    <div class="log"></div>`;
 
   document.body.appendChild(overlay);
 
@@ -44,8 +42,75 @@ export function startCombat(enemy) {
   updateHpBar(playerBar, playerHp, playerMax);
   updateHpBar(enemyBar, enemyHp, enemyMax);
 
+  const actionsEl = overlay.querySelector('.actions');
+  const logEl = overlay.querySelector('.log');
+
   function log(msg) {
+    const entry = document.createElement('div');
+    entry.textContent = msg;
+    logEl.appendChild(entry);
+    logEl.scrollTop = logEl.scrollHeight;
     console.log(msg);
+  }
+
+  let guardActive = false;
+  let healUsed = false;
+  let playerTurn = true;
+
+  const skills = {
+    strike: {
+      name: 'Strike',
+      execute() {
+        const dmg = 15;
+        enemyHp = Math.max(0, enemyHp - dmg);
+        log(`Player strikes for ${dmg} damage!`);
+        updateHpBar(enemyBar, enemyHp, enemyMax);
+        enemyBar.classList.add('damage');
+        setTimeout(() => enemyBar.classList.remove('damage'), 300);
+      },
+    },
+    guard: {
+      name: 'Guard',
+      execute() {
+        guardActive = true;
+        log('Player braces for impact.');
+      },
+    },
+    heal: {
+      name: 'Heal',
+      execute() {
+        if (healUsed) {
+          log('Heal can only be used once!');
+          return false;
+        }
+        healUsed = true;
+        playerHp = Math.min(playerMax, playerHp + 20);
+        log('Player heals for 20 HP.');
+        updateHpBar(playerBar, playerHp, playerMax);
+        playerBar.classList.add('damage');
+        setTimeout(() => playerBar.classList.remove('damage'), 300);
+      },
+    },
+  };
+
+  Object.values(skills).forEach(skill => {
+    const btn = document.createElement('button');
+    btn.textContent = skill.name;
+    btn.addEventListener('click', () => handleAction(skill));
+    actionsEl.appendChild(btn);
+  });
+
+  function handleAction(skill) {
+    if (!playerTurn || playerHp <= 0 || enemyHp <= 0) return;
+    const result = skill.execute();
+    if (result === false) return; // invalid action
+    if (enemyHp <= 0) {
+      log(`${enemy.name} was defeated!`);
+      endCombat();
+      return;
+    }
+    playerTurn = false;
+    setTimeout(enemyTurn, 300);
   }
 
   function endCombat() {
@@ -58,35 +123,23 @@ export function startCombat(enemy) {
     );
   }
 
-  function enemyTurn(damageMod = 0) {
+  function enemyTurn() {
     if (enemyHp <= 0) return;
-    const dmg = Math.max(0, 8 - damageMod);
+    let dmg = 8;
+    if (guardActive) {
+      dmg = Math.max(0, dmg - 5);
+      guardActive = false;
+    }
     playerHp = Math.max(0, playerHp - dmg);
     log(`${enemy.name} attacks for ${dmg} damage!`);
     updateHpBar(playerBar, playerHp, playerMax);
+    playerBar.classList.add('damage');
+    setTimeout(() => playerBar.classList.remove('damage'), 300);
     if (playerHp <= 0) {
       log('Player was defeated!');
       endCombat();
-    }
-  }
-
-  overlay.querySelector('#attack-btn').addEventListener('click', () => {
-    if (playerHp <= 0 || enemyHp <= 0) return;
-    const dmg = 10;
-    enemyHp = Math.max(0, enemyHp - dmg);
-    log(`Player attacks for ${dmg} damage!`);
-    updateHpBar(enemyBar, enemyHp, enemyMax);
-    if (enemyHp <= 0) {
-      log(`${enemy.name} was defeated!`);
-      endCombat();
       return;
     }
-    setTimeout(() => enemyTurn(), 300);
-  });
-
-  overlay.querySelector('#defend-btn').addEventListener('click', () => {
-    if (playerHp <= 0 || enemyHp <= 0) return;
-    log('Player defends.');
-    setTimeout(() => enemyTurn(5), 300);
-  });
+    playerTurn = true;
+  }
 }

--- a/style/main.css
+++ b/style/main.css
@@ -100,3 +100,31 @@
   margin: 0 5px;
   padding: 5px 15px;
 }
+
+#battle-overlay .log {
+  margin-top: 10px;
+  height: 80px;
+  overflow-y: auto;
+  width: 220px;
+  font-size: 14px;
+  border: 1px solid #555;
+  padding: 5px;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+#battle-overlay .actions button:hover {
+  outline: 2px solid #fff;
+}
+
+#battle-overlay .hp.damage {
+  animation: damageFlash 0.3s;
+}
+
+@keyframes damageFlash {
+  from {
+    background: #fff;
+  }
+  to {
+    background: #e74c3c;
+  }
+}


### PR DESCRIPTION
## Summary
- add dynamic skill buttons for Strike, Guard, and Heal
- manage skill effects and cooldown in `combatSystem.js`
- show a combat log and HP bar flashes
- style new battle UI elements in `main.css`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845c69fd8f483318f7662de3fd86393