### PR TITLE
Add blueprint recipe unlocking and crafting restrictions

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -21,6 +21,10 @@
     "name": "Health Amulet",
     "description": "An amulet that bolsters vitality"
   },
+  "blueprint_amulet": {
+    "name": "Blueprint: Amulet",
+    "description": "Instructions for crafting a health amulet"
+  },
   "commander_badge": {
     "name": "Commander Badge",
     "description": "Proof of defeating the scout commander"

--- a/data/recipes.json
+++ b/data/recipes.json
@@ -1,8 +1,16 @@
 {
   "healing_salve": {
+    "id": "healing_salve",
     "name": "Healing Salve",
     "ingredients": {"goblin_ear": 1, "rotten_tooth": 1},
     "result": "potion_of_health",
+    "quantity": 1
+  },
+  "health_amulet": {
+    "id": "health_amulet",
+    "name": "Health Amulet",
+    "ingredients": {"potion_of_health": 2},
+    "result": "health_amulet",
     "quantity": 1
   }
 }

--- a/scripts/craft.js
+++ b/scripts/craft.js
@@ -1,6 +1,17 @@
 import { loadItems, getItemData } from './item_loader.js';
 import { addItem, removeItem, getItemCount } from './inventory.js';
 import { craftState } from './craft_state.js';
+import { isRecipeUnlocked } from './recipe_state.js';
+
+let craftingAllowed = false;
+
+export function beginCraftingSession() {
+  craftingAllowed = true;
+}
+
+export function endCraftingSession() {
+  craftingAllowed = false;
+}
 
 let recipes = {};
 let loaded = false;
@@ -33,6 +44,8 @@ export function canCraft(id) {
 export async function craft(id) {
   await loadRecipes();
   await loadItems();
+  if (!craftingAllowed) return false;
+  if (!isRecipeUnlocked(id)) return false;
   if (!canCraft(id)) return false;
   const recipe = recipes[id];
   for (const [item, qty] of Object.entries(recipe.ingredients)) {

--- a/scripts/npc/arvalin.js
+++ b/scripts/npc/arvalin.js
@@ -1,6 +1,7 @@
 import { startDialogueTree } from '../dialogueSystem.js';
-import { arvalinDialogue } from '../npc_dialogues/arvalin_dialogue.js';
+import { createArvalinDialogue } from '../npc_dialogues/arvalin_dialogue.js';
 
-export function interact() {
-  startDialogueTree(arvalinDialogue);
+export async function interact() {
+  const dialogue = await createArvalinDialogue();
+  startDialogueTree(dialogue);
 }

--- a/scripts/npc_dialogues/arvalin_dialogue.js
+++ b/scripts/npc_dialogues/arvalin_dialogue.js
@@ -1,43 +1,63 @@
 import { startQuest } from '../quest_state.js';
 import { removeItem, addItem } from '../inventory.js';
 import { loadItems, getItemData } from '../item_loader.js';
+import { unlockRecipe, isRecipeUnlocked } from '../recipe_state.js';
 
-export const arvalinDialogue = [
-  {
-    text: "The Scout dropped something cursed. Bring me 1 goblin insignia and 1 cracked helmet.",
-    options: [
-      {
-        label: "I'll find them.",
-        goto: null,
-        memoryFlag: 'arvalin_quest_started',
-        onChoose: () => startQuest('purify_token')
-      },
-      { label: 'Maybe later.', goto: null }
-    ]
-  },
-  {
-    text: "Do you have the items I asked for?",
-    options: [
-      {
-        label: 'Yes, take them.',
-        goto: 2,
-        condition: (state) => state.inventory['goblin_insignia'] >= 1 && state.inventory['cracked_helmet'] >= 1,
-        onChoose: async () => {
-          await loadItems();
-          const data = getItemData('purified_token') || { name: 'Purified Token', description: '' };
-          removeItem('goblin_insignia', 1);
-          removeItem('cracked_helmet', 1);
-          addItem({ ...data, id: 'purified_token', quantity: 1 });
+export async function createArvalinDialogue() {
+  await loadItems();
+  return [
+    {
+      text: "The Scout dropped something cursed. Bring me 1 goblin insignia and 1 cracked helmet.",
+      options: [
+        {
+          label: "I'll find them.",
+          goto: null,
+          memoryFlag: 'arvalin_quest_started',
+          onChoose: () => startQuest('purify_token')
         },
-        completeQuest: 'purify_token'
-      },
-      { label: 'Not yet.', goto: null }
-    ]
-  },
-  {
-    text: 'Excellent. The curse is lifted. Take this token.',
-    options: [
-      { label: 'Thank you.', goto: null, memoryFlag: 'arvalin_quest_complete' }
-    ]
-  }
-];
+        { label: 'Maybe later.', goto: null }
+      ]
+    },
+    {
+      text: "Do you have the items I asked for?",
+      options: [
+        {
+          label: 'Yes, take them.',
+          goto: 2,
+          condition: state => state.inventory['goblin_insignia'] >= 1 && state.inventory['cracked_helmet'] >= 1,
+          onChoose: async () => {
+            const data = getItemData('purified_token') || { name: 'Purified Token', description: '' };
+            removeItem('goblin_insignia', 1);
+            removeItem('cracked_helmet', 1);
+            addItem({ ...data, id: 'purified_token', quantity: 1 });
+          },
+          completeQuest: 'purify_token'
+        },
+        { label: 'Not yet.', goto: null }
+      ]
+    },
+    {
+      text: 'Excellent. The curse is lifted. Take this token.',
+      options: [
+        { label: 'Thank you.', goto: null, memoryFlag: 'arvalin_quest_complete' }
+      ]
+    },
+    {
+      text: 'I can teach you a recipe if you have proof of valor.',
+      options: [
+        {
+          label: 'Trade commander badge.',
+          goto: null,
+          condition: state => state.inventory['commander_badge'] >= 1 && !isRecipeUnlocked('health_amulet'),
+          onChoose: async () => {
+            const bp = getItemData('blueprint_amulet') || { name: 'Blueprint: Amulet', description: '' };
+            removeItem('commander_badge', 1);
+            addItem({ ...bp, id: 'blueprint_amulet', quantity: 1 });
+            unlockRecipe('health_amulet');
+          }
+        },
+        { label: 'Maybe later.', goto: null }
+      ]
+    }
+  ];
+}

--- a/scripts/npc_dialogues/grindle_dialogue.js
+++ b/scripts/npc_dialogues/grindle_dialogue.js
@@ -1,10 +1,12 @@
-import { loadRecipes, canCraft, craft, getRecipe } from '../craft.js';
+import { loadRecipes, canCraft, craft, getRecipe, beginCraftingSession } from '../craft.js';
 import { craftState } from '../craft_state.js';
+import { isRecipeUnlocked } from '../recipe_state.js';
 import { showDialogue } from '../dialogueSystem.js';
 
 export async function createGrindleDialogue() {
   await loadRecipes();
-  const recipeIds = Object.keys(await loadRecipes());
+  const recipeIds = Object.keys(await loadRecipes()).filter(id => isRecipeUnlocked(id));
+  beginCraftingSession();
   const options = recipeIds.map(id => ({
     label: `Craft ${getRecipe(id).name}`,
     goto: null,

--- a/scripts/recipe_state.js
+++ b/scripts/recipe_state.js
@@ -1,0 +1,12 @@
+export const recipeState = {
+  unlocked: new Set(['healing_salve'])
+};
+
+export function unlockRecipe(id) {
+  recipeState.unlocked.add(id);
+  document.dispatchEvent(new CustomEvent('recipeUnlocked', { detail: id }));
+}
+
+export function isRecipeUnlocked(id) {
+  return recipeState.unlocked.has(id);
+}


### PR DESCRIPTION
## Summary
- introduce a blueprint tracking system with `recipe_state.js`
- require crafting sessions to be initiated through Grindle
- only show and craft recipes the player has unlocked
- allow trading a commander badge with Arvalin for a blueprint that unlocks the health amulet recipe
- include health amulet recipe and blueprint item data

## Testing
- `node -c scripts/craft.js`
- `node -c scripts/npc_dialogues/arvalin_dialogue.js`
- `node -c scripts/npc_dialogues/grindle_dialogue.js`
- `node -c scripts/npc/arvalin.js`
- `node -c scripts/recipe_state.js`

------
https://chatgpt.com/codex/tasks/task_e_6846531627b48331b9abf0a8de73526b