### PR TITLE
Implement status effect skills

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -7,8 +7,8 @@ import { loadItems, getItemData } from './item_loader.js';
 import { useDefensePotion } from './item_logic.js';
 import { updateInventoryUI } from './inventory_state.js';
 import { showDialogue } from './dialogueSystem.js';
-import { setupTabs, updateStatusUI } from './combat_ui.js';
-import { tickStatuses, initStatuses } from './statusManager.js';
+import { setupTabs, updateStatusUI, renderSkillList } from './combat_ui.js';
+import { tickStatuses, initStatuses, applyStatus } from './statusManager.js';
 import { initEnemyState } from './enemy.js';
 
 let overlay = null;
@@ -186,12 +186,7 @@ export async function startCombat(enemy, player) {
     .map(id => getSkill(id))
     .filter(Boolean);
 
-  skillList.forEach(skill => {
-    const btn = document.createElement('button');
-    btn.textContent = skill.name;
-    btn.addEventListener('click', () => handleAction(skill));
-    skillContainer.appendChild(btn);
-  });
+  renderSkillList(skillContainer, skillList, handleAction);
 
   updateItemsUI();
   document.addEventListener('inventoryUpdated', updateItemsUI);
@@ -208,6 +203,9 @@ export async function startCombat(enemy, player) {
       log,
       isHealUsed,
       setHealUsed,
+      applyStatus,
+      player,
+      enemy,
     });
     if (result === false) return; // invalid action
     if (enemyHp <= 0) {

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -1,3 +1,5 @@
+import { getStatusEffect } from './status_effects.js';
+
 export function setupTabs(overlay) {
   const skillContainer = overlay.querySelector('.skill-buttons');
   const itemContainer = overlay.querySelector('.item-buttons');
@@ -41,5 +43,24 @@ export function updateStatusUI(overlay, player, enemy) {
     const div = document.createElement('div');
     div.textContent = `${s.id} (${s.remaining})`;
     enemyList.appendChild(div);
+  });
+}
+
+export function renderSkillList(container, skills, onClick) {
+  if (!container) return;
+  container.innerHTML = '';
+  skills.forEach(skill => {
+    const btn = document.createElement('button');
+    const effects = [];
+    if (Array.isArray(skill.statuses)) {
+      skill.statuses.forEach(s => {
+        const ef = getStatusEffect(s.id);
+        if (ef) effects.push(ef.description);
+      });
+    }
+    const descParts = [skill.description, ...effects].filter(Boolean).join(' ');
+    btn.innerHTML = `<strong>${skill.name}</strong><div class="desc">${descParts}</div>`;
+    btn.addEventListener('click', () => onClick(skill));
+    container.appendChild(btn);
   });
 }

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -89,6 +89,36 @@ const skillDefs = {
       log('Arcane power lashes out for 12 damage!');
     },
   },
+  poisonDart: {
+    id: 'poisonDart',
+    name: 'Poison Dart',
+    description: 'Inflict Poisoned for 3 turns.',
+    statuses: [{ target: 'enemy', id: 'poisoned', duration: 3 }],
+    effect({ applyStatus, enemy, log }) {
+      applyStatus(enemy, 'poisoned', 3);
+      log('Enemy is poisoned!');
+    },
+  },
+  rally: {
+    id: 'rally',
+    name: 'Rally',
+    description: 'Gain Fortify for 3 turns.',
+    statuses: [{ target: 'self', id: 'fortify', duration: 3 }],
+    effect({ applyStatus, player, log }) {
+      applyStatus(player, 'fortify', 3);
+      log('You steel yourself against attacks.');
+    },
+  },
+  focusMind: {
+    id: 'focusMind',
+    name: 'Focus',
+    description: 'Gain Focus for your next attack.',
+    statuses: [{ target: 'self', id: 'focus', duration: 1 }],
+    effect({ applyStatus, player, log }) {
+      applyStatus(player, 'focus', 1);
+      log('You concentrate deeply, preparing your strike.');
+    },
+  },
 };
 
 let player = null;

--- a/scripts/statusManager.js
+++ b/scripts/statusManager.js
@@ -55,3 +55,7 @@ export function tickStatuses(target) {
     }
   }
 }
+
+export function applyStatus(target, id, duration) {
+  addStatus(target, id, duration);
+}

--- a/style/main.css
+++ b/style/main.css
@@ -334,6 +334,12 @@ body {
   border: 1px solid #222;
 }
 
+#battle-overlay .tab-panel button .desc {
+  display: block;
+  font-size: 12px;
+  color: #ccc;
+}
+
 #battle-overlay .log {
   margin-top: 10px;
   height: 80px;


### PR DESCRIPTION
## Summary
- add `applyStatus` utility in statusManager
- create new skills that apply statuses
- display skill descriptions along with status info in combat UI
- render skill list through new helper in combat UI
- style description text for skill buttons

## Testing
- `node -e "require('./scripts/skills.js')"`
- `node -e "require('./scripts/combat_ui.js')"`
- (failure) `node -e "require('./scripts/combatSystem.js')"`

------
https://chatgpt.com/codex/tasks/task_e_6846ddc6f7588331bdd4cabef22f2e2b