### PR TITLE
Improve favicon and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Node modules and build output
+node_modules/
+dist/
+
+# Logs and runtime files
+*.log
+npm-debug.log*
+.yarn-debug.log*
+.yarn-error.log*
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Editor directories and files
+.vscode/
+.idea/
+*.swp
+*~
+
+# Environment files
+.env
+
+# Temporary files
+.tmp/

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <rect width="16" height="16" fill="#2b2d42" />
+  <g stroke="#edf2f4" stroke-width="1">
+    <line x1="5.33" y1="0" x2="5.33" y2="16" />
+    <line x1="10.66" y1="0" x2="10.66" y2="16" />
+    <line x1="0" y1="5.33" x2="16" y2="5.33" />
+    <line x1="0" y1="10.66" x2="16" y2="10.66" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add simple grid graphic to `favicon.svg`
- ignore common temporary files and editor folders

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68470b24f1b48331a233d1890d196221