### PR TITLE
Add CSS environment effects

### DIFF
--- a/data/maps/map01.json
+++ b/data/maps/map01.json
@@ -1,4 +1,6 @@
 {
+  "name": "Fogbound Glade",
+  "environment": "fog",
   "grid": [
     "GGGGGGGGGGGGGGGGGGGG",
     "GGGGGGGGGGGGGGGGGGGG",

--- a/data/maps/map02.json
+++ b/data/maps/map02.json
@@ -1,4 +1,6 @@
 {
+  "name": "Rainy Crossroads",
+  "environment": "rain",
   "grid": [
     [
       { "type": "D", "target": "map01.json", "spawn": { "x": 6, "y": 7 } },

--- a/data/maps/map03.json
+++ b/data/maps/map03.json
@@ -1,1 +1,5 @@
-{}
+{
+  "name": "Twilight Field",
+  "environment": "dusk",
+  "grid": []
+}

--- a/data/maps/map04.json
+++ b/data/maps/map04.json
@@ -1,1 +1,5 @@
-{}
+{
+  "name": "Sunny Vale",
+  "environment": "clear",
+  "grid": []
+}

--- a/data/maps/map05.json
+++ b/data/maps/map05.json
@@ -1,1 +1,5 @@
-{}
+{
+  "name": "Misty Path",
+  "environment": "fog",
+  "grid": []
+}

--- a/data/maps/map06.json
+++ b/data/maps/map06.json
@@ -1,1 +1,5 @@
-{}
+{
+  "name": "Evening Ridge",
+  "environment": "dusk",
+  "grid": []
+}

--- a/data/maps/map07.json
+++ b/data/maps/map07.json
@@ -1,1 +1,5 @@
-{}
+{
+  "name": "Stormfront",
+  "environment": "rain",
+  "grid": []
+}

--- a/data/maps/map08.json
+++ b/data/maps/map08.json
@@ -1,1 +1,5 @@
-{}
+{
+  "name": "Clear Meadows",
+  "environment": "clear",
+  "grid": []
+}

--- a/data/maps/map09.json
+++ b/data/maps/map09.json
@@ -1,1 +1,5 @@
-{}
+{
+  "name": "Foggy Hollow",
+  "environment": "fog",
+  "grid": []
+}

--- a/data/maps/map10.json
+++ b/data/maps/map10.json
@@ -1,1 +1,5 @@
-{}
+{
+  "name": "Rainfall Basin",
+  "environment": "rain",
+  "grid": []
+}

--- a/data/maps/map11.json
+++ b/data/maps/map11.json
@@ -1,1 +1,5 @@
-{}
+{
+  "name": "Duskwatch",
+  "environment": "dusk",
+  "grid": []
+}

--- a/data/maps/map12.json
+++ b/data/maps/map12.json
@@ -1,1 +1,5 @@
-{}
+{
+  "name": "Sunlit Plains",
+  "environment": "clear",
+  "grid": []
+}

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -1,4 +1,5 @@
 let currentGrid = null;
+let currentEnvironment = 'clear';
 
 export async function loadMap(name) {
   const response = await fetch(`data/maps/${name}.json`);
@@ -6,6 +7,7 @@ export async function loadMap(name) {
     throw new Error(`Failed to load map ${name}`);
   }
   const data = await response.json();
+  currentEnvironment = data.environment || 'clear';
   currentGrid = data.grid.map(row => {
     if (typeof row === 'string') {
       return row.split('').map(ch => ({ type: ch }));
@@ -17,18 +19,29 @@ export async function loadMap(name) {
       return cell;
     });
   });
-  return currentGrid;
+  return { grid: currentGrid, environment: currentEnvironment };
 }
 
 export function getCurrentGrid() {
   return currentGrid;
 }
 
-export function renderMap(grid, container) {
+export function getCurrentEnvironment() {
+  return currentEnvironment;
+}
+
+export function renderMap(grid, container, environment = currentEnvironment) {
   container.innerHTML = '';
   const cols = grid[0].length;
   container.style.display = 'grid';
   container.style.gridTemplateColumns = `repeat(${cols}, 32px)`;
+
+  Array.from(container.classList)
+    .filter(c => c.startsWith('env-'))
+    .forEach(c => container.classList.remove(c));
+  if (environment) {
+    container.classList.add(`env-${environment}`);
+  }
 
   grid.forEach((row, y) => {
     row.forEach((cell, x) => {

--- a/scripts/router.js
+++ b/scripts/router.js
@@ -34,9 +34,9 @@ export function init(gameContainer, playerObj) {
 
 export async function loadMap(filename, spawnPoint) {
   const name = filename.replace(/\.json$/, '');
-  const grid = await loadMapData(name);
+  const { grid, environment } = await loadMapData(name);
   cols = grid[0].length;
-  renderMap(grid, container);
+  renderMap(grid, container, environment);
   resetChestState();
 
   if (spawnPoint) {

--- a/style/main.css
+++ b/style/main.css
@@ -13,6 +13,8 @@ body {
   width: max-content;
   gap: 2px;
   display: grid;
+  position: relative;
+  overflow: hidden;
   transition: transform 0.3s ease;
 }
 
@@ -428,5 +430,46 @@ body {
 .dialogue-choice.selected {
   background: #555;
   transform: scale(1.05);
+}
+
+.env-fog::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(135deg, rgba(255,255,255,0.05) 0px, rgba(255,255,255,0.1) 2px, transparent 4px);
+  backdrop-filter: blur(1.5px);
+  pointer-events: none;
+  animation: fogPulse 4s infinite alternate;
+}
+
+@keyframes fogPulse {
+  from { opacity: 0.1; }
+  to { opacity: 0.25; }
+}
+
+.env-rain::before {
+  content: "/////";
+  position: absolute;
+  font-size: 40px;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  color: rgba(173,216,230,0.2);
+  animation: rainMove 0.6s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes rainMove {
+  0% { transform: translateY(-100%); }
+  100% { transform: translateY(100%); }
+}
+
+.env-dusk {
+  background: radial-gradient(ellipse at center, #2c2c2c 0%, #0a0a0a 100%);
+  color: #f2e9e4;
 }
 


### PR DESCRIPTION
## Summary
- add env-fog, env-rain and env-dusk CSS classes
- make game grid container relative so pseudo elements render
- store environment info when loading maps
- apply environment classes when rendering maps
- add environment data to map files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845d20448dc83318e9311468329b8a8