### PR TITLE
Add player death and respawn system

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -1,5 +1,6 @@
 
 import { getSkill } from './skills.js';
+import { triggerDeath } from './player.js';
 
 let overlay = null;
 
@@ -145,6 +146,9 @@ export function startCombat(enemy, player) {
     log('Combat ended');
     if (player) {
       player.hp = playerHp;
+    }
+    if (playerHp <= 0) {
+      triggerDeath();
     }
     gridEl.classList.remove('blurred');
     overlay.remove();

--- a/scripts/game_state.js
+++ b/scripts/game_state.js
@@ -4,6 +4,7 @@ export const gameState = {
   defeatedEnemies: new Set(),
   environment: 'clear',
   maxHpBonus: 0,
+  isDead: false,
 };
 
 export function saveState() {

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -9,6 +9,7 @@ import { startCombat } from './combatSystem.js';
 import { showDialogue } from './dialogueSystem.js';
 import { getAllSkills, unlockSkill } from './skills.js';
 import * as router from './router.js';
+import { gameState } from './game_state.js';
 
 /**
  * Handles double click interactions on tiles.
@@ -27,6 +28,7 @@ export async function handleTileInteraction(
   cols,
   npcModules = {}
 ) {
+  if (gameState.isDead) return;
   const target = e.target;
   if (!target.classList.contains('tile')) return;
   const x = Number(target.dataset.x);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -7,6 +7,7 @@ import { findPath } from './pathfinder.js';
 import * as router from './router.js';
 import { showDialogue } from './dialogueSystem.js';
 import { handleTileInteraction } from './interaction.js';
+import { isMovementDisabled } from './movement.js';
 import * as eryndor from './npc/eryndor.js';
 import * as lioran from './npc/lioran.js';
 import {
@@ -48,7 +49,7 @@ function drawPlayer(player, container, cols) {
 let isMoving = false;
 
 function handleTileClick(e, player, container, cols) {
-  if (isMoving || isInBattle) return;
+  if (isMoving || isInBattle || isMovementDisabled()) return;
   const target = e.target;
   if (!target.classList.contains('tile')) return;
   const x = Number(target.dataset.x);
@@ -175,7 +176,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     container.addEventListener('click', e => handleTileClick(e, player, container, cols));
     container.addEventListener('dblclick', async e => {
-      if (isInBattle || isMoving) return;
+      if (isInBattle || isMoving || isMovementDisabled()) return;
       const newCols = await handleTileInteraction(e, player, container, cols, npcModules);
       if (newCols) {
         cols = newCols;
@@ -206,6 +207,11 @@ document.addEventListener('DOMContentLoaded', async () => {
           }
         }
       }
+    });
+
+    document.addEventListener('playerRespawned', e => {
+      cols = e.detail.cols;
+      updateHpDisplay();
     });
   } catch (err) {
     console.error(err);

--- a/scripts/movement.js
+++ b/scripts/movement.js
@@ -1,0 +1,13 @@
+let disabled = false;
+
+export function disableMovement() {
+  disabled = true;
+}
+
+export function enableMovement() {
+  disabled = false;
+}
+
+export function isMovementDisabled() {
+  return disabled;
+}

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -1,3 +1,8 @@
+import { gameState } from './game_state.js';
+import { disableMovement, enableMovement } from './movement.js';
+import { showDialogue } from './dialogueSystem.js';
+import { loadMap } from './router.js';
+
 export const player = {
   x: 0,
   y: 0,
@@ -21,7 +26,22 @@ export function isAlive() {
 }
 
 export function triggerDeath() {
-  // Placeholder for future death handling
+  gameState.isDead = true;
+  disableMovement();
+  const gridEl = document.getElementById('game-grid');
+  if (gridEl) gridEl.classList.add('death-screen');
+  showDialogue('You have fallen... but not forever.');
+  setTimeout(respawnPlayer, 3000);
+}
+
+export async function respawnPlayer() {
+  const { cols } = await loadMap('map01.json', { x: 1, y: 1 });
+  player.hp = player.maxHp;
+  gameState.isDead = false;
+  const gridEl = document.getElementById('game-grid');
+  if (gridEl) gridEl.classList.remove('death-screen');
+  enableMovement();
+  document.dispatchEvent(new CustomEvent('playerRespawned', { detail: { cols } }));
 }
 
 export function healFull() {

--- a/style/main.css
+++ b/style/main.css
@@ -128,6 +128,17 @@ body {
   filter: blur(3px);
 }
 
+#game-grid.death-screen::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+}
+
 #battle-overlay {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- track whether the player is dead in `game_state`
- add movement control helpers
- implement death/respawn logic in `player.js`
- block input while dead
- trigger death after combat
- dim the grid while dead

## Testing
- `node --check scripts/player.js`
- `node --check scripts/movement.js`
- `node --check scripts/combatSystem.js`
- `node --check scripts/interaction.js`
- `node --check scripts/main.js`

------
https://chatgpt.com/codex/tasks/task_e_68463734ec30833182edc4c0b9262ff0