### PR TITLE
Document clear environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Game scripts live under `scripts/`, data files are in `data/`, and stylesheets c
 
 ### Environments
 
-Maps can specify an `environment` value which adds a CSS class like `env-fog` or `env-rain` to the grid. The stylesheet provides visual effects for these classes. Additional options such as `env-day`, `env-dusk` and `env-night` are available for custom day, dusk or night scenes.
+Maps can specify an `environment` value which adds a CSS class like `env-fog` or `env-rain` to the grid. When the field is omitted the map defaults to the `clear` environment, applying an `env-clear` class. The stylesheet provides visual effects for these classes. Additional options such as `env-day`, `env-dusk` and `env-night` are available for custom day, dusk or night scenes.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- note that `clear` is the default map environment and adds an `env-clear` class

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846a5c7ce808331991995b89966db2e