### PR TITLE
Fix combat HP tracking

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -48,9 +48,9 @@ export function startCombat(enemy, player) {
   const playerBar = overlay.querySelector('.player .hp');
   const enemyBar = overlay.querySelector('.enemy .hp');
 
-  const playerMax = 100;
+  const playerMax = player.maxHp ?? 100;
   const enemyMax = enemy.hp || 50;
-  let playerHp = playerMax;
+  let playerHp = player.hp ?? playerMax;
   let enemyHp = enemyMax;
 
   updateHpBar(playerBar, playerHp, playerMax);
@@ -142,6 +142,9 @@ export function startCombat(enemy, player) {
 
   function endCombat() {
     log('Combat ended');
+    if (player) {
+      player.hp = playerHp;
+    }
     gridEl.classList.remove('blurred');
     overlay.remove();
     overlay = null;


### PR DESCRIPTION
## Summary
- initialize combat with player's current HP and max HP
- write combat results back to the player state before dispatching `combatEnded`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845f3c2459883319f621a562af2380f