### PR TITLE
Implement dialogue overlay system

### DIFF
--- a/data/dialog.json
+++ b/data/dialog.json
@@ -1,0 +1,5 @@
+{
+  "chest_intro_01": "You carefully open the dusty chest...",
+  "enemy_shadow_beast_intro": "A shadowy beast snarls and prepares to strike!",
+  "map01_entry": "The air is thick with mist as you enter the forgotten ruins."
+}

--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -1,0 +1,76 @@
+let dialogueLines = {};
+let dataLoaded = false;
+
+async function loadDialogData() {
+  if (dataLoaded) return;
+  try {
+    const res = await fetch('data/dialog.json');
+    if (res.ok) {
+      dialogueLines = await res.json();
+    }
+  } catch (err) {
+    console.error('Failed to load dialog data', err);
+  } finally {
+    dataLoaded = true;
+  }
+}
+
+export async function showDialogue(keyOrText, callback = () => {}) {
+  await loadDialogData();
+  const text = dialogueLines[keyOrText] || keyOrText || '';
+
+  const overlay = document.createElement('div');
+  overlay.id = 'dialogue-overlay';
+  overlay.innerHTML = `
+    <div class="dialogue-box">
+      <div class="dialogue-text"></div>
+      <div class="dialogue-advance">\u2192</div>
+    </div>`;
+  document.body.appendChild(overlay);
+  const textEl = overlay.querySelector('.dialogue-text');
+  const advance = overlay.querySelector('.dialogue-advance');
+  advance.style.display = 'none';
+
+  let index = 0;
+  const speed = 30; // ms per char
+
+  function typeNext() {
+    if (index < text.length) {
+      textEl.textContent += text.charAt(index);
+      index++;
+      setTimeout(typeNext, speed);
+    } else {
+      advance.style.display = 'block';
+      overlay.querySelector('.dialogue-box').classList.add('finished');
+    }
+  }
+  typeNext();
+
+  function finish() {
+    if (index < text.length) {
+      textEl.textContent = text;
+      index = text.length;
+      advance.style.display = 'block';
+      overlay.querySelector('.dialogue-box').classList.add('finished');
+    } else {
+      cleanup();
+      callback();
+    }
+  }
+
+  function keyHandler(e) {
+    if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault();
+      finish();
+    }
+  }
+
+  function cleanup() {
+    overlay.removeEventListener('click', finish);
+    document.removeEventListener('keydown', keyHandler);
+    overlay.remove();
+  }
+
+  overlay.addEventListener('click', finish);
+  document.addEventListener('keydown', keyHandler);
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,6 +3,7 @@ import { openChestAt, isChestOpened } from './gameEngine.js';
 import { findPath } from './pathfinder.js';
 import * as router from './router.js';
 import { startCombat } from './combatSystem.js';
+import { showDialogue } from './dialogueSystem.js';
 import {
   loadSettings,
   saveSettings,
@@ -110,7 +111,8 @@ function attemptStartCombat(player, container, grid, cols) {
       grid[y][x].type = 'G';
       const enemy = enemyDefinitions['E'] || { name: 'Enemy', hp: 50 };
       isInBattle = true;
-      startCombat({ ...enemy });
+      const intro = enemy.intro || 'A foe appears!';
+      showDialogue(intro, () => startCombat({ ...enemy }));
       return true;
     }
   }
@@ -139,7 +141,7 @@ function attemptOpenChest(player, container, grid, cols) {
         const item = openChestAt(x, y);
         if (item) {
           inventory.push(item);
-          console.log(`Obtained ${item.name} from chest at (${x}, ${y})`);
+          showDialogue(`You obtained ${item.name}!`);
 
           const index = y * cols + x;
           const tile = container.children[index];

--- a/style/main.css
+++ b/style/main.css
@@ -366,3 +366,44 @@ body {
   justify-content: space-between;
   margin: 10px 0;
 }
+
+/* Dialogue overlay */
+#dialogue-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1100;
+}
+
+.dialogue-box {
+  background: rgba(20, 20, 20, 0.85);
+  color: #fff;
+  padding: 20px 30px;
+  border-radius: 8px;
+  max-width: 80%;
+  font-family: 'Courier New', Courier, monospace;
+  position: relative;
+}
+
+.dialogue-advance {
+  position: absolute;
+  right: 10px;
+  bottom: 6px;
+  font-size: 20px;
+  animation: blink 1s steps(1) infinite;
+}
+
+.dialogue-box:not(.finished) .dialogue-advance {
+  display: none;
+}
+
+@keyframes blink {
+  50% { opacity: 0; }
+}
+


### PR DESCRIPTION
## Summary
- add example dialog lines
- implement new dialogueSystem module
- integrate dialogue for chests and combat intros
- style overlay in main.css

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845ccb24e808331a76afe0147acb7db