### PR TITLE
Standardize door field

### DIFF
--- a/data/maps/map02.json
+++ b/data/maps/map02.json
@@ -288,7 +288,7 @@
         "locked": true,
         "requiresItem": "silver_key",
         "consumeItem": true,
-        "leadsTo": "map03.json"
+        "target": "map03.json"
       }
     ],
     [

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -45,7 +45,7 @@ export async function handleTileInteraction(
         showDialogue('The door is locked.');
         break;
       }
-      const targetMap = tile.target || tile.leadsTo;
+      const targetMap = tile.target;
       if (required === 'commander_badge') {
         return new Promise(resolve => {
           showDialogue('Your commander badge unlocks the way.', async () => {


### PR DESCRIPTION
## Summary
- update second door on map02.json to use `target` field
- handle doors with a single `target` property

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68471415c5a483318130bbec1abdb504