### PR TITLE
Add full map03 with quest updates

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -67,7 +67,7 @@
     "description": "Leader of the goblin scouting parties, armored and alert.",
     "intro": "The scout commander barks orders and charges!",
     "portrait": "🎖️",
-    "drop": { "item": "ancient_scroll", "quantity": 1 },
+    "drop": { "item": "commander_badge", "quantity": 1 },
     "onDefeatMessage": "The commander falls. A silence settles over the hills."
   }
 }

--- a/data/items.json
+++ b/data/items.json
@@ -16,5 +16,13 @@
   "rotten_tooth": {
     "name": "Rotten Tooth",
     "description": "Crumbly but still has bite"
+  },
+  "health_amulet": {
+    "name": "Health Amulet",
+    "description": "An amulet that bolsters vitality"
+  },
+  "commander_badge": {
+    "name": "Commander Badge",
+    "description": "Proof of defeating the scout commander"
   }
 }

--- a/data/maps/map03.json
+++ b/data/maps/map03.json
@@ -1,5 +1,256 @@
 {
   "name": "Twilight Field",
   "environment": "dusk",
-  "grid": []
+  "grid": [
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "E",
+        "enemyId": "goblin_archer"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "E",
+        "enemyId": "goblin_scout"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "E",
+        "enemyId": "scout_commander"
+      },
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "t"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    [
+      {
+        "type": "D",
+        "target": "map02.json",
+        "spawn": {
+          "x": 18,
+          "y": 10
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "t"
+      },
+      {
+        "type": "C"
+      },
+      {
+        "type": "T"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "D",
+        "locked": true,
+        "requiresItem": "commander_badge",
+        "leadsTo": "map04.json"
+      }
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "T"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "E",
+        "enemyId": "rotting_warrior"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "E",
+        "enemyId": "goblin_archer"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ]
+  ]
 }

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -10,6 +10,7 @@ const chestContents = {
   'map02:5,5': { item: 'silver_key', message: 'You found a silver key.' },
   'map02:8,12': { message: 'This chest was empty.' },
   'map02:15,15': { item: 'potion_of_health' },
+  'map03:10,10': { item: 'health_amulet' },
 };
 
 export function isChestOpened(id) {
@@ -28,9 +29,14 @@ export async function openChest(id, player) {
     if (item) {
       const qty = config.quantity || 1;
       addItem({ ...item, id: config.item, quantity: qty });
-      if (config.item === 'potion_of_health' && player) {
-        increaseMaxHp(1);
-        gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
+      if (player) {
+        if (config.item === 'potion_of_health') {
+          increaseMaxHp(1);
+          gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
+        } else if (config.item === 'health_amulet') {
+          increaseMaxHp(2);
+          gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 2;
+        }
       }
       updateInventoryUI();
       unlockedSkills = unlockSkillsFromItem(config.item);

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -45,13 +45,26 @@ export async function handleTileInteraction(
         showDialogue('The door is locked.');
         break;
       }
+      const targetMap = tile.target || tile.leadsTo;
+      if (required === 'commander_badge') {
+        showDialogue('Your commander badge unlocks the way.', async () => {
+          if (tile.consumeItem) {
+            removeItem(required);
+            updateInventoryUI();
+          }
+          const { cols: newCols } = await router.loadMap(targetMap, tile.spawn);
+          return newCols;
+        });
+        break;
+      }
       if (required && tile.consumeItem) {
         removeItem(required);
         updateInventoryUI();
       }
-      const targetMap = tile.target || tile.leadsTo;
-      const { cols: newCols } = await router.loadMap(targetMap, tile.spawn);
-      return newCols;
+      {
+        const { cols: newCols } = await router.loadMap(targetMap, tile.spawn);
+        return newCols;
+      }
     }
     case 'E': {
       const index = y * cols + x;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,6 +4,8 @@ import { toggleInventoryView } from './inventory_state.js';
 import { toggleQuestLog } from './quest_log.js';
 import { player } from './player.js';
 import { loadEnemyData, defeatEnemy } from './enemy.js';
+import { setMemory } from './dialogue_state.js';
+import { completeQuest, isQuestStarted, isQuestCompleted } from './quest_state.js';
 import { findPath } from './pathfinder.js';
 import * as router from './router.js';
 import { showDialogue } from './dialogueSystem.js';
@@ -195,6 +197,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (e.detail.enemyHp <= 0) {
         const enemyId = e.detail.enemy.id;
         defeatEnemy(enemyId);
+        if (enemyId === 'goblin_scout') {
+          setMemory('scout_defeated');
+          if (isQuestStarted('scout_tracking') && !isQuestCompleted('scout_tracking')) {
+            completeQuest('scout_tracking');
+          }
+        }
       }
     });
 

--- a/scripts/quest_state.js
+++ b/scripts/quest_state.js
@@ -1,3 +1,5 @@
+import { hasMemory } from './dialogue_state.js';
+
 export const quests = {};
 
 let questData = {};
@@ -53,6 +55,11 @@ export function isQuestCompleted(id) {
 }
 
 export function getActiveQuests() {
+  if (isQuestStarted('scout_tracking') && !isQuestCompleted('scout_tracking')) {
+    if (hasMemory('scout_defeated')) {
+      completeQuest('scout_tracking');
+    }
+  }
   return Object.keys(quests)
     .filter(id => quests[id].started && !quests[id].completed)
     .map(id => {


### PR DESCRIPTION
## Summary
- build Twilight Field map03 with enemies, doors, chest, traps and water
- add health_amulet and commander_badge items
- drop commander_badge from scout commander
- support health_amulet effect when opening chest
- show message when using commander_badge door
- flag scout defeat and auto-complete quest

## Testing
- `node -c scripts/main.js`
- `node -c scripts/chest.js`
- `node -c scripts/interaction.js`
- `node -c scripts/quest_state.js`
- `node -e "const m=require('./data/maps/map03.json');console.log('rows',m.grid.length);"`

------
https://chatgpt.com/codex/tasks/task_e_684645a6ab288331a52b54529d641f73