### PR TITLE
Implement inventory overlay and style updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,9 +10,16 @@
   <div id="game-grid"></div>
   <div id="ui-bar">
     <div class="tab">Settings</div>
-    <div class="tab">Inventory</div>
+    <div class="tab inventory-tab">Inventory</div>
     <div class="tab">Save</div>
     <div class="tab">Load</div>
+  </div>
+  <div id="inventory-overlay" class="inventory-overlay">
+    <div class="inventory-content">
+      <button class="close-btn">&times;</button>
+      <h2>Inventory</h2>
+      <div id="inventory-list"></div>
+    </div>
   </div>
   <script type="module" src="scripts/main.js"></script>
 </body>

--- a/scripts/gameEngine.js
+++ b/scripts/gameEngine.js
@@ -28,7 +28,7 @@ export function isChestOpened(x, y) {
  *
  * @param {number} x
  * @param {number} y
- * @returns {string|null} the item granted or null if already opened
+ * @returns {{name:string,description:string}|null} the item granted or null if already opened
  */
 export function openChestAt(x, y) {
   if (isChestOpened(x, y)) {
@@ -36,6 +36,9 @@ export function openChestAt(x, y) {
   }
   openedChests.add(`${x},${y}`);
   // In the future this could look up items based on map data. For now each
-  // chest grants a single hard-coded item.
-  return 'Mysterious Key';
+  // chest grants a single hard-coded item object with name and description.
+  return {
+    name: 'Mysterious Key',
+    description: 'A rusty key of unknown origin.',
+  };
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5,7 +5,12 @@ import * as router from './router.js';
 import { startCombat } from './combatSystem.js';
 
 // Simple inventory array that stores items received during play.
-export const inventory = [];
+// Pre-populated with a few mock items for demonstration purposes.
+export const inventory = [
+  { name: 'Mysterious Key', description: 'A rusty key of unknown origin.' },
+  { name: 'Ancient Coin', description: 'An old coin from a forgotten era.' },
+  { name: 'Healing Herb', description: 'Restores a small amount of health.' },
+];
 
 let enemyDefinitions = {};
 let isInBattle = false;
@@ -129,7 +134,7 @@ function attemptOpenChest(player, container, grid, cols) {
         const item = openChestAt(x, y);
         if (item) {
           inventory.push(item);
-          console.log(`Obtained ${item} from chest at (${x}, ${y})`);
+          console.log(`Obtained ${item.name} from chest at (${x}, ${y})`);
 
           const index = y * cols + x;
           const tile = container.children[index];
@@ -146,6 +151,10 @@ function attemptOpenChest(player, container, grid, cols) {
 
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('game-grid');
+  const inventoryTab = document.querySelector('.inventory-tab');
+  const inventoryOverlay = document.getElementById('inventory-overlay');
+  const inventoryList = document.getElementById('inventory-list');
+  const closeBtn = inventoryOverlay.querySelector('.close-btn');
   const player = { x: 0, y: 0 };
   let cols = 0;
 
@@ -159,6 +168,31 @@ document.addEventListener('DOMContentLoaded', async () => {
   } catch (e) {
     console.error('Failed to load enemies', e);
   }
+
+  function renderInventory() {
+    inventoryList.innerHTML = '';
+    inventory.forEach(item => {
+      const row = document.createElement('div');
+      row.classList.add('inventory-item');
+      row.innerHTML = `<strong>${item.name}</strong><div class="desc">${item.description}</div>`;
+      inventoryList.appendChild(row);
+    });
+  }
+
+  function showInventory() {
+    renderInventory();
+    inventoryOverlay.classList.add('active');
+  }
+
+  function hideInventory() {
+    inventoryOverlay.classList.remove('active');
+  }
+
+  inventoryTab.addEventListener('click', showInventory);
+  closeBtn.addEventListener('click', hideInventory);
+  inventoryOverlay.addEventListener('click', e => {
+    if (e.target === inventoryOverlay) hideInventory();
+  });
 
   try {
     const { cols: newCols } = await router.loadMap('map01');

--- a/style/main.css
+++ b/style/main.css
@@ -1,6 +1,18 @@
+body {
+  margin: 0;
+  background: linear-gradient(#444, #222);
+  font-family: 'Segoe UI', Tahoma, sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+}
+
 #game-grid {
   margin: 20px auto;
   width: max-content;
+  gap: 2px;
+  display: grid;
 }
 
 .tile {
@@ -8,6 +20,8 @@
   height: 32px;
   box-sizing: border-box;
   border: 1px solid #333;
+  border-radius: 4px;
+  box-shadow: inset 0 0 3px rgba(0, 0, 0, 0.6);
 }
 
 .ground {
@@ -37,16 +51,24 @@
 
 #ui-bar {
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   padding: 10px;
   background: #222;
   color: #fff;
-  font-family: sans-serif;
+  width: 100%;
 }
 
 #ui-bar .tab {
-  padding: 5px 10px;
+  background: #333;
+  margin: 0 5px;
+  padding: 8px 12px;
   cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+#ui-bar .tab:hover {
+  background: #555;
 }
 
 .tile.player {
@@ -127,4 +149,66 @@
   to {
     background: #e74c3c;
   }
+}
+
+/* Inventory UI */
+.inventory-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 900;
+}
+
+.inventory-overlay.active {
+  visibility: visible;
+  opacity: 1;
+}
+
+.inventory-content {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 300px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  position: relative;
+}
+
+.inventory-content h2 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.inventory-content .close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.inventory-item {
+  border-bottom: 1px solid #ddd;
+  padding: 6px 0;
+}
+
+.inventory-item:last-child {
+  border-bottom: none;
+}
+
+.inventory-item .desc {
+  font-size: 12px;
+  color: #555;
 }


### PR DESCRIPTION
## Summary
- add markup for inventory overlay
- manage inventory items with descriptions in `main.js`
- open chests to grant item objects
- show/hide inventory overlay with smooth transitions
- overhaul styles: gradient background, centred grid, rounded tiles, styled bottom bar, inventory overlay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845c80464a08331a36bb68405676679