### PR TITLE
Add settings menu with persistent preferences

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
   <div id="game-grid"></div>
   <div id="ui-bar">
-    <div class="tab">Settings</div>
+    <div class="tab settings-tab">Settings</div>
     <div class="tab inventory-tab">Inventory</div>
     <div class="tab">Save</div>
     <div class="tab">Load</div>
@@ -19,6 +19,26 @@
       <button class="close-btn">&times;</button>
       <h2>Inventory</h2>
       <div id="inventory-list"></div>
+    </div>
+  </div>
+  <div id="settings-overlay" class="settings-overlay">
+    <div class="settings-content">
+      <button class="close-btn">&times;</button>
+      <h2>Settings</h2>
+      <label class="setting-row">
+        <input type="checkbox" id="sound-toggle" /> Sound
+      </label>
+      <label class="setting-row">
+        UI Scale
+        <select id="ui-scale">
+          <option value="small">Small</option>
+          <option value="medium">Medium</option>
+          <option value="large">Large</option>
+        </select>
+      </label>
+      <label class="setting-row">
+        <input type="checkbox" id="anim-toggle" /> Enable Grid Animations
+      </label>
     </div>
   </div>
   <script type="module" src="scripts/main.js"></script>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,6 +3,11 @@ import { openChestAt, isChestOpened } from './gameEngine.js';
 import { findPath } from './pathfinder.js';
 import * as router from './router.js';
 import { startCombat } from './combatSystem.js';
+import {
+  loadSettings,
+  saveSettings,
+  applySettings,
+} from './settingsManager.js';
 
 // Simple inventory array that stores items received during play.
 // Pre-populated with a few mock items for demonstration purposes.
@@ -155,8 +160,20 @@ document.addEventListener('DOMContentLoaded', async () => {
   const inventoryOverlay = document.getElementById('inventory-overlay');
   const inventoryList = document.getElementById('inventory-list');
   const closeBtn = inventoryOverlay.querySelector('.close-btn');
+  const settingsTab = document.querySelector('.settings-tab');
+  const settingsOverlay = document.getElementById('settings-overlay');
+  const settingsClose = settingsOverlay.querySelector('.close-btn');
+  const soundToggle = document.getElementById('sound-toggle');
+  const scaleSelect = document.getElementById('ui-scale');
+  const animToggle = document.getElementById('anim-toggle');
   const player = { x: 0, y: 0 };
   let cols = 0;
+
+  let settings = loadSettings();
+  applySettings(settings);
+  soundToggle.checked = settings.sound;
+  scaleSelect.value = settings.scale;
+  animToggle.checked = settings.animations;
 
   router.init(container, player);
 
@@ -192,6 +209,37 @@ document.addEventListener('DOMContentLoaded', async () => {
   closeBtn.addEventListener('click', hideInventory);
   inventoryOverlay.addEventListener('click', e => {
     if (e.target === inventoryOverlay) hideInventory();
+  });
+
+  function showSettings() {
+    settingsOverlay.classList.add('active');
+  }
+
+  function hideSettings() {
+    settingsOverlay.classList.remove('active');
+  }
+
+  settingsTab.addEventListener('click', showSettings);
+  settingsClose.addEventListener('click', hideSettings);
+  settingsOverlay.addEventListener('click', e => {
+    if (e.target === settingsOverlay) hideSettings();
+  });
+
+  soundToggle.addEventListener('change', () => {
+    settings.sound = soundToggle.checked;
+    saveSettings(settings);
+  });
+
+  scaleSelect.addEventListener('change', () => {
+    settings.scale = scaleSelect.value;
+    applySettings(settings);
+    saveSettings(settings);
+  });
+
+  animToggle.addEventListener('change', () => {
+    settings.animations = animToggle.checked;
+    applySettings(settings);
+    saveSettings(settings);
   });
 
   try {

--- a/scripts/settingsManager.js
+++ b/scripts/settingsManager.js
@@ -1,0 +1,34 @@
+const DEFAULT_SETTINGS = {
+  sound: true,
+  scale: 'medium',
+  animations: true,
+};
+
+export function loadSettings() {
+  const json = localStorage.getItem('gridquest.settings');
+  if (!json) return { ...DEFAULT_SETTINGS };
+  try {
+    const obj = JSON.parse(json);
+    return { ...DEFAULT_SETTINGS, ...obj };
+  } catch {
+    return { ...DEFAULT_SETTINGS };
+  }
+}
+
+export function saveSettings(settings) {
+  localStorage.setItem('gridquest.settings', JSON.stringify(settings));
+}
+
+export function applySettings(settings) {
+  const grid = document.getElementById('game-grid');
+  if (!grid) return;
+  const scales = ['scale-small', 'scale-medium', 'scale-large'];
+  grid.classList.remove(...scales);
+  grid.classList.add(`scale-${settings.scale}`);
+  if (settings.animations) {
+    grid.classList.remove('no-animations');
+  } else {
+    grid.classList.add('no-animations');
+  }
+  // sound setting stored for future use
+}

--- a/style/main.css
+++ b/style/main.css
@@ -13,6 +13,27 @@ body {
   width: max-content;
   gap: 2px;
   display: grid;
+  transition: transform 0.3s ease;
+}
+
+#game-grid.scale-small {
+  transform: scale(0.8);
+  transform-origin: top left;
+}
+
+#game-grid.scale-medium {
+  transform: scale(1);
+  transform-origin: top left;
+}
+
+#game-grid.scale-large {
+  transform: scale(1.3);
+  transform-origin: top left;
+}
+
+#game-grid.no-animations * {
+  transition: none !important;
+  animation: none !important;
 }
 
 .tile {
@@ -211,4 +232,59 @@ body {
 .inventory-item .desc {
   font-size: 12px;
   color: #555;
+}
+
+/* Settings UI */
+.settings-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 900;
+}
+
+.settings-overlay.active {
+  visibility: visible;
+  opacity: 1;
+}
+
+.settings-content {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 300px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  position: relative;
+}
+
+.settings-content h2 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.settings-content .close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 10px 0;
 }


### PR DESCRIPTION
## Summary
- add modal overlay for settings with sound toggle, scale dropdown, and animation checkbox
- create `settingsManager.js` to handle saving/loading/applying settings
- implement UI logic in `main.js` for the new menu and persistence
- style new overlay and add scale/animation classes in CSS

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845c9dfd3b48331bbbba49e46364928