### PR TITLE
Add health amulet bonus

### DIFF
--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -34,8 +34,12 @@ export async function openChest(id, player) {
           increaseMaxHp(1);
           gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
         } else if (config.item === 'health_amulet') {
-          increaseMaxHp(2);
-          gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 2;
+          if (!player.bonusHpGiven?.health_amulet) {
+            increaseMaxHp(2);
+            gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 2;
+            if (!player.bonusHpGiven) player.bonusHpGiven = {};
+            player.bonusHpGiven.health_amulet = true;
+          }
         }
       }
       updateInventoryUI();

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -9,6 +9,7 @@ export const player = {
   hp: 100,
   maxHp: 100,
   learnedSkills: [],
+  bonusHpGiven: {},
 };
 
 export function moveTo(x, y) {


### PR DESCRIPTION
## Summary
- track unique HP bonuses on the player object
- apply health amulet bonus only once when obtained from chests

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684648308fd48331a8cadc82644e16f5