### PR TITLE
Fix typo in dialogueSystem.js comment

### DIFF
--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -37,7 +37,7 @@ export async function showDialogue(keyOrText, callback = () => {}) {
   advance.style.display = 'none';
 
   let index = 0;
-  const speed = 30; // ms per char
+  const speed = 30; // ms per character
 
   function typeNext() {
     if (index < text.length) {


### PR DESCRIPTION
## Summary
- clarify typing speed comment in dialogueSystem.js

## Testing
- `grep -n "ms per" scripts/dialogueSystem.js`

------
https://chatgpt.com/codex/tasks/task_e_6845f27883088331b5bd25122adfd10a