### PR TITLE
Fix chest persistence on map load

### DIFF
--- a/scripts/router.js
+++ b/scripts/router.js
@@ -43,6 +43,19 @@ export async function loadMap(filename, spawnPoint) {
   cols = grid[0].length;
   renderGrid(grid, container, environment);
 
+  // Mark chests that were previously opened
+  for (const id of gameState.openedChests) {
+    const [map, coord] = id.split(':');
+    if (map !== name) continue;
+    const [cx, cy] = coord.split(',').map(Number);
+    const index = cy * cols + cx;
+    const tileEl = container.children[index];
+    if (tileEl) {
+      tileEl.classList.remove('chest');
+      tileEl.classList.add('chest-opened');
+    }
+  }
+
   if (spawnPoint) {
     player.x = spawnPoint.x;
     player.y = spawnPoint.y;


### PR DESCRIPTION
## Summary
- ensure opened chests remain visually opened when a map loads

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684654dbd44883319f8d2ad2bc2125aa