### PR TITLE
Improve fetch error handling and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Game scripts live under `scripts/`, data files are in `data/`, and stylesheets c
 
 Maps can specify an `environment` value which adds a CSS class like `env-fog` or `env-rain` to the grid. When the field is omitted the map defaults to the `clear` environment, applying an `env-clear` class. The stylesheet provides visual effects for these classes. Additional options such as `env-day`, `env-dusk` and `env-night` are available for custom day, dusk or night scenes.
 
+## Tests
+
+Basic unit tests are provided using Node's built-in test runner. After installing Node.js run:
+
+```bash
+npm test
+```
+
+This will execute the tests found in the `tests/` directory.
+
 ## Deployment
 
 The repository is ready for GitHub Pages. Commit your changes to the default branch and enable Pages to serve `index.html` from the repository root.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "grid-quest",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/scripts/craft.js
+++ b/scripts/craft.js
@@ -2,6 +2,7 @@ import { loadItems, getItemData } from './item_loader.js';
 import { addItem, removeItem, getItemCount } from './inventory.js';
 import { craftState } from './craft_state.js';
 import { isRecipeUnlocked } from './recipe_state.js';
+import { showError } from './errorMessage.js';
 
 let craftingAllowed = false;
 
@@ -20,11 +21,13 @@ export async function loadRecipes() {
   if (loaded) return recipes;
   try {
     const res = await fetch('data/recipes.json');
-    if (res.ok) {
-      recipes = await res.json();
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
     }
-  } catch {
-    // ignore
+    recipes = await res.json();
+  } catch (err) {
+    console.error('Failed to load recipes', err);
+    showError('Failed to load recipes. Please try again later.');
   } finally {
     loaded = true;
   }

--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -4,6 +4,7 @@ import { loadItems, getItemData } from './item_loader.js';
 import { unlockSkillsFromItem, getAllSkills } from './skills.js';
 import { dialogueMemory, setMemory } from './dialogue_state.js';
 import { quests, completeQuest } from './quest_state.js';
+import { showError } from './errorMessage.js';
 
 let dialogueLines = {};
 let dataLoaded = false;
@@ -12,11 +13,13 @@ async function loadDialogData() {
   if (dataLoaded) return;
   try {
     const res = await fetch('data/dialog.json');
-    if (res.ok) {
-      dialogueLines = await res.json();
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
     }
+    dialogueLines = await res.json();
   } catch (err) {
     console.error('Failed to load dialog data', err);
+    showError('Failed to load dialogue. Please try again later.');
   } finally {
     dataLoaded = true;
   }

--- a/scripts/enemy.js
+++ b/scripts/enemy.js
@@ -1,12 +1,19 @@
 import { gameState } from './game_state.js';
+import { showError } from './errorMessage.js';
 
 let enemyData = {};
 
 export async function loadEnemyData() {
   if (Object.keys(enemyData).length) return enemyData;
-  const res = await fetch('data/enemies.json');
-  if (res.ok) {
+  try {
+    const res = await fetch('data/enemies.json');
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
     enemyData = await res.json();
+  } catch (err) {
+    console.error('Failed to load enemy data', err);
+    showError('Failed to load enemy data. Please try again later.');
   }
   return enemyData;
 }

--- a/scripts/errorMessage.js
+++ b/scripts/errorMessage.js
@@ -1,0 +1,7 @@
+export function showError(message) {
+  if (typeof document !== 'undefined' && typeof alert === 'function') {
+    alert(message);
+  } else {
+    console.error(message);
+  }
+}

--- a/scripts/item_loader.js
+++ b/scripts/item_loader.js
@@ -1,14 +1,18 @@
 let items = {};
 
+import { showError } from './errorMessage.js';
+
 export async function loadItems() {
   if (Object.keys(items).length) return items;
   try {
     const res = await fetch('data/items.json');
-    if (res.ok) {
-      items = await res.json();
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
     }
-  } catch {
-    // ignore errors
+    items = await res.json();
+  } catch (err) {
+    console.error('Failed to load items', err);
+    showError('Failed to load item data. Please try again later.');
   }
   return items;
 }

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -1,3 +1,5 @@
+import { showError } from './errorMessage.js';
+
 let currentGrid = null;
 let currentEnvironment = 'clear';
 
@@ -17,11 +19,18 @@ export function normalizeGrid(grid, size = 20) {
 }
 
 export async function loadMap(name) {
-  const response = await fetch(`data/maps/${name}.json`);
-  if (!response.ok) {
-    throw new Error(`Failed to load map ${name}`);
+  let data;
+  try {
+    const response = await fetch(`data/maps/${name}.json`);
+    if (!response.ok) {
+      throw new Error(`Failed to load map ${name}`);
+    }
+    data = await response.json();
+  } catch (err) {
+    console.error('Failed to load map', err);
+    showError('Failed to load map data. Please try again later.');
+    throw err;
   }
-  const data = await response.json();
   currentEnvironment = data.environment || 'clear';
   currentGrid = data.grid.map(row => {
     if (typeof row === 'string') {

--- a/scripts/quest_state.js
+++ b/scripts/quest_state.js
@@ -1,4 +1,5 @@
 import { hasMemory } from './dialogue_state.js';
+import { showError } from './errorMessage.js';
 
 export const quests = {};
 
@@ -9,11 +10,13 @@ export async function loadQuestData() {
   if (dataLoaded) return questData;
   try {
     const res = await fetch('data/quests.json');
-    if (res.ok) {
-      questData = await res.json();
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
     }
-  } catch {
-    // ignore errors
+    questData = await res.json();
+  } catch (err) {
+    console.error('Failed to load quest data', err);
+    showError('Failed to load quests. Please try again later.');
   } finally {
     dataLoaded = true;
   }

--- a/tests/enemy.test.js
+++ b/tests/enemy.test.js
@@ -1,0 +1,11 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { initEnemyState } from '../scripts/enemy.js';
+
+test('initEnemyState sets defaults', () => {
+  const enemy = {};
+  initEnemyState(enemy);
+  assert.deepStrictEqual(enemy.statuses, []);
+  assert.equal(enemy.tempDefense, 0);
+  assert.equal(enemy.tempAttack, 0);
+});

--- a/tests/mapLoader.test.js
+++ b/tests/mapLoader.test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { normalizeGrid } from '../scripts/mapLoader.js';
+
+test('normalizeGrid pads grid and converts strings', () => {
+  const grid = [['A', 'B']];
+  const result = normalizeGrid(grid, 5);
+  assert.equal(result.length, 5);
+  assert.equal(result[0].length, 5);
+  assert.deepStrictEqual(result[0][0], { type: 'A' });
+  assert.deepStrictEqual(result[0][1], { type: 'B' });
+  assert.deepStrictEqual(result[4][4], { type: 'G' });
+});


### PR DESCRIPTION
## Summary
- show user-friendly error messages when data loading fails
- add simple unit tests using Node's built-in test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68470bf1c92c8331bcf757d63e35b80c