### PR TITLE
Add basic equipment system

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -1,7 +1,13 @@
 
 import { getSkill } from './skills.js';
 import { getEnemySkill } from './enemy_skills.js';
-import { respawn, addTempDefense, increaseMaxHp, gainXP } from './player.js';
+import {
+  respawn,
+  addTempDefense,
+  increaseMaxHp,
+  gainXP,
+  getTotalStats,
+} from './player.js';
 import { getPassive } from './passive_skills.js';
 import { applyDamage } from './logic.js';
 import {
@@ -142,9 +148,10 @@ export async function startCombat(enemy, player) {
       amount = Math.max(0, amount - 5);
       guardActive = false;
     }
+    const base = getTotalStats();
     const tempTarget = {
       hp: playerHp,
-      stats: { defense: (player.stats?.defense || 0) + player.tempDefense },
+      stats: { defense: (base.defense || 0) + player.tempDefense },
     };
     const applied = applyDamage(tempTarget, amount);
     playerHp = tempTarget.hp;
@@ -156,7 +163,9 @@ export async function startCombat(enemy, player) {
     return applied;
   }
 
-  function damageEnemy(dmg) {
+  function damageEnemy(baseDmg) {
+    const stats = getTotalStats();
+    const dmg = baseDmg + (stats.attack || 0) + (player.tempAttack || 0);
     enemyHp = Math.max(0, enemyHp - dmg);
     enemy.hp = enemyHp;
     updateHpBar(enemyBar, enemyHp, enemyMax);

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -1,4 +1,6 @@
 import { getItemData } from './item_loader.js';
+import { player } from './player.js';
+import { getItemBonuses } from './item_stats.js';
 
 export const inventory = [];
 
@@ -62,4 +64,19 @@ export function removeHealthBonusItem() {
     return true;
   }
   return false;
+}
+
+export function equipItem(itemId) {
+  const bonus = getItemBonuses(itemId);
+  if (!bonus || !bonus.slot) return false;
+  if (!player.equipment) {
+    player.equipment = { weapon: null, armor: null, accessory: null };
+  }
+  player.equipment[bonus.slot] = itemId;
+  document.dispatchEvent(new CustomEvent('equipmentChanged'));
+  return true;
+}
+
+export function getEquippedItem(slot) {
+  return player.equipment ? player.equipment[slot] : null;
 }

--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -1,6 +1,7 @@
-import { inventory } from './inventory.js';
-import { player } from './player.js';
+import { inventory, equipItem, getEquippedItem } from './inventory.js';
+import { player, getTotalStats } from './player.js';
 import { useArmorPiece } from './item_logic.js';
+import { getItemBonuses } from './item_stats.js';
 
 export function updateInventoryUI() {
   const list = document.getElementById('inventory-list');
@@ -8,7 +9,8 @@ export function updateInventoryUI() {
   list.innerHTML = '';
   const statsEl = document.getElementById('player-stats');
   if (statsEl) {
-    statsEl.textContent = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}  Defense: ${player.stats?.defense || 0}`;
+    const stats = getTotalStats();
+    statsEl.textContent = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}  Defense: ${stats.defense || 0}`;
   }
   inventory.forEach(item => {
     const row = document.createElement('div');
@@ -21,6 +23,18 @@ export function updateInventoryUI() {
         useArmorPiece();
       }
     });
+    const bonus = getItemBonuses(item.id);
+    if (bonus && bonus.slot) {
+      const btn = document.createElement('button');
+      btn.classList.add('equip-btn');
+      btn.textContent = getEquippedItem(bonus.slot) === item.id ? 'Unequip' : 'Equip';
+      btn.addEventListener('click', e => {
+        e.stopPropagation();
+        equipItem(item.id);
+        updateInventoryUI();
+      });
+      row.appendChild(btn);
+    }
     list.appendChild(row);
   });
 }

--- a/scripts/item_stats.js
+++ b/scripts/item_stats.js
@@ -1,0 +1,9 @@
+export const itemBonuses = {
+  cracked_helmet: { slot: 'armor', defense: 1 },
+  commander_badge: { slot: 'weapon', attack: 2 },
+  health_amulet: { slot: 'accessory', maxHp: 5 },
+};
+
+export function getItemBonuses(id) {
+  return itemBonuses[id] || null;
+}

