### PR TITLE
Add Purify skill with cleansing mechanics

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -9,7 +9,13 @@ import { useDefensePotion } from './item_logic.js';
 import { updateInventoryUI } from './inventory_state.js';
 import { showDialogue } from './dialogueSystem.js';
 import { setupTabs, updateStatusUI, renderSkillList } from './combat_ui.js';
-import { tickStatuses, initStatuses, applyStatus } from './statusManager.js';
+import {
+  tickStatuses,
+  initStatuses,
+  applyStatus,
+  removeStatus,
+  removeNegativeStatus,
+} from './statusManager.js';
 import { initEnemyState } from './enemy.js';
 
 let overlay = null;
@@ -227,6 +233,8 @@ export async function startCombat(enemy, player) {
       isHealUsed,
       setHealUsed,
       applyStatus,
+      removeStatus,
+      removeNegativeStatus,
       player,
       enemy,
     });
@@ -307,6 +315,8 @@ export async function startCombat(enemy, player) {
         enemy,
         damagePlayer,
         applyStatus,
+        removeStatus,
+        removeNegativeStatus,
         log,
       });
     }

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -67,6 +67,12 @@ export function renderSkillList(container, skills, onClick) {
         if (ef) effects.push(ef.description);
       });
     }
+    if (Array.isArray(skill.cleanse)) {
+      const names = skill.cleanse
+        .map(id => getStatusEffect(id)?.name || id)
+        .join(', ');
+      effects.push(`Removes ${names}`);
+    }
     const descParts = [skill.description, ...effects].filter(Boolean).join(' ');
     btn.innerHTML = `<strong>${skill.name}</strong><div class="desc">${descParts}</div>`;
     btn.addEventListener('click', () => onClick(skill));

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -1,4 +1,5 @@
 // Defines skill data and manages unlocking/lookup
+import { getStatusEffect } from './status_effects.js';
 
 const skillDefs = {
   strike: {
@@ -117,6 +118,27 @@ const skillDefs = {
     effect({ applyStatus, player, log }) {
       applyStatus(player, 'focus', 1);
       log('You concentrate deeply, preparing your strike.');
+    },
+  },
+  purify: {
+    id: 'purify',
+    name: 'Purify',
+    description: 'Remove certain negative effects from yourself.',
+    cleanse: ['poisoned', 'cursed', 'blinded'],
+    effect({ player, removeNegativeStatus, log }) {
+      const removed = removeNegativeStatus(player, [
+        'poisoned',
+        'cursed',
+        'blinded',
+      ]);
+      if (removed.length > 0) {
+        const names = removed
+          .map(id => getStatusEffect(id)?.name || id)
+          .join(', ');
+        log(`Purify cleanses ${names}!`);
+      } else {
+        log('No negative effects to purify.');
+      }
     },
   },
 };

--- a/scripts/statusManager.js
+++ b/scripts/statusManager.js
@@ -38,6 +38,27 @@ export function removeStatus(target, id) {
   target.statuses.splice(idx, 1);
 }
 
+export function removeNegativeStatus(target, ids) {
+  if (!target || !target.statuses) return [];
+  const toRemove = Array.isArray(ids)
+    ? ids
+    : ids
+    ? [ids]
+    : target.statuses.map(s => s.id);
+  const removed = [];
+  for (const id of toRemove) {
+    const effect = getStatusEffect(id);
+    if (!effect || effect.type !== 'negative') continue;
+    const idx = target.statuses.findIndex(s => s.id === id);
+    if (idx !== -1) {
+      if (effect.remove) effect.remove(target);
+      target.statuses.splice(idx, 1);
+      removed.push(id);
+    }
+  }
+  return removed;
+}
+
 export function tickStatuses(target) {
   if (!target || !target.statuses) return;
   for (let i = target.statuses.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## Summary
- add `removeNegativeStatus` helper
- display cleanse info in skill descriptions
- add `Purify` skill to remove common negative effects
- support cleansing skills in combat system

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846e96036408331b60ae796455390a4