### PR TITLE
Add mobile-friendly status panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,9 @@
   <div id="status-overlay" class="status-overlay">
     <div class="status-content">
       <button class="close-btn">&times;</button>
-      <h2>Passive Skills</h2>
+      <h2>Player Status</h2>
+      <div id="status-info"></div>
+      <h3>Passive Skills</h3>
       <div id="status-passives"></div>
     </div>
   </div>

--- a/scripts/menu/status.js
+++ b/scripts/menu/status.js
@@ -3,9 +3,11 @@ import { getAllPassives } from '../passive_skills.js';
 
 export function updateStatusPanel() {
   const list = document.getElementById('status-passives');
-  if (!list) return;
+  const info = document.getElementById('status-info');
+  if (!list || !info) return;
   const defs = getAllPassives();
   list.innerHTML = '';
+  info.textContent = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}`;
   (player.passives || []).forEach(id => {
     const p = defs[id];
     if (!p) return;
@@ -31,3 +33,5 @@ export function toggleStatusPanel() {
 }
 
 document.addEventListener('passivesUpdated', updateStatusPanel);
+document.addEventListener('playerXpChanged', updateStatusPanel);
+document.addEventListener('playerLevelUp', updateStatusPanel);

--- a/scripts/passive_skills.js
+++ b/scripts/passive_skills.js
@@ -1,5 +1,17 @@
+function createPassive(def) {
+  return {
+    id: def.id,
+    name: def.name,
+    description: def.description,
+    unlockLevel: def.unlockLevel,
+    apply: def.apply,
+    immunity: def.immunity || [],
+    itemHealBonus: def.itemHealBonus || 0,
+  };
+}
+
 export const passiveDefs = {
-  toughness: {
+  toughness: createPassive({
     id: 'toughness',
     name: 'Toughness',
     description: '+5 Max HP',
@@ -8,21 +20,21 @@ export const passiveDefs = {
       player.maxHp += 5;
       player.hp = Math.min(player.hp, player.maxHp);
     },
-  },
-  poisonWard: {
+  }),
+  poisonWard: createPassive({
     id: 'poisonWard',
     name: 'Poison Ward',
     description: 'Immune to poison',
     unlockLevel: 5,
     immunity: ['poisoned'],
-  },
-  potionMaster: {
+  }),
+  potionMaster: createPassive({
     id: 'potionMaster',
     name: 'Potion Mastery',
     description: 'Potions heal for +5 HP',
     unlockLevel: 7,
     itemHealBonus: 5,
-  },
+  }),
 };
 
 let playerRef = null;

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -130,3 +130,12 @@ export function gainXP(amount) {
   }
   return leveled;
 }
+
+export function getPlayerSummary() {
+  return {
+    level: player.level,
+    xp: player.xp,
+    xpToNextLevel: player.xpToNextLevel,
+    passives: Array.isArray(player.passives) ? [...player.passives] : [],
+  };
+}

--- a/style/main.css
+++ b/style/main.css
@@ -537,6 +537,8 @@ body {
   max-width: 90%;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
   position: relative;
+  max-height: 80vh;
+  overflow-y: auto;
 }
 
 .status-content h2 {
@@ -554,6 +556,12 @@ body {
   cursor: pointer;
 }
 
+#status-info {
+  margin-bottom: 10px;
+  font-weight: bold;
+  text-align: center;
+}
+
 .status-passive {
   border-bottom: 1px solid #ddd;
   padding: 6px 0;
@@ -566,6 +574,12 @@ body {
 .status-passive .desc {
   font-size: 12px;
   color: #555;
+}
+
+@media (max-width: 500px) {
+  .status-content {
+    width: 95%;
+  }
 }
 
 .quest-item {


### PR DESCRIPTION
## Summary
- enhance `index.html` with a player status panel
- update menu logic to populate level/XP information
- normalize passive skill definitions
- expose a helper to fetch player stats
- add responsive styles for the new panel

## Testing
- `python3 -m http.server` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6847260fc82083319f007b79dbaab9ad