### PR TITLE
Add goblin enemies and defeat message support

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -36,5 +36,38 @@
     "description": "Bones clatter as it advances.",
     "intro": "A skeleton rattles menacingly!",
     "portrait": "💀"
+  },
+  "goblin_scout": {
+    "name": "Goblin Scout",
+    "hp": 40,
+    "description": "A keen-eyed goblin keeping watch over the hills.",
+    "intro": "The scout spots you and blows a horn!",
+    "portrait": "🗡️",
+    "drop": { "item": "goblin_ear", "quantity": 1 }
+  },
+  "goblin_archer": {
+    "name": "Goblin Archer",
+    "hp": 45,
+    "description": "This goblin prefers attacking from a distance.",
+    "intro": "A goblin archer nocks an arrow your way!",
+    "portrait": "🏹",
+    "drop": { "item": "goblin_ear", "quantity": 1 }
+  },
+  "rotting_warrior": {
+    "name": "Rotting Warrior",
+    "hp": 60,
+    "description": "A decayed soldier still clinging to its rusted blade.",
+    "intro": "The rotting warrior staggers forward with a groan!",
+    "portrait": "🪓",
+    "drop": { "item": "rotten_tooth", "quantity": 1 }
+  },
+  "scout_commander": {
+    "name": "Scout Commander",
+    "hp": 90,
+    "description": "Leader of the goblin scouting parties, armored and alert.",
+    "intro": "The scout commander barks orders and charges!",
+    "portrait": "🎖️",
+    "drop": { "item": "ancient_scroll", "quantity": 1 },
+    "onDefeatMessage": "The commander falls. A silence settles over the hills."
   }
 }

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -179,6 +179,9 @@ export async function startCombat(enemy, player) {
     document.dispatchEvent(
       new CustomEvent('combatEnded', { detail: { playerHp, enemyHp, enemy } })
     );
+    if (enemyHp <= 0 && enemy.onDefeatMessage) {
+      showDialogue(enemy.onDefeatMessage);
+    }
   }
 
   function enemyTurn() {


### PR DESCRIPTION
## Summary
- introduce Goblin Scout, Goblin Archer, Rotting Warrior, and Scout Commander
- allow combat system to display custom `onDefeatMessage`

## Testing
- `cat data/enemies.json | jq '.' >/tmp/parsed.json && tail -n 1 /tmp/parsed.json`

------
https://chatgpt.com/codex/tasks/task_e_6846437b39a08331945f7af7c86403a0