### PR TITLE
Enforce adjacent-only interactions and map size

### DIFF
--- a/scripts/gameEngine.js
+++ b/scripts/gameEngine.js
@@ -42,3 +42,17 @@ export function openChestAt(x, y) {
     description: 'A rusty key of unknown origin.',
   };
 }
+
+/**
+ * Determines if two grid positions are directly adjacent horizontally or
+ * vertically.
+ *
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} x2
+ * @param {number} y2
+ * @returns {boolean}
+ */
+export function isAdjacent(x1, y1, x2, y2) {
+  return Math.abs(x1 - x2) + Math.abs(y1 - y2) === 1;
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,5 +1,5 @@
 import { getCurrentGrid } from './mapLoader.js';
-import { openChestAt, isChestOpened } from './gameEngine.js';
+import { openChestAt, isChestOpened, isAdjacent } from './gameEngine.js';
 import { findPath } from './pathfinder.js';
 import * as router from './router.js';
 import { startCombat } from './combatSystem.js';
@@ -40,7 +40,13 @@ function handleTileClick(e, player, container, cols) {
   const x = Number(target.dataset.x);
   const y = Number(target.dataset.y);
   const grid = getCurrentGrid();
-  if (grid[y][x].type !== 'G' && grid[y][x].type !== 'D') return;
+  const tileType = grid[y][x].type;
+
+  if (tileType === 'D' && !isAdjacent(player.x, player.y, x, y)) {
+    return;
+  }
+
+  if (tileType !== 'G' && tileType !== 'D') return;
 
   const path = findPath(grid, player.x, player.y, x, y);
   if (path.length === 0) return;
@@ -101,7 +107,8 @@ function attemptStartCombat(player, container, grid, cols) {
       y < grid.length &&
       x >= 0 &&
       x < grid[0].length &&
-      grid[y][x].type === 'E'
+      grid[y][x].type === 'E' &&
+      isAdjacent(player.x, player.y, x, y)
     ) {
       const index = y * cols + x;
       const tile = container.children[index];
@@ -136,7 +143,8 @@ function attemptOpenChest(player, container, grid, cols) {
       y < grid.length &&
       x >= 0 &&
       x < grid[0].length &&
-      grid[y][x].type === 'C'
+      grid[y][x].type === 'C' &&
+      isAdjacent(player.x, player.y, x, y)
     ) {
       if (!isChestOpened(x, y)) {
         const item = openChestAt(x, y);

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -1,6 +1,16 @@
 let currentGrid = null;
 let currentEnvironment = 'clear';
 
+function normalizeGrid(grid, size = 20) {
+  const normalized = [];
+  for (let y = 0; y < size; y++) {
+    const row = grid[y] || [];
+    const paddedRow = [...row.slice(0, size), ...Array(size - row.length).fill('G')];
+    normalized.push(paddedRow);
+  }
+  return normalized;
+}
+
 export async function loadMap(name) {
   const response = await fetch(`data/maps/${name}.json`);
   if (!response.ok) {
@@ -19,6 +29,7 @@ export async function loadMap(name) {
       return cell;
     });
   });
+  currentGrid = normalizeGrid(currentGrid);
   return { grid: currentGrid, environment: currentEnvironment };
 }
 


### PR DESCRIPTION
## Summary
- add `isAdjacent` helper to gameEngine
- restrict door clicks to adjacent tiles
- ensure combat and chest interactions use `isAdjacent`
- normalize all loaded maps to 20×20 in mapLoader

## Testing
- `node --check scripts/main.js`
- `node --check scripts/mapLoader.js`
- `node --check scripts/gameEngine.js`

------
https://chatgpt.com/codex/tasks/task_e_6845d6ba38a08331b5ad98c876761094