### PR TITLE
Extend skill system with new enemy and item unlocks

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -13,5 +13,19 @@
     "description": "A decaying corpse that refuses to rest.",
     "intro": "The zombie shambles toward you!",
     "portrait": "🧟"
+  },
+  "B": {
+    "name": "Bandit",
+    "hp": 60,
+    "description": "A scruffy thief eyeing your belongings.",
+    "intro": "The bandit lunges for your coin purse!",
+    "portrait": "🥷"
+  },
+  "S": {
+    "name": "Skeleton",
+    "hp": 40,
+    "description": "Bones clatter as it advances.",
+    "intro": "A skeleton rattles menacingly!",
+    "portrait": "💀"
   }
 }

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -3,6 +3,7 @@ import { addItem } from './inventory.js';
 import { updateInventoryUI } from './inventory_state.js';
 import { getItemData, loadItems } from './item_loader.js';
 import { increaseMaxHp } from './player.js';
+import { unlockSkillsFromItem } from './skills.js';
 
 const chestContents = {
   'map01:11,3': { item: 'rusty_key' },
@@ -21,6 +22,7 @@ export async function openChest(id, player) {
   await loadItems();
   const config = chestContents[id] || {};
   let item = null;
+  let unlockedSkills = [];
   if (config.item) {
     item = getItemData(config.item);
     if (item) {
@@ -30,7 +32,8 @@ export async function openChest(id, player) {
         gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
       }
       updateInventoryUI();
+      unlockedSkills = unlockSkillsFromItem(config.item);
     }
   }
-  return { item, message: config.message || null };
+  return { item, message: config.message || null, unlockedSkills };
 }

--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -1,6 +1,7 @@
 import { addItem, inventory } from './inventory.js';
 import { updateInventoryUI } from './inventory_state.js';
 import { loadItems, getItemData } from './item_loader.js';
+import { unlockSkillsFromItem, getAllSkills } from './skills.js';
 import { dialogueMemory, setMemory } from './dialogue_state.js';
 
 let dialogueLines = {};
@@ -215,6 +216,13 @@ export async function startDialogueTree(dialogue, index = 0) {
         if (item) {
           addItem(item);
           updateInventoryUI();
+          const unlocked = unlockSkillsFromItem(opt.give);
+          unlocked.forEach(id => {
+            const skill = getAllSkills()[id];
+            if (skill) {
+              showDialogue(`You've learned a new skill: ${skill.name}!`);
+            }
+          });
         }
       }
       if (opt.goto !== null && opt.goto !== undefined) {

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -76,6 +76,14 @@ export async function handleTileInteraction(
           if (result.item) {
             showDialogue(`You obtained ${result.item.name}!`);
           }
+          if (Array.isArray(result.unlockedSkills)) {
+            result.unlockedSkills.forEach(id => {
+              const skill = getAllSkills()[id];
+              if (skill) {
+                showDialogue(`You've learned a new skill: ${skill.name}!`);
+              }
+            });
+          }
           const index = y * cols + x;
           const tileEl = container.children[index];
           if (tileEl) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -9,7 +9,13 @@ import { showDialogue } from './dialogueSystem.js';
 import { handleTileInteraction } from './interaction.js';
 import * as eryndor from './npc/eryndor.js';
 import * as lioran from './npc/lioran.js';
-import { initSkillSystem, unlockSkill, getAllSkills } from './skills.js';
+import {
+  initSkillSystem,
+  unlockSkill,
+  getAllSkills,
+  isEnemySourceUsed,
+  markEnemySource,
+} from './skills.js';
 import { saveState, loadState, gameState } from './game_state.js';
 import {
   loadSettings,
@@ -181,11 +187,19 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (e.detail.enemyHp <= 0) {
         const enemyId = e.detail.enemy.id;
         defeatEnemy(enemyId);
-        for (const [id, skill] of Object.entries(getAllSkills())) {
-          if (skill.unlockCondition?.enemy === enemyId) {
-            if (unlockSkill(id)) {
-              showDialogue(`You've learned a new skill: ${skill.name}!`);
+        if (!isEnemySourceUsed(enemyId)) {
+          let unlocked = false;
+          for (const [id, skill] of Object.entries(getAllSkills())) {
+            if (skill.unlockCondition?.enemy === enemyId) {
+              if (unlockSkill(id)) {
+                showDialogue(`You've learned a new skill: ${skill.name}!`);
+                unlocked = true;
+                break;
+              }
             }
+          }
+          if (unlocked) {
+            markEnemySource(enemyId);
           }
         }
       }

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -56,9 +56,59 @@ const skillDefs = {
       log('Flames scorch the enemy for 10 damage!');
     },
   },
+  shadowStab: {
+    id: 'shadowStab',
+    name: 'Shadow Stab',
+    description: 'Strike from the shadows for 20 damage.',
+    unlockCondition: { enemy: 'B' },
+    effect({ damageEnemy, log }) {
+      const dmg = 20;
+      damageEnemy(dmg);
+      log('You lunge from the darkness for 20 damage!');
+    },
+  },
+  boneSpike: {
+    id: 'boneSpike',
+    name: 'Bone Spike',
+    description: 'Hurl bone shards for 18 damage.',
+    unlockCondition: { enemy: 'S' },
+    effect({ damageEnemy, log }) {
+      const dmg = 18;
+      damageEnemy(dmg);
+      log('Bone shards pierce the foe for 18 damage!');
+    },
+  },
+  arcaneBlast: {
+    id: 'arcaneBlast',
+    name: 'Arcane Blast',
+    description: 'Unleash arcane energy for 12 damage.',
+    unlockCondition: { item: 'ancient_scroll' },
+    effect({ damageEnemy, log }) {
+      const dmg = 12;
+      damageEnemy(dmg);
+      log('Arcane power lashes out for 12 damage!');
+    },
+  },
 };
 
 let player = null;
+const enemySkillSources = new Set();
+
+function loadEnemySkillSources() {
+  const json = localStorage.getItem('gridquest.enemySkillSources');
+  if (!json) return [];
+  try {
+    const arr = JSON.parse(json);
+    if (Array.isArray(arr)) return arr;
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function saveEnemySkillSources(list) {
+  localStorage.setItem('gridquest.enemySkillSources', JSON.stringify(list));
+}
 
 function loadLearnedSkills() {
   const json = localStorage.getItem('gridquest.skills');
@@ -81,6 +131,8 @@ export function initSkillSystem(playerObj) {
   if (!Array.isArray(player.learnedSkills)) {
     player.learnedSkills = loadLearnedSkills();
   }
+  const enemyList = loadEnemySkillSources();
+  enemyList.forEach(id => enemySkillSources.add(id));
   // Ensure starting skills are present
   ['strike', 'guard', 'heal'].forEach(id => {
     if (!player.learnedSkills.includes(id)) {
@@ -98,6 +150,29 @@ export function unlockSkill(id) {
     return true;
   }
   return false;
+}
+
+export function isEnemySourceUsed(id) {
+  return enemySkillSources.has(id);
+}
+
+export function markEnemySource(id) {
+  if (!enemySkillSources.has(id)) {
+    enemySkillSources.add(id);
+    saveEnemySkillSources(Array.from(enemySkillSources));
+  }
+}
+
+export function unlockSkillsFromItem(itemId) {
+  const unlocked = [];
+  for (const [id, skill] of Object.entries(skillDefs)) {
+    if (skill.unlockCondition?.item === itemId) {
+      if (unlockSkill(id)) {
+        unlocked.push(id);
+      }
+    }
+  }
+  return unlocked;
 }
 
 export function hasSkill(id) {


### PR DESCRIPTION
## Summary
- add Bandit and Skeleton enemy entries
- introduce new skills unlocked by defeating specific enemies or finding items
- persist which enemy types already granted skills
- prevent multiple skills from a single enemy type
- allow item-based skill unlocks via chests and dialogues

## Testing
- `node --check scripts/skills.js`
- `node --check scripts/main.js`
- `node --check scripts/chest.js`
- `node --check scripts/interaction.js`
- `node --check scripts/dialogueSystem.js`

------
https://chatgpt.com/codex/tasks/task_e_68461b2775f88331917a266d6ac1c0bc