### PR TITLE
Add status effect definitions

### DIFF
--- a/scripts/status_effects.js
+++ b/scripts/status_effects.js
@@ -1,0 +1,230 @@
+// Defines positive and negative status effects that can influence
+// combat and other game systems. Each effect includes logic for
+// duration and its core impact on gameplay. Skills, items and enemies
+// can apply these by referencing the ID.
+
+export const statusEffects = {
+  // ---------- Positive Effects ----------
+  regen: {
+    id: 'regen',
+    name: 'Regeneration',
+    description: 'Heal 1 HP per turn.',
+    type: 'positive',
+    duration: 3,
+    apply(target) {
+      target.hp = Math.min(target.maxHp, target.hp + 1);
+    },
+  },
+  fortify: {
+    id: 'fortify',
+    name: 'Fortify',
+    description: '+2 defense.',
+    type: 'positive',
+    duration: 3,
+    apply(target) {
+      target.stats.defense += 2;
+    },
+    remove(target) {
+      target.stats.defense -= 2;
+    },
+  },
+  focus: {
+    id: 'focus',
+    name: 'Focus',
+    description: '+2 damage on next attack.',
+    type: 'positive',
+    duration: 1,
+    apply(target) {
+      target.bonusDamage = (target.bonusDamage || 0) + 2;
+    },
+    remove(target) {
+      target.bonusDamage -= 2;
+    },
+  },
+  speed_boost: {
+    id: 'speed_boost',
+    name: 'Speed Boost',
+    description: 'Act first in combat.',
+    type: 'positive',
+    duration: 2,
+    apply(target) {
+      target.priority = (target.priority || 0) + 1;
+    },
+    remove(target) {
+      target.priority -= 1;
+    },
+  },
+  clarity: {
+    id: 'clarity',
+    name: 'Clarity',
+    description: 'See enemy intents.',
+    type: 'positive',
+    duration: 3,
+  },
+  barrier: {
+    id: 'barrier',
+    name: 'Barrier',
+    description: 'Absorb next 5 damage.',
+    type: 'positive',
+    duration: 2,
+    apply(target) {
+      target.absorb = (target.absorb || 0) + 5;
+    },
+    remove(target) {
+      target.absorb -= 5;
+    },
+  },
+  blessed: {
+    id: 'blessed',
+    name: 'Blessed',
+    description: 'Immune to one negative effect.',
+    type: 'positive',
+    duration: 2,
+  },
+  empowered: {
+    id: 'empowered',
+    name: 'Empowered',
+    description: 'Double skill effects.',
+    type: 'positive',
+    duration: 1,
+  },
+  resolve: {
+    id: 'resolve',
+    name: 'Resolve',
+    description: 'Survive 1 fatal blow with 1 HP.',
+    type: 'positive',
+    duration: 3,
+    apply(target) {
+      target.hasResolve = true;
+    },
+    remove(target) {
+      target.hasResolve = false;
+    },
+  },
+  invisible: {
+    id: 'invisible',
+    name: 'Invisible',
+    description: 'Cannot be targeted for 1 turn.',
+    type: 'positive',
+    duration: 1,
+  },
+
+  // ---------- Negative Effects ----------
+  poisoned: {
+    id: 'poisoned',
+    name: 'Poisoned',
+    description: 'Lose 1 HP per turn.',
+    type: 'negative',
+    duration: 3,
+    apply(target) {
+      target.hp = Math.max(0, target.hp - 1);
+    },
+  },
+  weakened: {
+    id: 'weakened',
+    name: 'Weakened',
+    description: 'Deal half damage.',
+    type: 'negative',
+    duration: 2,
+    apply(target) {
+      target.damageModifier = (target.damageModifier || 1) * 0.5;
+    },
+    remove(target) {
+      target.damageModifier /= 0.5;
+    },
+  },
+  cursed: {
+    id: 'cursed',
+    name: 'Cursed',
+    description: 'Cannot use items.',
+    type: 'negative',
+    duration: 3,
+    apply(target) {
+      target.noItems = true;
+    },
+    remove(target) {
+      target.noItems = false;
+    },
+  },
+  blinded: {
+    id: 'blinded',
+    name: 'Blinded',
+    description: '50% miss chance.',
+    type: 'negative',
+    duration: 2,
+    apply(target) {
+      target.missChance = (target.missChance || 0) + 0.5;
+    },
+    remove(target) {
+      target.missChance -= 0.5;
+    },
+  },
+  burned: {
+    id: 'burned',
+    name: 'Burned',
+    description: 'Lose 2 HP when using a skill.',
+    type: 'negative',
+    duration: 3,
+  },
+  paralyzed: {
+    id: 'paralyzed',
+    name: 'Paralyzed',
+    description: '50% chance to skip turn.',
+    type: 'negative',
+    duration: 2,
+  },
+  silenced: {
+    id: 'silenced',
+    name: 'Silenced',
+    description: 'Cannot use skills.',
+    type: 'negative',
+    duration: 2,
+  },
+  vulnerable: {
+    id: 'vulnerable',
+    name: 'Vulnerable',
+    description: 'Take 50% more damage.',
+    type: 'negative',
+    duration: 2,
+    apply(target) {
+      target.damageTakenMod = (target.damageTakenMod || 1) + 0.5;
+    },
+    remove(target) {
+      target.damageTakenMod -= 0.5;
+    },
+  },
+  slowed: {
+    id: 'slowed',
+    name: 'Slowed',
+    description: 'Act last in turn order.',
+    type: 'negative',
+    duration: 2,
+    apply(target) {
+      target.priority = (target.priority || 0) - 1;
+    },
+    remove(target) {
+      target.priority += 1;
+    },
+  },
+  haunted: {
+    id: 'haunted',
+    name: 'Haunted',
+    description: 'Cannot heal while active.',
+    type: 'negative',
+    duration: 3,
+    apply(target) {
+      target.noHealing = true;
+    },
+    remove(target) {
+      target.noHealing = false;
+    },
+  },
+};
+
+export function getStatusEffect(id) {
+  return statusEffects[id];
+}
+
+export function getAllStatusEffects() {
+  return statusEffects;
+}


### PR DESCRIPTION
## Summary
- create `status_effects.js` to hold 10 buffs and 10 debuffs

## Testing
- `node -e "require('./scripts/status_effects.js'); console.log('ok');"`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846d8e9eedc8331a27aa4a18511560d