--- a/scripts/menu/status.js
+++ b/scripts/menu/status.js
@@ -1,12 +1,34 @@
 import { player } from '../player.js';
 import { getAllPassives } from '../passive_skills.js';
+import { getItemData } from '../item_loader.js';
 
 export function updateStatusPanel() {
   const list = document.getElementById('status-passives');
   const info = document.getElementById('status-info');
-  if (!list || !info) return;
+  let equipList = document.getElementById('status-equipment');
+  const container = document.querySelector('#status-overlay .status-content');
+  if (!list || !info || !container) return;
+  if (!equipList) {
+    const heading = document.createElement('h3');
+    heading.textContent = 'Equipment';
+    equipList = document.createElement('div');
+    equipList.id = 'status-equipment';
+    container.insertBefore(heading, list);
+    container.insertBefore(equipList, list);
+  }
   const defs = getAllPassives();
   list.innerHTML = '';
+  equipList.innerHTML = '';
+  const eq = player.equipment || {};
+  ['weapon', 'armor', 'accessory'].forEach(slot => {
+    const id = eq[slot];
+    const item = id ? getItemData(id) : null;
+    const row = document.createElement('div');
+    row.classList.add('status-equip');
+    const name = item ? item.name : 'None';
+    row.textContent = `${slot.charAt(0).toUpperCase() + slot.slice(1)}: ${name}`;
+    equipList.appendChild(row);
+  });
   info.textContent = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}`;
   (player.passives || []).forEach(id => {
     const p = defs[id];
@@ -35,3 +57,4 @@ export function toggleStatusPanel() {
 document.addEventListener('passivesUpdated', updateStatusPanel);
 document.addEventListener('playerXpChanged', updateStatusPanel);
 document.addEventListener('playerLevelUp', updateStatusPanel);
+document.addEventListener('equipmentChanged', updateStatusPanel);

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -3,6 +3,7 @@ import { disableMovement, enableMovement } from './movement.js';
 import { showDialogue } from './dialogueSystem.js';
 import { movePlayerTo } from './map.js';
 import { unlockPassivesForLevel, getPassive } from './passive_skills.js';
+import { getItemBonuses } from './item_stats.js';
 
 export const player = {
   x: 0,
@@ -14,6 +15,11 @@ export const player = {
   xpToNextLevel: 10,
   stats: {
     defense: 0,
+  },
+  equipment: {
+    weapon: null,
+    armor: null,
+    accessory: null,
   },
   learnedSkills: [],
   passives: [],
@@ -138,4 +144,23 @@ export function getPlayerSummary() {
     xpToNextLevel: player.xpToNextLevel,
     passives: Array.isArray(player.passives) ? [...player.passives] : [],
   };
+}
+
+export function getTotalStats() {
+  const base = { ...(player.stats || {}) };
+  const total = { ...base };
+  const eq = player.equipment || {};
+  for (const slot of Object.keys(eq)) {
+    const itemId = eq[slot];
+    if (itemId) {
+      const bonus = getItemBonuses(itemId);
+      if (bonus) {
+        for (const [key, val] of Object.entries(bonus)) {
+          if (key === 'slot') continue;
+          total[key] = (total[key] || 0) + val;
+        }
+      }
+    }
+  }
+  return total;
 }

--- a/style/main.css
+++ b/style/main.css
@@ -458,6 +458,12 @@ body {
   color: #555;
 }
 
+.inventory-item .equip-btn {
+  margin-left: 6px;
+  padding: 2px 6px;
+  font-size: 12px;
+}
+
 /* Quest Log UI */
 .quest-overlay {
   position: fixed;
@@ -574,6 +580,11 @@ body {
 .status-passive .desc {
   font-size: 12px;
   color: #555;
+}
+
+.status-equip {
+  padding: 4px 0;
+  font-size: 14px;
 }
 
 @media (max-width: 500px) {


### PR DESCRIPTION
## Summary
- add item bonus definitions
- track equipped items on the player and compute totals
- allow equipping items from the inventory UI
- display equipment on the status screen
- factor equipment stats into combat calculations
- style equip buttons

## Testing
- `npm test` *(fails: no test suite)*

------
https://chatgpt.com/codex/tasks/task_e_6847276a63908331bdc709e1da5a5b6a