### PR TITLE
Fix: remove unused rusted_key item

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1,7 +1,6 @@
 {
   "mysterious_key": { "name": "Mysterious Key", "description": "It hums faintly." },
   "rusty_key": { "name": "Rusty Key", "description": "Old and corroded, but it might still work." },
-  "rusted_key": { "name": "Rusted Key", "description": "Looks fragile but might still work." },
   "silver_key": { "name": "Silver Key", "description": "Shines with a dull luster." },
   "potion_of_health": { "name": "Potion of Health", "description": "Increases maximum health permanently." },
   "ancient_scroll": { "name": "Ancient Scroll", "description": "Faded text hints at forgotten lore." },


### PR DESCRIPTION
## Summary
- remove `rusted_key` from the item list since it's not used anywhere

## Testing
- `python3 -m json.tool data/items.json`

------
https://chatgpt.com/codex/tasks/task_e_6846a495b72c8331aea0c498f7e640dc