### PR TITLE
Add combat status effect display

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -38,14 +38,14 @@ export async function startCombat(enemy, player) {
         <div class="combatant player">
           <div class="name">Hero</div>
           <div class="hp-bar"><div class="hp"></div></div>
-          <div class="statuses player-statuses"></div>
+          <div class="statuses status-effects player-statuses"></div>
         </div>
         <div class="combatant enemy intro-anim">
           <div class="portrait">${enemy.portrait || '👾'}</div>
           <div class="name">${enemy.name}</div>
           <div class="desc">${enemy.description || ''}</div>
           <div class="hp-bar"><div class="hp"></div></div>
-          <div class="statuses enemy-statuses"></div>
+          <div class="statuses status-effects enemy-statuses"></div>
         </div>
       </div>
       <div class="intro-text">${

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -1,4 +1,5 @@
 import { getStatusEffect } from './status_effects.js';
+import { getStatusList } from './statusManager.js';
 
 export function setupTabs(overlay) {
   const skillContainer = overlay.querySelector('.skill-buttons');
@@ -34,15 +35,23 @@ export function updateStatusUI(overlay, player, enemy) {
   if (!playerList || !enemyList) return;
   playerList.innerHTML = '';
   enemyList.innerHTML = '';
-  (player.statuses || []).forEach(s => {
-    const div = document.createElement('div');
-    div.textContent = `${s.id} (${s.remaining})`;
-    playerList.appendChild(div);
+  getStatusList(player).forEach(s => {
+    const ef = getStatusEffect(s.id);
+    const span = document.createElement('span');
+    span.className = 'effect';
+    span.title = ef?.description || s.id;
+    const icon = ef?.icon ? `${ef.icon} ` : '';
+    span.textContent = `${icon}${ef?.name || s.id} (${s.remaining})`;
+    playerList.appendChild(span);
   });
-  (enemy.statuses || []).forEach(s => {
-    const div = document.createElement('div');
-    div.textContent = `${s.id} (${s.remaining})`;
-    enemyList.appendChild(div);
+  getStatusList(enemy).forEach(s => {
+    const ef = getStatusEffect(s.id);
+    const span = document.createElement('span');
+    span.className = 'effect';
+    span.title = ef?.description || s.id;
+    const icon = ef?.icon ? `${ef.icon} ` : '';
+    span.textContent = `${icon}${ef?.name || s.id} (${s.remaining})`;
+    enemyList.appendChild(span);
   });
 }
 

--- a/scripts/statusManager.js
+++ b/scripts/statusManager.js
@@ -59,3 +59,8 @@ export function tickStatuses(target) {
 export function applyStatus(target, id, duration) {
   addStatus(target, id, duration);
 }
+
+export function getStatusList(target) {
+  if (!target || !Array.isArray(target.statuses)) return [];
+  return target.statuses.map(s => ({ id: s.id, remaining: s.remaining }));
+}

--- a/scripts/status_effects.js
+++ b/scripts/status_effects.js
@@ -8,6 +8,7 @@ export const statusEffects = {
   regen: {
     id: 'regen',
     name: 'Regeneration',
+    icon: '💚',
     description: 'Heal 1 HP per turn.',
     type: 'positive',
     duration: 3,
@@ -18,6 +19,7 @@ export const statusEffects = {
   fortify: {
     id: 'fortify',
     name: 'Fortify',
+    icon: '🛡',
     description: '+2 defense.',
     type: 'positive',
     duration: 3,
@@ -31,6 +33,7 @@ export const statusEffects = {
   focus: {
     id: 'focus',
     name: 'Focus',
+    icon: '🎯',
     description: '+2 damage on next attack.',
     type: 'positive',
     duration: 1,
@@ -44,6 +47,7 @@ export const statusEffects = {
   speed_boost: {
     id: 'speed_boost',
     name: 'Speed Boost',
+    icon: '💨',
     description: 'Act first in combat.',
     type: 'positive',
     duration: 2,
@@ -57,6 +61,7 @@ export const statusEffects = {
   clarity: {
     id: 'clarity',
     name: 'Clarity',
+    icon: '👁️',
     description: 'See enemy intents.',
     type: 'positive',
     duration: 3,
@@ -64,6 +69,7 @@ export const statusEffects = {
   barrier: {
     id: 'barrier',
     name: 'Barrier',
+    icon: '🔰',
     description: 'Absorb next 5 damage.',
     type: 'positive',
     duration: 2,
@@ -77,6 +83,7 @@ export const statusEffects = {
   blessed: {
     id: 'blessed',
     name: 'Blessed',
+    icon: '✨',
     description: 'Immune to one negative effect.',
     type: 'positive',
     duration: 2,
@@ -84,6 +91,7 @@ export const statusEffects = {
   empowered: {
     id: 'empowered',
     name: 'Empowered',
+    icon: '⚡',
     description: 'Double skill effects.',
     type: 'positive',
     duration: 1,
@@ -91,6 +99,7 @@ export const statusEffects = {
   resolve: {
     id: 'resolve',
     name: 'Resolve',
+    icon: '❤️',
     description: 'Survive 1 fatal blow with 1 HP.',
     type: 'positive',
     duration: 3,
@@ -104,6 +113,7 @@ export const statusEffects = {
   invisible: {
     id: 'invisible',
     name: 'Invisible',
+    icon: '👤',
     description: 'Cannot be targeted for 1 turn.',
     type: 'positive',
     duration: 1,
@@ -113,6 +123,7 @@ export const statusEffects = {
   poisoned: {
     id: 'poisoned',
     name: 'Poisoned',
+    icon: '☠️',
     description: 'Lose 1 HP per turn.',
     type: 'negative',
     duration: 3,
@@ -123,6 +134,7 @@ export const statusEffects = {
   weakened: {
     id: 'weakened',
     name: 'Weakened',
+    icon: '🤕',
     description: 'Deal half damage.',
     type: 'negative',
     duration: 2,
@@ -136,6 +148,7 @@ export const statusEffects = {
   cursed: {
     id: 'cursed',
     name: 'Cursed',
+    icon: '💀',
     description: 'Cannot use items.',
     type: 'negative',
     duration: 3,
@@ -149,6 +162,7 @@ export const statusEffects = {
   blinded: {
     id: 'blinded',
     name: 'Blinded',
+    icon: '🙈',
     description: '50% miss chance.',
     type: 'negative',
     duration: 2,
@@ -162,6 +176,7 @@ export const statusEffects = {
   burned: {
     id: 'burned',
     name: 'Burned',
+    icon: '🔥',
     description: 'Lose 2 HP when using a skill.',
     type: 'negative',
     duration: 3,
@@ -169,6 +184,7 @@ export const statusEffects = {
   paralyzed: {
     id: 'paralyzed',
     name: 'Paralyzed',
+    icon: '⛔',
     description: '50% chance to skip turn.',
     type: 'negative',
     duration: 2,
@@ -176,6 +192,7 @@ export const statusEffects = {
   silenced: {
     id: 'silenced',
     name: 'Silenced',
+    icon: '🤐',
     description: 'Cannot use skills.',
     type: 'negative',
     duration: 2,
@@ -183,6 +200,7 @@ export const statusEffects = {
   vulnerable: {
     id: 'vulnerable',
     name: 'Vulnerable',
+    icon: '💢',
     description: 'Take 50% more damage.',
     type: 'negative',
     duration: 2,
@@ -196,6 +214,7 @@ export const statusEffects = {
   slowed: {
     id: 'slowed',
     name: 'Slowed',
+    icon: '🐢',
     description: 'Act last in turn order.',
     type: 'negative',
     duration: 2,
@@ -209,6 +228,7 @@ export const statusEffects = {
   haunted: {
     id: 'haunted',
     name: 'Haunted',
+    icon: '👻',
     description: 'Cannot heal while active.',
     type: 'negative',
     duration: 3,

--- a/style/main.css
+++ b/style/main.css
@@ -264,6 +264,22 @@ body {
   margin-top: 2px;
 }
 
+/* new style for improved status display */
+#battle-overlay .status-effects {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  justify-content: center;
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+#battle-overlay .status-effects .effect {
+  background: rgba(0, 0, 0, 0.5);
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+
 #battle-overlay .intro-text {
   margin-top: 10px;
   opacity: 0;


### PR DESCRIPTION
## Summary
- show icon, name and duration for active status effects
- provide `getStatusList` helper in statusManager
- include icons with status effect definitions
- style new `.status-effects` elements

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6846e412db9c8331bbd80e91a3f825b4