### PR TITLE
Add trap damage system

### DIFF
--- a/scripts/gameEngine.js
+++ b/scripts/gameEngine.js
@@ -1,5 +1,6 @@
 // Handles trap and tile effects triggered when the player steps on certain tiles.
 import { showDialogue } from './dialogueSystem.js';
+import { takeDamage, healFull } from './player.js';
 
 /**
  * Applies effects based on the tile symbol the player stepped on.
@@ -9,13 +10,13 @@ import { showDialogue } from './dialogueSystem.js';
  */
 export function handleTileEffects(tileSymbol, player) {
   if (tileSymbol === 't') {
-    player.hp = Math.max(0, player.hp - 5);
-    showDialogue('You stepped on a hidden spike. -5 HP.');
+    takeDamage(1);
+    showDialogue('A hidden snare cuts at your feet.');
   } else if (tileSymbol === 'T') {
-    player.hp = Math.max(0, player.hp - 15);
-    showDialogue('A trap! You were badly hurt. -15 HP.');
+    takeDamage(2);
+    showDialogue('Spikes! You\u2019re badly wounded!');
   } else if (tileSymbol === 'W') {
-    player.hp = player.maxHp;
+    healFull();
     showDialogue('The cool water rejuvenates you. HP fully restored.');
   }
 }

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -13,6 +13,15 @@ export function moveTo(x, y) {
 
 export function takeDamage(amount) {
   player.hp = Math.max(0, player.hp - amount);
+  if (player.hp === 0) triggerDeath();
+}
+
+export function isAlive() {
+  return player.hp > 0;
+}
+
+export function triggerDeath() {
+  // Placeholder for future death handling
 }
 
 export function healFull() {

--- a/style/main.css
+++ b/style/main.css
@@ -77,11 +77,11 @@ body {
 }
 
 .tile.trap-light {
-  background-color: #C0C0C0;
+  background-color: #999;
 }
 
 .tile.trap-dark {
-  background-color: #505050;
+  background-color: #555;
 }
 
 .tile.water {


### PR DESCRIPTION
## Summary
- reduce HP when stepping on trap tiles
- highlight traps with adjusted floor-tone coloring
- expose player damage/death helpers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684635c62e588331b6e2a5280baa7a7f