### PR TITLE
Add defense stat with damage reduction

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <div id="game-grid"></div>
   <div id="ui-bar">
     <div id="hp-display"></div>
+    <div id="defense-display"></div>
     <div class="tab settings-tab">Settings</div>
     <div class="tab inventory-tab">Inventory</div>
     <div class="tab quests-tab">Quests</div>
@@ -20,6 +21,7 @@
     <div class="inventory-content">
       <button class="close-btn">&times;</button>
       <h2>Inventory</h2>
+      <div id="player-stats"></div>
       <div id="inventory-list"></div>
     </div>
   </div>

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -1,6 +1,7 @@
 
 import { getSkill } from './skills.js';
 import { triggerDeath } from './player.js';
+import { applyDamage } from './logic.js';
 import { addItem } from './inventory.js';
 import { loadItems, getItemData } from './item_loader.js';
 import { updateInventoryUI } from './inventory_state.js';
@@ -194,8 +195,10 @@ export async function startCombat(enemy, player) {
       dmg = Math.max(0, dmg - 5);
       guardActive = false;
     }
-    playerHp = Math.max(0, playerHp - dmg);
-    log(`${enemy.name} attacks for ${dmg} damage!`);
+    const tempTarget = { hp: playerHp, stats: player.stats };
+    const applied = applyDamage(tempTarget, dmg);
+    playerHp = tempTarget.hp;
+    log(`${enemy.name} attacks for ${applied} damage!`);
     updateHpBar(playerBar, playerHp, playerMax);
     playerBar.classList.add('damage');
     setTimeout(() => playerBar.classList.remove('damage'), 300);

--- a/scripts/gameEngine.js
+++ b/scripts/gameEngine.js
@@ -1,6 +1,7 @@
 // Handles trap and tile effects triggered when the player steps on certain tiles.
 import { showDialogue } from './dialogueSystem.js';
-import { takeDamage, healFull } from './player.js';
+import { healFull } from './player.js';
+import { applyDamage } from './logic.js';
 
 /**
  * Applies effects based on the tile symbol the player stepped on.
@@ -10,10 +11,10 @@ import { takeDamage, healFull } from './player.js';
  */
 export function handleTileEffects(tileSymbol, player) {
   if (tileSymbol === 't') {
-    takeDamage(1);
+    applyDamage(player, 1);
     showDialogue('A hidden snare cuts at your feet.');
   } else if (tileSymbol === 'T') {
-    takeDamage(2);
+    applyDamage(player, 2);
     showDialogue('Spikes! You\u2019re badly wounded!');
   } else if (tileSymbol === 'W') {
     healFull();

--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -1,9 +1,14 @@
 import { inventory } from './inventory.js';
+import { player } from './player.js';
 
 export function updateInventoryUI() {
   const list = document.getElementById('inventory-list');
   if (!list) return;
   list.innerHTML = '';
+  const statsEl = document.getElementById('player-stats');
+  if (statsEl) {
+    statsEl.textContent = `Defense: ${player.stats?.defense || 0}`;
+  }
   inventory.forEach(item => {
     const row = document.createElement('div');
     row.classList.add('inventory-item');
@@ -26,3 +31,4 @@ export function toggleInventoryView() {
 
 // Keep UI in sync when inventory changes
 document.addEventListener('inventoryUpdated', updateInventoryUI);
+document.addEventListener('playerDefenseChanged', updateInventoryUI);

--- a/scripts/logic.js
+++ b/scripts/logic.js
@@ -5,3 +5,10 @@ export function isAdjacent(x1, y1, x2, y2) {
 export function generateTileId(x, y) {
   return `${x},${y}`;
 }
+
+export function applyDamage(target, amount) {
+  const defense = target.stats?.defense || 0;
+  const final = Math.max(0, amount - defense);
+  target.hp = Math.max(0, target.hp - final);
+  return final;
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -30,10 +30,17 @@ let isInBattle = false;
 const npcModules = { eryndor, lioran, goblinQuestGiver, arvalin, grindle };
 
 let hpDisplay;
+let defenseDisplay;
 
 function updateHpDisplay() {
   if (hpDisplay) {
     hpDisplay.textContent = `HP: ${player.hp}/${player.maxHp}`;
+  }
+}
+
+function updateDefenseDisplay() {
+  if (defenseDisplay) {
+    defenseDisplay.textContent = `Defense: ${player.stats?.defense || 0}`;
   }
 }
 
@@ -93,7 +100,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const scaleSelect = document.getElementById('ui-scale');
   const animToggle = document.getElementById('anim-toggle');
   hpDisplay = document.getElementById('hp-display');
+  defenseDisplay = document.getElementById('defense-display');
   updateHpDisplay();
+  updateDefenseDisplay();
   let cols = 0;
 
   let settings = loadSettings();
@@ -203,7 +212,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.addEventListener('playerRespawned', e => {
       cols = e.detail.cols;
       updateHpDisplay();
+      updateDefenseDisplay();
     });
+    document.addEventListener('playerDefenseChanged', updateDefenseDisplay);
   } catch (err) {
     console.error(err);
   }

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -8,6 +8,9 @@ export const player = {
   y: 0,
   hp: 100,
   maxHp: 100,
+  stats: {
+    defense: 0,
+  },
   learnedSkills: [],
   bonusHpGiven: {},
 };
@@ -52,4 +55,12 @@ export function healFull() {
 export function increaseMaxHp(amount) {
   player.maxHp += amount;
   player.hp = Math.min(player.hp, player.maxHp);
+}
+
+export function increaseDefense(amount) {
+  if (!player.stats) player.stats = { defense: 0 };
+  player.stats.defense = (player.stats.defense || 0) + amount;
+  document.dispatchEvent(
+    new CustomEvent('playerDefenseChanged', { detail: { defense: player.stats.defense } })
+  );
 }

--- a/style/main.css
+++ b/style/main.css
@@ -132,6 +132,11 @@ body {
   padding: 8px 12px;
 }
 
+#defense-display {
+  margin-right: 10px;
+  padding: 8px 12px;
+}
+
 #ui-bar .tab {
   background: #333;
   margin: 0 5px;
@@ -355,6 +360,12 @@ body {
 
 .inventory-content h2 {
   margin-top: 0;
+  text-align: center;
+}
+
+#player-stats {
+  margin-bottom: 10px;
+  font-weight: bold;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- track player defense in `player.stats`
- centralize damage logic with `applyDamage()`
- reduce trap and combat damage using defense
- show defense on the UI bar and inventory screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846acaa68d08331a86203db4db002c2