### PR TITLE
Fix map normalization bug

### DIFF
--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -5,7 +5,12 @@ export function normalizeGrid(grid, size = 20) {
   const normalized = [];
   for (let y = 0; y < size; y++) {
     const row = grid[y] || [];
-    const paddedRow = [...row.slice(0, size), ...Array(size - row.length).fill('G')];
+    const paddedRow = row.slice(0, size).map(cell =>
+      typeof cell === 'string' ? { type: cell } : cell
+    );
+    for (let i = paddedRow.length; i < size; i++) {
+      paddedRow.push({ type: 'G' });
+    }
     normalized.push(paddedRow);
   }
   return normalized;


### PR DESCRIPTION
## Summary
- ensure `normalizeGrid` fills missing cells with proper tile objects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845ec0fc28c8331b93fd884d5b7604f