### PR TITLE
Add quest log and responsive layout

### DIFF
--- a/data/quests.json
+++ b/data/quests.json
@@ -1,0 +1,6 @@
+{
+  "goblin_gear": {
+    "title": "Goblin Gear",
+    "description": "Collect three goblin ears for the quest giver."
+  }
+}

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <div id="hp-display"></div>
     <div class="tab settings-tab">Settings</div>
     <div class="tab inventory-tab">Inventory</div>
+    <div class="tab quests-tab">Quests</div>
     <div class="tab save-tab">Save</div>
     <div class="tab load-tab">Load</div>
   </div>
@@ -20,6 +21,13 @@
       <button class="close-btn">&times;</button>
       <h2>Inventory</h2>
       <div id="inventory-list"></div>
+    </div>
+  </div>
+  <div id="quest-log-overlay" class="quest-overlay">
+    <div class="quest-content">
+      <button class="close-btn">&times;</button>
+      <h2>Active Quests</h2>
+      <div id="quest-log"></div>
     </div>
   </div>
   <div id="settings-overlay" class="settings-overlay">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,7 @@
 import { getCurrentGrid } from './mapLoader.js';
 import { handleTileEffects } from './gameEngine.js';
 import { toggleInventoryView } from './inventory_state.js';
+import { toggleQuestLog } from './quest_log.js';
 import { player } from './player.js';
 import { loadEnemyData, defeatEnemy } from './enemy.js';
 import { findPath } from './pathfinder.js';
@@ -84,6 +85,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const inventoryTab = document.querySelector('.inventory-tab');
   const inventoryOverlay = document.getElementById('inventory-overlay');
   const closeBtn = inventoryOverlay.querySelector('.close-btn');
+  const questsTab = document.querySelector('.quests-tab');
+  const questsOverlay = document.getElementById('quest-log-overlay');
+  const questsClose = questsOverlay.querySelector('.close-btn');
   const settingsTab = document.querySelector('.settings-tab');
   const settingsOverlay = document.getElementById('settings-overlay');
   const settingsClose = settingsOverlay.querySelector('.close-btn');
@@ -115,6 +119,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   closeBtn.addEventListener('click', toggleInventoryView);
   inventoryOverlay.addEventListener('click', e => {
     if (e.target === inventoryOverlay) toggleInventoryView();
+  });
+  questsTab.addEventListener('click', toggleQuestLog);
+  questsClose.addEventListener('click', toggleQuestLog);
+  questsOverlay.addEventListener('click', e => {
+    if (e.target === questsOverlay) toggleQuestLog();
   });
 
   function showSettings() {

--- a/scripts/quest_log.js
+++ b/scripts/quest_log.js
@@ -1,0 +1,29 @@
+import { loadQuestData, getActiveQuests } from './quest_state.js';
+
+export async function updateQuestUI() {
+  const list = document.getElementById('quest-log');
+  if (!list) return;
+  await loadQuestData();
+  const quests = getActiveQuests();
+  list.innerHTML = '';
+  quests.forEach(q => {
+    const row = document.createElement('div');
+    row.classList.add('quest-item');
+    row.innerHTML = `<strong>${q.title}</strong><div class="desc">${q.description}</div>`;
+    list.appendChild(row);
+  });
+  if (quests.length === 0) {
+    list.innerHTML = '<em>No active quests</em>';
+  }
+}
+
+export function toggleQuestLog() {
+  const overlay = document.getElementById('quest-log-overlay');
+  if (!overlay) return;
+  if (overlay.classList.contains('active')) {
+    overlay.classList.remove('active');
+  } else {
+    updateQuestUI();
+    overlay.classList.add('active');
+  }
+}

--- a/scripts/quest_state.js
+++ b/scripts/quest_state.js
@@ -1,5 +1,27 @@
 export const quests = {};
 
+let questData = {};
+let dataLoaded = false;
+
+export async function loadQuestData() {
+  if (dataLoaded) return questData;
+  try {
+    const res = await fetch('data/quests.json');
+    if (res.ok) {
+      questData = await res.json();
+    }
+  } catch {
+    // ignore errors
+  } finally {
+    dataLoaded = true;
+  }
+  return questData;
+}
+
+export function getQuestData(id) {
+  return questData[id];
+}
+
 export function startQuest(id) {
   if (!quests[id]) {
     quests[id] = { started: false, completed: false };
@@ -20,4 +42,13 @@ export function isQuestStarted(id) {
 
 export function isQuestCompleted(id) {
   return !!quests[id]?.completed;
+}
+
+export function getActiveQuests() {
+  return Object.keys(quests)
+    .filter(id => quests[id].started && !quests[id].completed)
+    .map(id => {
+      const data = questData[id] || { title: id, description: '' };
+      return { id, ...data };
+    });
 }

--- a/style/main.css
+++ b/style/main.css
@@ -8,6 +8,25 @@ body {
   min-height: 100vh;
 }
 
+@media (min-width: 900px) {
+  body {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+  #ui-bar {
+    flex-direction: column;
+    width: auto;
+    margin-left: 20px;
+  }
+}
+
+@media (max-width: 600px) {
+  #ui-bar {
+    flex-wrap: wrap;
+    text-align: center;
+  }
+}
+
 #game-grid {
   margin: 20px auto;
   width: max-content;
@@ -52,7 +71,7 @@ body {
   cursor: pointer;
 }
 
-.ground:hover {
+.tile:hover {
   outline: 2px solid #fff;
 }
 
@@ -109,6 +128,7 @@ body {
   cursor: pointer;
   border-radius: 4px;
   transition: background 0.2s;
+  border: 1px solid #444;
 }
 
 #ui-bar .tab:hover {
@@ -351,6 +371,68 @@ body {
   color: #555;
 }
 
+/* Quest Log UI */
+.quest-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 900;
+}
+
+.quest-overlay.active {
+  visibility: visible;
+  opacity: 1;
+}
+
+.quest-content {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 300px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  position: relative;
+}
+
+.quest-content h2 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.quest-content .close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.quest-item {
+  border-bottom: 1px solid #ddd;
+  padding: 6px 0;
+}
+
+.quest-item:last-child {
+  border-bottom: none;
+}
+
+.quest-item .desc {
+  font-size: 12px;
+  color: #555;
+}
+
 /* Settings UI */
 .settings-overlay {
   position: fixed;
@@ -428,6 +510,8 @@ body {
   max-width: 80%;
   font-family: 'Courier New', Courier, monospace;
   position: relative;
+  border: 2px solid #666;
+  box-shadow: 0 0 10px rgba(0,0,0,0.7);
 }
 
 .dialogue-advance {


### PR DESCRIPTION
## Summary
- support loading quest metadata and retrieving active quests
- create quest log overlay with toggle functions
- add Quests menu button and overlay in `index.html`
- wire quest log controls in `main.js`
- improve styling and responsiveness in `main.css`
- provide initial quest data

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68463ec55b808331834012ad0afff4a6