### PR TITLE
Add quest chaining for goblin quests

### DIFF
--- a/data/quests.json
+++ b/data/quests.json
@@ -1,6 +1,11 @@
 {
   "goblin_gear": {
     "title": "Goblin Gear",
-    "description": "Collect three goblin ears for the quest giver."
+    "description": "Collect three goblin ears for the quest giver.",
+    "onCompleteUnlocks": ["scout_tracking"]
+  },
+  "scout_tracking": {
+    "title": "Tracking the Scout",
+    "description": "Follow the goblin scout's trail to their camp."
   }
 }

--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -3,7 +3,7 @@ import { updateInventoryUI } from './inventory_state.js';
 import { loadItems, getItemData } from './item_loader.js';
 import { unlockSkillsFromItem, getAllSkills } from './skills.js';
 import { dialogueMemory, setMemory } from './dialogue_state.js';
-import { quests } from './quest_state.js';
+import { quests, completeQuest } from './quest_state.js';
 
 let dialogueLines = {};
 let dataLoaded = false;
@@ -236,6 +236,9 @@ export async function startDialogueTree(dialogue, index = 0) {
             }
           });
         }
+      }
+      if (opt.completeQuest) {
+        completeQuest(opt.completeQuest);
       }
       if (opt.goto !== null && opt.goto !== undefined) {
         startDialogueTree(dialogue, opt.goto);

--- a/scripts/npc_dialogues/goblin_quest_giver.js
+++ b/scripts/npc_dialogues/goblin_quest_giver.js
@@ -1,4 +1,4 @@
-import { startQuest, completeQuest } from '../quest_state.js';
+import { startQuest } from '../quest_state.js';
 import { removeItem, addItem } from '../inventory.js';
 import { loadItems, getItemData } from '../item_loader.js';
 
@@ -26,8 +26,8 @@ export const goblinQuestDialogue = [
           const data = getItemData('silver_key') || { name: 'Silver Key', description: '' };
           removeItem('goblin_ear', 3);
           addItem({ ...data, id: 'silver_key', quantity: 1 });
-          completeQuest('goblin_gear');
-        }
+        },
+        completeQuest: 'goblin_gear'
       },
       {
         label: "Not yet.",

--- a/scripts/quest_log.js
+++ b/scripts/quest_log.js
@@ -27,3 +27,6 @@ export function toggleQuestLog() {
     overlay.classList.add('active');
   }
 }
+
+// Refresh the quest list whenever quest data changes
+document.addEventListener('questUpdated', updateQuestUI);

--- a/scripts/quest_state.js
+++ b/scripts/quest_state.js
@@ -27,6 +27,7 @@ export function startQuest(id) {
     quests[id] = { started: false, completed: false };
   }
   quests[id].started = true;
+  document.dispatchEvent(new CustomEvent('questUpdated'));
 }
 
 export function completeQuest(id) {
@@ -34,6 +35,13 @@ export function completeQuest(id) {
     quests[id] = { started: true, completed: false };
   }
   quests[id].completed = true;
+  loadQuestData().then(() => {
+    const data = questData[id];
+    if (data && Array.isArray(data.onCompleteUnlocks)) {
+      data.onCompleteUnlocks.forEach(qId => startQuest(qId));
+    }
+    document.dispatchEvent(new CustomEvent('questUpdated'));
+  });
 }
 
 export function isQuestStarted(id) {


### PR DESCRIPTION
## Summary
- support chained quests via `onCompleteUnlocks`
- automatically refresh quest log when quests change
- allow dialogues to mark quests as complete
- use new quest completion property in goblin quest dialogue
- define `Tracking the Scout` quest unlocked from `Goblin Gear`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684640672ed0833184b4893fabd6033b