### PR TITLE
Implement dialogue-based quest system

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -10,6 +10,7 @@ import { handleTileInteraction } from './interaction.js';
 import { isMovementDisabled } from './movement.js';
 import * as eryndor from './npc/eryndor.js';
 import * as lioran from './npc/lioran.js';
+import * as goblinQuestGiver from './npc/goblin_quest_giver.js';
 import { initSkillSystem } from './skills.js';
 import { saveState, loadState, gameState } from './game_state.js';
 import {
@@ -21,7 +22,7 @@ import {
 // Inventory contents are managed in inventory.js
 
 let isInBattle = false;
-const npcModules = { eryndor, lioran };
+const npcModules = { eryndor, lioran, goblinQuestGiver };
 
 let hpDisplay;
 

--- a/scripts/npc/goblin_quest_giver.js
+++ b/scripts/npc/goblin_quest_giver.js
@@ -1,0 +1,6 @@
+import { startDialogueTree } from '../dialogueSystem.js';
+import { goblinQuestDialogue } from '../npc_dialogues/goblin_quest_giver.js';
+
+export function interact() {
+  startDialogueTree(goblinQuestDialogue);
+}

--- a/scripts/npc_dialogues/eryndor_dialogue.js
+++ b/scripts/npc_dialogues/eryndor_dialogue.js
@@ -21,7 +21,7 @@ export const eryndorDialogue = [
         goto: null,
         give: "ancient_scroll",
         memoryFlag: "received_scroll",
-        condition: (state) => !state.inventory.includes("ancient_scroll")
+        condition: (state) => !state.inventory['ancient_scroll']
       }
     ]
   }

--- a/scripts/npc_dialogues/goblin_quest_giver.js
+++ b/scripts/npc_dialogues/goblin_quest_giver.js
@@ -1,0 +1,48 @@
+import { startQuest, completeQuest } from '../quest_state.js';
+import { removeItem, addItem } from '../inventory.js';
+import { loadItems, getItemData } from '../item_loader.js';
+
+export const goblinQuestDialogue = [
+  {
+    text: "If you bring me goblin gear, I might give you something in return...",
+    options: [
+      {
+        label: "I'll see what I can do.",
+        goto: null,
+        memoryFlag: "quest_goblin_started",
+        onChoose: () => startQuest('goblin_gear')
+      }
+    ]
+  },
+  {
+    text: "Have you managed to get some goblin gear?",
+    options: [
+      {
+        label: "Yes, here it is.",
+        goto: 2,
+        condition: (state) => (state.inventory['goblin_ear'] || 0) >= 3,
+        onChoose: async () => {
+          await loadItems();
+          const data = getItemData('silver_key') || { name: 'Silver Key', description: '' };
+          removeItem('goblin_ear', 3);
+          addItem({ ...data, id: 'silver_key', quantity: 1 });
+          completeQuest('goblin_gear');
+        }
+      },
+      {
+        label: "Not yet.",
+        goto: null
+      }
+    ]
+  },
+  {
+    text: "Impressive. Here's something useful in return.",
+    options: [
+      {
+        label: "Thank you.",
+        goto: null,
+        memoryFlag: "quest_goblin_completed"
+      }
+    ]
+  }
+];

--- a/scripts/npc_dialogues/lioran_dialogue.js
+++ b/scripts/npc_dialogues/lioran_dialogue.js
@@ -31,7 +31,7 @@ export const lioranDialogue = [
         goto: null,
         give: "mysterious_token",
         memoryFlag: "lioran_gift_given",
-        condition: (state) => !state.inventory.includes("mysterious_token")
+        condition: (state) => !state.inventory['mysterious_token']
       },
       {
         label: "I don't trust strange gifts.",

--- a/scripts/quest_state.js
+++ b/scripts/quest_state.js
@@ -1,0 +1,23 @@
+export const quests = {};
+
+export function startQuest(id) {
+  if (!quests[id]) {
+    quests[id] = { started: false, completed: false };
+  }
+  quests[id].started = true;
+}
+
+export function completeQuest(id) {
+  if (!quests[id]) {
+    quests[id] = { started: true, completed: false };
+  }
+  quests[id].completed = true;
+}
+
+export function isQuestStarted(id) {
+  return !!quests[id]?.started;
+}
+
+export function isQuestCompleted(id) {
+  return !!quests[id]?.completed;
+}


### PR DESCRIPTION
## Summary
- create `quest_state.js` to track quest progress
- support quest flags and onChoose hooks in dialogue
- update dialogue conditions to use inventory counts
- add Goblin Gear quest NPC and dialogue
- register new NPC in main entry point

## Testing
- `npm test` *(fails: missing npm project)*

------
https://chatgpt.com/codex/tasks/task_e_68463bc93b6c8331b928ab7834c09570