### PR TITLE
Remove duplicate player drawing code

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -35,14 +35,6 @@ function updateHpDisplay() {
   }
 }
 
-function drawPlayer(player, container, cols) {
-  container.querySelectorAll('.player').forEach(el => el.classList.remove('player'));
-  const index = player.y * cols + player.x;
-  const tile = container.children[index];
-  if (tile) {
-    tile.classList.add('player');
-  }
-}
 
 let isMoving = false;
 
@@ -71,7 +63,7 @@ function handleTileClick(e, player, container, cols) {
     const pos = path[index];
     player.x = pos.x;
     player.y = pos.y;
-    drawPlayer(player, container, cols);
+    router.drawPlayer(player, container, cols);
     const tile = grid[player.y][player.x];
     handleTileEffects(tile.type, player);
     updateHpDisplay();

--- a/scripts/router.js
+++ b/scripts/router.js
@@ -18,7 +18,7 @@ function findFirstWalkable(grid) {
   return { x: 0, y: 0 };
 }
 
-function drawPlayer(playerObj, containerEl, colsCount) {
+export function drawPlayer(playerObj, containerEl, colsCount) {
   containerEl
     .querySelectorAll('.player')
     .forEach(el => el.classList.remove('player'));


### PR DESCRIPTION
## Summary
- expose `drawPlayer` from `router.js`
- drop local `drawPlayer` in `main.js` and reuse router helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68464c9d0a6483318c0d895dd95a4e7e