### PR TITLE
Encapsulate state modules

### DIFF
--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -3,7 +3,7 @@ import { updateInventoryUI } from './inventory_state.js';
 import { loadItems, getItemData } from './item_loader.js';
 import { unlockSkillsFromItem, getAllSkills } from './skills.js';
 import { dialogueMemory, setMemory } from './dialogue_state.js';
-import { quests, completeQuest } from './quest_state.js';
+import { getQuests, completeQuest } from './quest_state.js';
 import { showError } from './errorPrompt.js';
 
 let dialogueLines = {};
@@ -198,7 +198,7 @@ export async function startDialogueTree(dialogue, index = 0) {
   const state = {
     inventory: {},
     memory: dialogueMemory,
-    quests,
+    quests: getQuests(),
   };
   inventory.forEach(it => {
     state.inventory[it.id] = it.quantity || 1;

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -1,5 +1,12 @@
 export const dialogueMemory = new Set();
-export let activeDialogue = null;
+
+const state = {
+  activeDialogue: null,
+};
+
+export function getActiveDialogue() {
+  return state.activeDialogue;
+}
 
 export function setMemory(flag) {
   dialogueMemory.add(flag);
@@ -10,9 +17,11 @@ export function hasMemory(flag) {
 }
 
 export function startSession(dialogue) {
-  activeDialogue = dialogue;
+  state.activeDialogue = dialogue;
 }
 
 export function endSession() {
-  activeDialogue = null;
+  state.activeDialogue = null;
 }
+
+export const dialogueState = state;

--- a/scripts/movement.js
+++ b/scripts/movement.js
@@ -1,13 +1,17 @@
-let disabled = false;
+const state = {
+  disabled: false,
+};
 
 export function disableMovement() {
-  disabled = true;
+  state.disabled = true;
 }
 
 export function enableMovement() {
-  disabled = false;
+  state.disabled = false;
 }
 
 export function isMovementDisabled() {
-  return disabled;
+  return state.disabled;
 }
+
+export const movementState = state;


### PR DESCRIPTION
## Summary
- convert `movement` to expose a state object
- encapsulate active dialogue in `dialogue_state`
- move quest state into a single object and update consumers
- adjust dialogue system to use new quest state accessors

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68471e1efdc0833192f7624ecb11a2f7