### PR TITLE
Improve README and add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,37 @@ Maps can specify an `environment` value which adds a CSS class like `env-fog` or
 ## Deployment
 
 The repository is ready for GitHub Pages. Commit your changes to the default branch and enable Pages to serve `index.html` from the repository root.
+
+## Code Layout
+
+The project keeps game scripts in the `scripts/` directory. Data files such as
+dialog definitions live under `data/` and stylesheets are found in `style/`.
+`index.html` loads these assets and initializes the game using modules from
+`scripts/`.
+
+## Testing
+
+Grid Quest does not have an automated test suite. To manually test changes,
+start a local server and open the game in your browser:
+
+```bash
+python3 -m http.server
+```
+
+Once the server is running, navigate to `http://localhost:8000/` and interact
+with the game. Reload the page after making changes to verify they work as
+expected.
+
+## Contributing
+
+1. Fork the repository and create a new branch for your feature or fix.
+2. Follow the testing steps above to verify your changes locally.
+3. Submit a pull request against the default branch with a clear description of
+   your changes.
+
+Contributions should follow the existing code style (two-space indentation) and
+include documentation updates when relevant.
+
+## License
+
+Distributed under the MIT License. See [LICENSE](LICENSE) for more information.


### PR DESCRIPTION
## Summary
- expand README with layout, testing and contribution sections
- clarify license terms

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68471b7e44148331a1a705073832ffce