### PR TITLE
Improve combat UI tabbing

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -7,6 +7,7 @@ import { loadItems, getItemData } from './item_loader.js';
 import { useDefensePotion } from './item_logic.js';
 import { updateInventoryUI } from './inventory_state.js';
 import { showDialogue } from './dialogueSystem.js';
+import { setupTabs } from './combat_ui.js';
 
 let overlay = null;
 
@@ -50,8 +51,10 @@ export async function startCombat(enemy, player) {
           <button class="skills-tab selected">Skills</button>
           <button class="items-tab">Items</button>
         </div>
-        <div class="skill-buttons"></div>
-        <div class="item-buttons hidden"></div>
+        <div class="tab-panels">
+          <div class="skill-buttons tab-panel"></div>
+          <div class="item-buttons tab-panel hidden"></div>
+        </div>
       </div>
       <div class="log hidden"></div>
     </div>`;
@@ -74,8 +77,6 @@ export async function startCombat(enemy, player) {
   const actionsEl = overlay.querySelector('.actions');
   const skillContainer = overlay.querySelector('.skill-buttons');
   const itemContainer = overlay.querySelector('.item-buttons');
-  const skillsTabBtn = overlay.querySelector('.skills-tab');
-  const itemsTabBtn = overlay.querySelector('.items-tab');
   const logEl = overlay.querySelector('.log');
 
   await loadItems();
@@ -184,18 +185,7 @@ export async function startCombat(enemy, player) {
 
   updateItemsUI();
   document.addEventListener('inventoryUpdated', updateItemsUI);
-  skillsTabBtn.addEventListener('click', () => {
-    skillContainer.classList.remove('hidden');
-    itemContainer.classList.add('hidden');
-    skillsTabBtn.classList.add('selected');
-    itemsTabBtn.classList.remove('selected');
-  });
-  itemsTabBtn.addEventListener('click', () => {
-    itemContainer.classList.remove('hidden');
-    skillContainer.classList.add('hidden');
-    itemsTabBtn.classList.add('selected');
-    skillsTabBtn.classList.remove('selected');
-  });
+  setupTabs(overlay);
 
   async function handleAction(skill) {
     if (!playerTurn || playerHp <= 0 || enemyHp <= 0) return;

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -1,0 +1,27 @@
+export function setupTabs(overlay) {
+  const skillContainer = overlay.querySelector('.skill-buttons');
+  const itemContainer = overlay.querySelector('.item-buttons');
+  const skillsTabBtn = overlay.querySelector('.skills-tab');
+  const itemsTabBtn = overlay.querySelector('.items-tab');
+  if (!skillContainer || !itemContainer || !skillsTabBtn || !itemsTabBtn) return;
+
+  function showSkills() {
+    skillContainer.classList.remove('hidden');
+    itemContainer.classList.add('hidden');
+    skillsTabBtn.classList.add('selected');
+    itemsTabBtn.classList.remove('selected');
+  }
+
+  function showItems() {
+    itemContainer.classList.remove('hidden');
+    skillContainer.classList.add('hidden');
+    itemsTabBtn.classList.add('selected');
+    skillsTabBtn.classList.remove('selected');
+  }
+
+  skillsTabBtn.addEventListener('click', showSkills);
+  itemsTabBtn.addEventListener('click', showItems);
+
+  // default
+  showSkills();
+}

--- a/style/main.css
+++ b/style/main.css
@@ -284,10 +284,30 @@ body {
 
 #battle-overlay .action-tabs {
   margin-bottom: 10px;
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+}
+
+#battle-overlay .action-tabs button {
+  padding: 6px 14px;
 }
 
 #battle-overlay .action-tabs button.selected {
   background: #666;
+  border-color: #999;
+}
+
+#battle-overlay .tab-panel {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+#battle-overlay .hidden {
+  display: none;
 }
 
 #battle-overlay .actions.hidden,


### PR DESCRIPTION
## Summary
- add dedicated UI tab logic module
- style combat panels and tabs for easier use
- create tab containers in combat UI and hook up setup logic

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846d6904c7083318a86e1478f752c97