### PR TITLE
Add armor piece item with defense boost

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -36,6 +36,10 @@
     "name": "Cracked Helmet",
     "description": "Barely held together after many battles."
   },
+  "armor_piece": {
+    "name": "Armor Piece",
+    "description": "A chunk of metal that can be forged into protection."
+  },
   "purified_token": {
     "name": "Purified Token",
     "description": "Cleansed and safe to handle."

--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -1,5 +1,6 @@
 import { inventory } from './inventory.js';
 import { player } from './player.js';
+import { useArmorPiece } from './item_logic.js';
 
 export function updateInventoryUI() {
   const list = document.getElementById('inventory-list');
@@ -12,8 +13,14 @@ export function updateInventoryUI() {
   inventory.forEach(item => {
     const row = document.createElement('div');
     row.classList.add('inventory-item');
+    row.dataset.id = item.id;
     const qty = item.quantity > 1 ? ` x${item.quantity}` : '';
     row.innerHTML = `<strong>${item.name}${qty}</strong><div class="desc">${item.description}</div>`;
+    row.addEventListener('click', () => {
+      if (item.id === 'armor_piece') {
+        useArmorPiece();
+      }
+    });
     list.appendChild(row);
   });
 }

--- a/scripts/item_logic.js
+++ b/scripts/item_logic.js
@@ -1,0 +1,10 @@
+import { removeItem } from './inventory.js';
+import { increaseDefense } from './player.js';
+
+export function useArmorPiece() {
+  if (removeItem('armor_piece', 1)) {
+    increaseDefense(1);
+    return true;
+  }
+  return false;
+}

--- a/style/main.css
+++ b/style/main.css
@@ -382,6 +382,7 @@ body {
 .inventory-item {
   border-bottom: 1px solid #ddd;
   padding: 6px 0;
+  cursor: pointer;
 }
 
 .inventory-item:last-child {


### PR DESCRIPTION
## Summary
- add `armor_piece` to item database
- make inventory items clickable and consume armor pieces
- implement `useArmorPiece` effect logic
- show pointer cursor for inventory items

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846ae8b396c83318fe35a2c960b454c