### PR TITLE
Add combat log panel with real-time updates

### DIFF
--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -79,3 +79,23 @@ export function renderSkillList(container, skills, onClick) {
     container.appendChild(btn);
   });
 }
+
+let logContainer = null;
+
+// Initialize the combat log panel and return a convenience log function.
+export function initLogPanel(overlay) {
+  logContainer = overlay.querySelector('.log');
+  if (logContainer) {
+    logContainer.innerHTML = '';
+  }
+  return appendLog;
+}
+
+// Append a single entry to the combat log panel.
+export function appendLog(message) {
+  if (!logContainer) return;
+  const entry = document.createElement('div');
+  entry.textContent = message;
+  logContainer.appendChild(entry);
+  logContainer.scrollTop = logContainer.scrollHeight;
+}


### PR DESCRIPTION
## Summary
- implement log panel helpers in `combat_ui.js`
- integrate log panel in combat system
- log skill usage, damage, healing, item use and status changes

## Testing
- `node -c scripts/combat_ui.js`
- `node -c scripts/combatSystem.js`


------
https://chatgpt.com/codex/tasks/task_e_6846f5d33bac83319c0b8e241be5b4bc