### PR TITLE
Add rusty key to map01

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1,5 +1,6 @@
 {
   "mysterious_key": { "name": "Mysterious Key", "description": "It hums faintly." },
+  "rusty_key": { "name": "Rusty Key", "description": "Old and corroded, but it might still work." },
   "rusted_key": { "name": "Rusted Key", "description": "Looks fragile but might still work." },
   "silver_key": { "name": "Silver Key", "description": "Shines with a dull luster." },
   "potion_of_health": { "name": "Potion of Health", "description": "Increases maximum health permanently." }

--- a/data/maps/map01.json
+++ b/data/maps/map01.json
@@ -23,7 +23,8 @@
           "x": 1,
           "y": 1
         },
-        "key": "rusted_key"
+        "locked": true,
+        "requiresItem": "rusty_key"
       },
       "G",
       "G",

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -5,6 +5,7 @@ import { getItemData, loadItems } from './item_loader.js';
 import { increaseMaxHp } from './player.js';
 
 const chestContents = {
+  'map01:11,3': { item: 'rusty_key' },
   'map02:5,5': { item: 'silver_key' },
   'map02:8,12': { message: 'This chest was empty.' },
   'map02:15,15': { item: 'potion_of_health' },

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -2,7 +2,8 @@
 import { getCurrentGrid } from './mapLoader.js';
 import { isAdjacent } from './logic.js';
 import { isChestOpened, openChest } from './chest.js';
-import { hasItem } from './inventory.js';
+import { hasItem, removeItem } from './inventory.js';
+import { updateInventoryUI } from './inventory_state.js';
 import { getEnemyData } from './enemy.js';
 import { startCombat } from './combatSystem.js';
 import { showDialogue } from './dialogueSystem.js';
@@ -41,6 +42,10 @@ export async function handleTileInteraction(
       if (required && !hasItem(required)) {
         showDialogue('The door is locked.');
         break;
+      }
+      if (required) {
+        removeItem(required);
+        updateInventoryUI();
       }
       const targetMap = tile.target || tile.leadsTo;
       const { cols: newCols } = await router.loadMap(targetMap, tile.spawn);

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -7,3 +7,12 @@ export function addItem(item) {
 export function hasItem(name) {
   return inventory.some(it => it.name === name);
 }
+
+export function removeItem(name) {
+  const idx = inventory.findIndex(it => it.name === name);
+  if (idx !== -1) {
+    inventory.splice(idx, 1);
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- add Rusty Key item
- put rusty key into map01 chest and lock door to map02 using it
- allow inventory item removal and update door interaction to consume keys

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846086795a08331ba91cdddf48e4166