### PR TITLE
Fix split comment in gameEngine.js

### DIFF
--- a/scripts/gameEngine.js
+++ b/scripts/gameEngine.js
@@ -1,5 +1,4 @@
-// Handles trap and tile effects triggered when the player steps on
-// certain tiles.
+// Handles trap and tile effects triggered when the player steps on certain tiles.
 import { showDialogue } from './dialogueSystem.js';
 
 /**


### PR DESCRIPTION
## Summary
- combine introductory comment into one line

## Testing
- `no tests`

------
https://chatgpt.com/codex/tasks/task_e_6846145a37cc8331b84c31190788e3e7