### PR TITLE
Add combat start event

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -43,6 +43,7 @@ export function startCombat(enemy, player) {
     </div>`;
 
   document.body.appendChild(overlay);
+  document.dispatchEvent(new CustomEvent('combatStarted'));
   requestAnimationFrame(() => overlay.classList.add('active'));
 
   const playerBar = overlay.querySelector('.player .hp');

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -182,6 +182,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         updateHpDisplay();
       }
     });
+    document.addEventListener('combatStarted', () => {
+      isInBattle = true;
+    });
     document.addEventListener('combatEnded', e => {
       isInBattle = false;
       if (e.detail.enemyHp <= 0) {


### PR DESCRIPTION
## Summary
- dispatch `combatStarted` event after the combat overlay is attached
- listen for `combatStarted` in `main.js` to set `isInBattle` to `true`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68461fc557908331b22e42fb644c3f43