### PR TITLE
Modular refactor with map normalization

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,3 @@
+{
+  "mysterious_key": { "name": "Mysterious Key", "description": "It hums faintly." }
+}

--- a/data/maps/map02.json
+++ b/data/maps/map02.json
@@ -3,15 +3,52 @@
   "environment": "rain",
   "grid": [
     [
-      { "type": "D", "target": "map01.json", "spawn": { "x": 6, "y": 7 } },
+      {
+        "type": "D",
+        "target": "map01.json",
+        "spawn": {
+          "x": 6,
+          "y": 7
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
       "G",
       "G",
       "G",
       "G"
     ],
-    "GGGGG",
-    "GGGGG",
-    "GGGGG",
-    "GGGGG"
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG"
   ]
 }

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -1,0 +1,20 @@
+import { gameState } from './game_state.js';
+import { addItem } from './inventory.js';
+import { updateInventoryUI } from './inventory_state.js';
+import { getItemData, loadItems } from './item_loader.js';
+
+export function isChestOpened(id) {
+  return gameState.openedChests.has(id);
+}
+
+export async function openChest(id) {
+  if (isChestOpened(id)) return null;
+  gameState.openedChests.add(id);
+  await loadItems();
+  const item = getItemData('mysterious_key');
+  if (item) {
+    addItem(item);
+    updateInventoryUI();
+  }
+  return item;
+}

--- a/scripts/enemy.js
+++ b/scripts/enemy.js
@@ -1,0 +1,24 @@
+import { gameState } from './game_state.js';
+
+let enemyData = {};
+
+export async function loadEnemyData() {
+  if (Object.keys(enemyData).length) return enemyData;
+  const res = await fetch('data/enemies.json');
+  if (res.ok) {
+    enemyData = await res.json();
+  }
+  return enemyData;
+}
+
+export function getEnemyData(id) {
+  return enemyData[id];
+}
+
+export function isEnemyDefeated(id) {
+  return gameState.defeatedEnemies.has(id);
+}
+
+export function defeatEnemy(id) {
+  gameState.defeatedEnemies.add(id);
+}

--- a/scripts/gameEngine.js
+++ b/scripts/gameEngine.js
@@ -2,63 +2,6 @@
 // and environmental tile effects.
 import { showDialogue } from './dialogueSystem.js';
 
-const openedChests = new Set();
-
-/**
- * Clears all tracked chest state. Intended to be called when a new map is
- * loaded.
- */
-export function resetChestState() {
-  openedChests.clear();
-}
-
-/**
- * Determines if the chest at the provided coordinates has already been opened.
- *
- * @param {number} x
- * @param {number} y
- * @returns {boolean}
- */
-export function isChestOpened(x, y) {
-  return openedChests.has(`${x},${y}`);
-}
-
-/**
- * Marks the chest at the given coordinates as opened and returns an item if it
- * wasn't opened before. If the chest has already been opened this function
- * returns null.
- *
- * @param {number} x
- * @param {number} y
- * @returns {{name:string,description:string}|null} the item granted or null if already opened
- */
-export function openChestAt(x, y) {
-  if (isChestOpened(x, y)) {
-    return null;
-  }
-  openedChests.add(`${x},${y}`);
-  // In the future this could look up items based on map data. For now each
-  // chest grants a single hard-coded item object with name and description.
-  return {
-    name: 'Mysterious Key',
-    description: 'A rusty key of unknown origin.',
-  };
-}
-
-/**
- * Determines if two grid positions are directly adjacent horizontally or
- * vertically.
- *
- * @param {number} x1
- * @param {number} y1
- * @param {number} x2
- * @param {number} y2
- * @returns {boolean}
- */
-export function isAdjacent(x1, y1, x2, y2) {
-  return Math.abs(x1 - x2) + Math.abs(y1 - y2) === 1;
-}
-
 /**
  * Applies effects based on the tile symbol the player stepped on.
  *
@@ -74,3 +17,4 @@ export function handleTileEffects(tileSymbol, player) {
     showDialogue('A trap! You were badly hurt. -15 HP.');
   }
 }
+

--- a/scripts/game_state.js
+++ b/scripts/game_state.js
@@ -1,0 +1,28 @@
+export const gameState = {
+  currentMap: '',
+  openedChests: new Set(),
+  defeatedEnemies: new Set(),
+  environment: 'clear',
+};
+
+export function saveState() {
+  const data = {
+    currentMap: gameState.currentMap,
+    openedChests: Array.from(gameState.openedChests),
+    defeatedEnemies: Array.from(gameState.defeatedEnemies),
+  };
+  localStorage.setItem('gridquest.state', JSON.stringify(data));
+}
+
+export function loadState() {
+  const json = localStorage.getItem('gridquest.state');
+  if (!json) return;
+  try {
+    const data = JSON.parse(json);
+    gameState.currentMap = data.currentMap || '';
+    gameState.openedChests = new Set(data.openedChests || []);
+    gameState.defeatedEnemies = new Set(data.defeatedEnemies || []);
+  } catch {
+    // ignore malformed data
+  }
+}

--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -1,0 +1,50 @@
+export function renderGrid(grid, container, environment = 'clear') {
+  container.innerHTML = '';
+  const cols = grid[0].length;
+  container.style.display = 'grid';
+  container.style.gridTemplateColumns = `repeat(${cols}, 32px)`;
+
+  Array.from(container.classList)
+    .filter(c => c.startsWith('env-'))
+    .forEach(c => container.classList.remove(c));
+  if (environment) {
+    container.classList.add(`env-${environment}`);
+  }
+
+  grid.forEach((row, y) => {
+    row.forEach((cell, x) => {
+      const div = document.createElement('div');
+      div.classList.add('tile');
+      div.dataset.x = x;
+      div.dataset.y = y;
+
+      switch (cell.type) {
+        case 'G':
+          div.classList.add('ground');
+          break;
+        case 'C':
+          div.classList.add('chest', 'blocked');
+          break;
+        case 'E':
+          div.classList.add('enemy', 'blocked');
+          break;
+        case 'D':
+          div.classList.add('door', 'blocked');
+          break;
+        case 't':
+          div.classList.add('trap-light');
+          break;
+        case 'T':
+          div.classList.add('trap-dark');
+          break;
+        case 'W':
+          div.classList.add('water');
+          break;
+        default:
+          div.classList.add('ground');
+      }
+
+      container.appendChild(div);
+    });
+  });
+}

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -1,0 +1,9 @@
+export const inventory = [];
+
+export function addItem(item) {
+  inventory.push(item);
+}
+
+export function hasItem(name) {
+  return inventory.some(it => it.name === name);
+}

--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -1,0 +1,24 @@
+import { inventory } from './inventory.js';
+
+export function updateInventoryUI() {
+  const list = document.getElementById('inventory-list');
+  if (!list) return;
+  list.innerHTML = '';
+  inventory.forEach(item => {
+    const row = document.createElement('div');
+    row.classList.add('inventory-item');
+    row.innerHTML = `<strong>${item.name}</strong><div class="desc">${item.description}</div>`;
+    list.appendChild(row);
+  });
+}
+
+export function toggleInventoryView() {
+  const overlay = document.getElementById('inventory-overlay');
+  if (!overlay) return;
+  if (overlay.classList.contains('active')) {
+    overlay.classList.remove('active');
+  } else {
+    updateInventoryUI();
+    overlay.classList.add('active');
+  }
+}

--- a/scripts/item_loader.js
+++ b/scripts/item_loader.js
@@ -1,0 +1,18 @@
+let items = {};
+
+export async function loadItems() {
+  if (Object.keys(items).length) return items;
+  try {
+    const res = await fetch('data/items.json');
+    if (res.ok) {
+      items = await res.json();
+    }
+  } catch {
+    // ignore errors
+  }
+  return items;
+}
+
+export function getItemData(id) {
+  return items[id];
+}

--- a/scripts/logic.js
+++ b/scripts/logic.js
@@ -1,0 +1,7 @@
+export function isAdjacent(x1, y1, x2, y2) {
+  return Math.abs(x1 - x2) + Math.abs(y1 - y2) === 1;
+}
+
+export function generateTileId(x, y) {
+  return `${x},${y}`;
+}

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -1,7 +1,7 @@
 let currentGrid = null;
 let currentEnvironment = 'clear';
 
-function normalizeGrid(grid, size = 20) {
+export function normalizeGrid(grid, size = 20) {
   const normalized = [];
   for (let y = 0; y < size; y++) {
     const row = grid[y] || [];
@@ -41,53 +41,3 @@ export function getCurrentEnvironment() {
   return currentEnvironment;
 }
 
-export function renderMap(grid, container, environment = currentEnvironment) {
-  container.innerHTML = '';
-  const cols = grid[0].length;
-  container.style.display = 'grid';
-  container.style.gridTemplateColumns = `repeat(${cols}, 32px)`;
-
-  Array.from(container.classList)
-    .filter(c => c.startsWith('env-'))
-    .forEach(c => container.classList.remove(c));
-  if (environment) {
-    container.classList.add(`env-${environment}`);
-  }
-
-  grid.forEach((row, y) => {
-    row.forEach((cell, x) => {
-      const div = document.createElement('div');
-      div.classList.add('tile');
-      div.dataset.x = x;
-      div.dataset.y = y;
-
-      switch (cell.type) {
-        case 'G':
-          div.classList.add('ground');
-          break;
-        case 'C':
-          div.classList.add('chest', 'blocked');
-          break;
-        case 'E':
-          div.classList.add('enemy', 'blocked');
-          break;
-        case 'D':
-          div.classList.add('door', 'blocked');
-          break;
-        case 't':
-          div.classList.add('trap-light');
-          break;
-        case 'T':
-          div.classList.add('trap-dark');
-          break;
-        case 'W':
-          div.classList.add('water');
-          break;
-        default:
-          div.classList.add('ground');
-      }
-
-      container.appendChild(div);
-    });
-  });
-}

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -1,0 +1,20 @@
+export const player = {
+  x: 0,
+  y: 0,
+  hp: 100,
+  maxHp: 100,
+  learnedSkills: [],
+};
+
+export function moveTo(x, y) {
+  player.x = x;
+  player.y = y;
+}
+
+export function takeDamage(amount) {
+  player.hp = Math.max(0, player.hp - amount);
+}
+
+export function healFull() {
+  player.hp = player.maxHp;
+}

--- a/scripts/router.js
+++ b/scripts/router.js
@@ -1,5 +1,6 @@
-import { loadMap as loadMapData, renderMap } from './mapLoader.js';
-import { resetChestState } from './gameEngine.js';
+import { loadMap as loadMapData } from './mapLoader.js';
+import { renderGrid } from './grid.js';
+import { gameState } from './game_state.js';
 
 let container = null;
 let player = null;
@@ -37,9 +38,10 @@ export async function loadMap(filename, spawnPoint) {
   const name = filename.replace(/\.json$/, '');
   currentMap = name;
   const { grid, environment } = await loadMapData(name);
+  gameState.currentMap = name;
+  gameState.environment = environment;
   cols = grid[0].length;
-  renderMap(grid, container, environment);
-  resetChestState();
+  renderGrid(grid, container, environment);
 
   if (spawnPoint) {
     player.x = spawnPoint.x;


### PR DESCRIPTION
## Summary
- split code into focused modules (player, game state, enemy, chest, inventory, logic and grid helpers)
- normalize map02.json to 20×20
- update router and main logic to use new modules and state
- export normalizeGrid from map loader
- keep chest and enemy interactions working

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845de1bf5008331aa841c4d16942ad5