### PR TITLE
Add new day/night environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Then open `http://localhost:8000/` in your browser to launch `index.html`. Any o
 
 Game scripts live under `scripts/` and data files are in `data/`. With the server running, modifying these files and refreshing the page is enough to see changes.
 
+### Environments
+
+Maps can specify an `environment` value which adds a CSS class like `env-fog` or `env-rain` to the grid. The stylesheet provides visual effects for these classes. Additional options such as `env-day` and `env-night` are available for custom day or night scenes.
+
 ## Deployment
 
 The repository is ready for GitHub Pages. Commit your changes to the default branch and enable Pages to serve `index.html` from the repository root.

--- a/data/maps/map13.json
+++ b/data/maps/map13.json
@@ -1,0 +1,5 @@
+{
+  "name": "Starry Night",
+  "environment": "night",
+  "grid": []
+}

--- a/style/main.css
+++ b/style/main.css
@@ -499,3 +499,33 @@ body {
   color: #f2e9e4;
 }
 
+.env-day {
+  background: linear-gradient(#bcd9ff 0%, #eaf4ff 100%);
+  color: #111;
+}
+
+.env-night {
+  background: radial-gradient(circle at center, #111 0%, #000 100%);
+  color: #ddd;
+}
+
+.env-night::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image:
+    radial-gradient(2px 2px at 20% 30%, rgba(255,255,255,0.8), transparent 40%),
+    radial-gradient(2px 2px at 80% 40%, rgba(255,255,255,0.8), transparent 40%),
+    radial-gradient(2px 2px at 30% 70%, rgba(255,255,255,0.8), transparent 40%),
+    radial-gradient(2px 2px at 70% 80%, rgba(255,255,255,0.8), transparent 40%);
+  animation: starTwinkle 3s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes starTwinkle {
+  50% { opacity: 0.5; }
+}
+


### PR DESCRIPTION
## Summary
- document environment classes in README
- add `env-day` and `env-night` styles with a simple star effect
- include a new map `map13.json` showcasing the `night` environment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68461ca3ff70833193e9cd13d72e16ea