### PR TITLE
Add combat item section

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -43,5 +43,11 @@
   "purified_token": {
     "name": "Purified Token",
     "description": "Cleansed and safe to handle."
+  },
+  "defense_potion_I": {
+    "name": "Defense Potion I",
+    "description": "Increases defense by 1 for this fight.",
+    "type": "combat",
+    "effect": { "temporaryDefense": 1 }
   }
 }

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -1,3 +1,5 @@
+import { getItemData } from './item_loader.js';
+
 export const inventory = [];
 
 export function getItemCount(nameOrId) {
@@ -39,4 +41,11 @@ export function removeItem(nameOrId, qty = 1) {
     return true;
   }
   return false;
+}
+
+export function getItemsByType(type) {
+  return inventory.filter(it => {
+    const data = getItemData(it.id);
+    return data && data.type === type;
+  });
 }

--- a/scripts/item_logic.js
+++ b/scripts/item_logic.js
@@ -8,3 +8,10 @@ export function useArmorPiece() {
   }
   return false;
 }
+
+export function useDefensePotion() {
+  if (removeItem('defense_potion_I', 1)) {
+    return { defense: 1 };
+  }
+  return null;
+}

--- a/style/main.css
+++ b/style/main.css
@@ -282,6 +282,14 @@ body {
   text-align: center;
 }
 
+#battle-overlay .action-tabs {
+  margin-bottom: 10px;
+}
+
+#battle-overlay .action-tabs button.selected {
+  background: #666;
+}
+
 #battle-overlay .actions.hidden,
 #battle-overlay .log.hidden {
   display: none;


### PR DESCRIPTION
## Summary
- add `defense_potion_I` item metadata
- allow inventory filtering by item type
- implement `useDefensePotion` helper
- extend combat system with temporary defense buffs and item tab
- style item tab for combat UI

## Testing
- `npm test` *(fails: could not find package.json)*
- `node --check scripts/combatSystem.js`
- `node --check scripts/item_logic.js`
- `node --check scripts/inventory.js`
- `node -e "JSON.parse(require('fs').readFileSync('data/items.json','utf8'));"`

------
https://chatgpt.com/codex/tasks/task_e_6846b1e045fc8331aa21d91c2d6b6799