### PR TITLE
Add basic Save/Load UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     <div id="hp-display"></div>
     <div class="tab settings-tab">Settings</div>
     <div class="tab inventory-tab">Inventory</div>
-    <div class="tab">Save</div>
-    <div class="tab">Load</div>
+    <div class="tab save-tab">Save</div>
+    <div class="tab load-tab">Load</div>
   </div>
   <div id="inventory-overlay" class="inventory-overlay">
     <div class="inventory-content">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -10,6 +10,7 @@ import { handleTileInteraction } from './interaction.js';
 import * as eryndor from './npc/eryndor.js';
 import * as lioran from './npc/lioran.js';
 import { initSkillSystem, unlockSkill, getAllSkills } from './skills.js';
+import { saveState, loadState, gameState } from './game_state.js';
 import {
   loadSettings,
   saveSettings,
@@ -84,6 +85,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   const settingsTab = document.querySelector('.settings-tab');
   const settingsOverlay = document.getElementById('settings-overlay');
   const settingsClose = settingsOverlay.querySelector('.close-btn');
+  const saveTab = document.querySelector('.save-tab');
+  const loadTab = document.querySelector('.load-tab');
   const soundToggle = document.getElementById('sound-toggle');
   const scaleSelect = document.getElementById('ui-scale');
   const animToggle = document.getElementById('anim-toggle');
@@ -141,6 +144,22 @@ document.addEventListener('DOMContentLoaded', async () => {
     settings.animations = animToggle.checked;
     applySettings(settings);
     saveSettings(settings);
+  });
+
+  saveTab.addEventListener('click', () => {
+    saveState();
+    showDialogue('Game saved!');
+  });
+
+  loadTab.addEventListener('click', async () => {
+    loadState();
+    const mapName = gameState.currentMap || 'map01';
+    const { cols: newCols } = await router.loadMap(mapName);
+    cols = newCols;
+    player.maxHp = 100 + (gameState.maxHpBonus || 0);
+    player.hp = Math.min(player.hp, player.maxHp);
+    updateHpDisplay();
+    showDialogue('Game loaded!');
   });
 
   try {


### PR DESCRIPTION
## Summary
- add Save and Load tabs to the UI bar
- hook tabs up to new click handlers
- call `saveState` and `loadState` to persist game progress
- reload the map after loading and update player HP

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684619298abc83318424cb14a0bc528b