### PR TITLE
Add branching dialogue with player choices

### DIFF
--- a/style/main.css
+++ b/style/main.css
@@ -407,3 +407,26 @@ body {
   50% { opacity: 0; }
 }
 
+.dialogue-choices {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dialogue-choice {
+  background: #444;
+  color: #fff;
+  border: 1px solid #222;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.dialogue-choice:hover,
+.dialogue-choice.selected {
+  background: #555;
+  transform: scale(1.05);
+}
+


### PR DESCRIPTION
## Summary
- extend dialogue system with a `showDialogueWithChoices` function
- add styles for dialogue choice buttons

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6845ceeaa73c8331a576bfedd5384a89