### PR TITLE
Implement passive skill system

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <div class="tab settings-tab">Settings</div>
     <div class="tab inventory-tab">Inventory</div>
     <div class="tab quests-tab">Quests</div>
+    <div class="tab status-tab">Status</div>
     <div class="tab save-tab">Save</div>
     <div class="tab load-tab">Load</div>
   </div>
@@ -31,6 +32,13 @@
       <button class="close-btn">&times;</button>
       <h2>Active Quests</h2>
       <div id="quest-log"></div>
+    </div>
+  </div>
+  <div id="status-overlay" class="status-overlay">
+    <div class="status-content">
+      <button class="close-btn">&times;</button>
+      <h2>Passive Skills</h2>
+      <div id="status-passives"></div>
     </div>
   </div>
   <div id="settings-overlay" class="settings-overlay">

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -2,6 +2,7 @@
 import { getSkill } from './skills.js';
 import { getEnemySkill } from './enemy_skills.js';
 import { respawn, addTempDefense, increaseMaxHp, gainXP } from './player.js';
+import { getPassive } from './passive_skills.js';
 import { applyDamage } from './logic.js';
 import {
   addItem,
@@ -328,8 +329,16 @@ export async function startCombat(enemy, player) {
     if (id === 'defense_potion_I') {
       const res = useDefensePotion();
       if (res) {
-        addTempDefense(res.defense);
-        log('Defense increased by 1 for this fight!');
+        let amount = res.defense;
+        if (player.passives && player.passives.includes('potionMaster')) {
+          const p = getPassive('potionMaster');
+          if (p && p.itemHealBonus) {
+            // if potion mastery defined bonus to defense potions, reuse field
+            amount += p.itemHealBonus;
+          }
+        }
+        addTempDefense(amount);
+        log(`Defense increased by ${amount} for this fight!`);
         used = true;
       } else {
         log('No potion available.');

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -88,6 +88,7 @@ export function initLogPanel(overlay) {
   if (logContainer) {
     logContainer.innerHTML = '';
   }
+  document.addEventListener('passiveUnlocked', onPassiveUnlocked);
   return appendLog;
 }
 
@@ -110,4 +111,9 @@ export function showXpGain(amount) {
 
 export function showLevelUp(level) {
   appendLog(`Level Up! Now level ${level}`);
+}
+
+function onPassiveUnlocked(e) {
+  const name = e.detail?.name || e.detail?.id || 'Passive';
+  appendLog(`Passive unlocked: ${name}`);
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -17,6 +17,8 @@ import * as goblinQuestGiver from './npc/goblin_quest_giver.js';
 import * as arvalin from './npc/arvalin.js';
 import * as grindle from './npc/grindle.js';
 import { initSkillSystem } from './skills.js';
+import { initPassiveSystem } from './passive_skills.js';
+import { toggleStatusPanel } from './menu/status.js';
 import { saveState, loadState, gameState } from './game_state.js';
 import {
   loadSettings,
@@ -98,6 +100,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const questsTab = document.querySelector('.quests-tab');
   const questsOverlay = document.getElementById('quest-log-overlay');
   const questsClose = questsOverlay.querySelector('.close-btn');
+  const statusTab = document.querySelector('.status-tab');
+  const statusOverlay = document.getElementById('status-overlay');
+  const statusClose = statusOverlay?.querySelector('.close-btn');
   const settingsTab = document.querySelector('.settings-tab');
   const settingsOverlay = document.getElementById('settings-overlay');
   const settingsClose = settingsOverlay.querySelector('.close-btn');
@@ -122,6 +127,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   router.init(container, player);
   initSkillSystem(player);
+  initPassiveSystem(player);
 
   try {
     await loadEnemyData();
@@ -139,6 +145,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   questsOverlay.addEventListener('click', e => {
     if (e.target === questsOverlay) toggleQuestLog();
   });
+  if (statusTab) statusTab.addEventListener('click', toggleStatusPanel);
+  if (statusClose) statusClose.addEventListener('click', toggleStatusPanel);
+  if (statusOverlay) {
+    statusOverlay.addEventListener('click', e => {
+      if (e.target === statusOverlay) toggleStatusPanel();
+    });
+  }
 
   function showSettings() {
     settingsOverlay.classList.add('active');
@@ -233,6 +246,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.addEventListener('playerDefenseChanged', updateDefenseDisplay);
     document.addEventListener('playerXpChanged', updateXpDisplay);
     document.addEventListener('playerLevelUp', updateXpDisplay);
+    document.addEventListener('passivesUpdated', () => {
+      updateHpDisplay();
+      updateDefenseDisplay();
+    });
   } catch (err) {
     console.error(err);
   }

--- a/scripts/menu/status.js
+++ b/scripts/menu/status.js
@@ -1,0 +1,33 @@
+import { player } from '../player.js';
+import { getAllPassives } from '../passive_skills.js';
+
+export function updateStatusPanel() {
+  const list = document.getElementById('status-passives');
+  if (!list) return;
+  const defs = getAllPassives();
+  list.innerHTML = '';
+  (player.passives || []).forEach(id => {
+    const p = defs[id];
+    if (!p) return;
+    const row = document.createElement('div');
+    row.classList.add('status-passive');
+    row.innerHTML = `<strong>${p.name}</strong><div class="desc">${p.description}</div>`;
+    list.appendChild(row);
+  });
+  if ((player.passives || []).length === 0) {
+    list.innerHTML = '<em>No passive skills</em>';
+  }
+}
+
+export function toggleStatusPanel() {
+  const overlay = document.getElementById('status-overlay');
+  if (!overlay) return;
+  if (overlay.classList.contains('active')) {
+    overlay.classList.remove('active');
+  } else {
+    updateStatusPanel();
+    overlay.classList.add('active');
+  }
+}
+
+document.addEventListener('passivesUpdated', updateStatusPanel);

--- a/scripts/passive_skills.js
+++ b/scripts/passive_skills.js
@@ -1,0 +1,92 @@
+export const passiveDefs = {
+  toughness: {
+    id: 'toughness',
+    name: 'Toughness',
+    description: '+5 Max HP',
+    unlockLevel: 3,
+    apply(player) {
+      player.maxHp += 5;
+      player.hp = Math.min(player.hp, player.maxHp);
+    },
+  },
+  poisonWard: {
+    id: 'poisonWard',
+    name: 'Poison Ward',
+    description: 'Immune to poison',
+    unlockLevel: 5,
+    immunity: ['poisoned'],
+  },
+  potionMaster: {
+    id: 'potionMaster',
+    name: 'Potion Mastery',
+    description: 'Potions heal for +5 HP',
+    unlockLevel: 7,
+    itemHealBonus: 5,
+  },
+};
+
+let playerRef = null;
+
+function loadPassives() {
+  const json = localStorage.getItem('gridquest.passives');
+  if (!json) return [];
+  try {
+    const arr = JSON.parse(json);
+    if (Array.isArray(arr)) return arr;
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function savePassives(list) {
+  localStorage.setItem('gridquest.passives', JSON.stringify(list));
+}
+
+export function initPassiveSystem(playerObj) {
+  playerRef = playerObj;
+  if (!Array.isArray(playerRef.passives)) {
+    playerRef.passives = loadPassives();
+  }
+  applyAllPassives();
+}
+
+function applyAllPassives() {
+  if (!playerRef || !Array.isArray(playerRef.passives)) return;
+  playerRef.passiveImmunities = [];
+  playerRef.passives.forEach(id => {
+    const p = passiveDefs[id];
+    if (!p) return;
+    if (typeof p.apply === 'function') p.apply(playerRef);
+    if (Array.isArray(p.immunity)) {
+      playerRef.passiveImmunities.push(...p.immunity);
+    }
+  });
+}
+
+export function unlockPassivesForLevel(level) {
+  if (!playerRef) return [];
+  const unlocked = [];
+  for (const p of Object.values(passiveDefs)) {
+    if (p.unlockLevel && level >= p.unlockLevel && !playerRef.passives.includes(p.id)) {
+      playerRef.passives.push(p.id);
+      unlocked.push(p.id);
+    }
+  }
+  if (unlocked.length) {
+    savePassives(playerRef.passives);
+    applyAllPassives();
+    document.dispatchEvent(
+      new CustomEvent('passivesUpdated')
+    );
+  }
+  return unlocked;
+}
+
+export function getPassive(id) {
+  return passiveDefs[id];
+}
+
+export function getAllPassives() {
+  return passiveDefs;
+}

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -2,6 +2,7 @@ import { gameState } from './game_state.js';
 import { disableMovement, enableMovement } from './movement.js';
 import { showDialogue } from './dialogueSystem.js';
 import { movePlayerTo } from './map.js';
+import { unlockPassivesForLevel, getPassive } from './passive_skills.js';
 
 export const player = {
   x: 0,
@@ -15,6 +16,8 @@ export const player = {
     defense: 0,
   },
   learnedSkills: [],
+  passives: [],
+  passiveImmunities: [],
   bonusHpGiven: {},
   tempDefense: 0,
   tempAttack: 0,
@@ -91,6 +94,14 @@ export function levelUp() {
   player.xpToNextLevel = Math.floor(player.xpToNextLevel * 1.5);
   player.maxHp += 1;
   player.hp = player.maxHp;
+  const unlocked = unlockPassivesForLevel(player.level);
+  unlocked.forEach(id => {
+    const p = getPassive(id);
+    const name = p?.name || id;
+    document.dispatchEvent(
+      new CustomEvent('passiveUnlocked', { detail: { id, name } })
+    );
+  });
   document.dispatchEvent(
     new CustomEvent('playerLevelUp', { detail: { level: player.level } })
   );

--- a/scripts/statusManager.js
+++ b/scripts/statusManager.js
@@ -13,6 +13,9 @@ export function initStatuses(target) {
 export function addStatus(target, id, duration) {
   const effect = getStatusEffect(id);
   if (!effect) return;
+  if (Array.isArray(target.passiveImmunities) && target.passiveImmunities.includes(id)) {
+    return;
+  }
   ensureArray(target);
   const existing = target.statuses.find(s => s.id === id);
   const dur = duration ?? effect.duration ?? 1;

--- a/style/main.css
+++ b/style/main.css
@@ -506,6 +506,68 @@ body {
   cursor: pointer;
 }
 
+/* Status/Passive Panel */
+.status-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 900;
+}
+
+.status-overlay.active {
+  visibility: visible;
+  opacity: 1;
+}
+
+.status-content {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 300px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  position: relative;
+}
+
+.status-content h2 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.status-content .close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.status-passive {
+  border-bottom: 1px solid #ddd;
+  padding: 6px 0;
+}
+
+.status-passive:last-child {
+  border-bottom: none;
+}
+
+.status-passive .desc {
+  font-size: 12px;
+  color: #555;
+}
+
 .quest-item {
   border-bottom: 1px solid #ddd;
   padding: 6px 0;


### PR DESCRIPTION
## Summary
- add passive skill definitions and storage
- track and unlock passives during level up
- prevent statuses if player has passive immunity
- boost defense potion when potion mastery passive active
- log passive unlocks in combat
- new status menu shows unlocked passives
- show status menu in UI and style overlay

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684722e624208331981735040887d669