### PR TITLE
Add blueprint equipment crafting

### DIFF
--- a/data/blueprints.json
+++ b/data/blueprints.json
@@ -1,0 +1,16 @@
+{
+  "health_amulet": {
+    "id": "health_amulet",
+    "name": "Health Amulet",
+    "ingredients": {"potion_of_health": 2},
+    "result": "health_amulet",
+    "quantity": 1
+  },
+  "cracked_helmet": {
+    "id": "cracked_helmet",
+    "name": "Cracked Helmet",
+    "ingredients": {"armor_piece": 3},
+    "result": "cracked_helmet",
+    "quantity": 1
+  }
+}

--- a/scripts/craft.js
+++ b/scripts/craft.js
@@ -1,6 +1,7 @@
 import { loadItems, getItemData } from './item_loader.js';
-import { addItem, removeItem, getItemCount } from './inventory.js';
-import { craftState } from './craft_state.js';
+import { addItem, removeItem, getItemCount, equipItem, getEquippedItem } from './inventory.js';
+import { craftState, isBlueprintUnlocked } from './craft_state.js';
+import { getItemBonuses } from './item_stats.js';
 import { isRecipeUnlocked } from './recipe_state.js';
 import { loadJson } from './dataService.js';
 import { showError } from './errorPrompt.js';
@@ -17,6 +18,8 @@ export function endCraftingSession() {
 
 let recipes = {};
 let loaded = false;
+let blueprints = {};
+let blueprintsLoaded = false;
 
 export async function loadRecipes() {
   if (loaded) return recipes;
@@ -30,23 +33,42 @@ export async function loadRecipes() {
   return recipes;
 }
 
+export async function loadBlueprints() {
+  if (blueprintsLoaded) return blueprints;
+  const data = await loadJson('data/blueprints.json');
+  if (data) {
+    blueprints = data;
+  } else {
+    showError('Failed to load blueprints');
+  }
+  blueprintsLoaded = true;
+  return blueprints;
+}
+
+export function getBlueprint(id) {
+  return blueprints[id];
+}
+
 export function getRecipe(id) {
   return recipes[id];
 }
 
 export function canCraft(id) {
-  const recipe = recipes[id];
+  const recipe = recipes[id] || blueprints[id];
   if (!recipe) return false;
   return Object.entries(recipe.ingredients).every(([item, qty]) => getItemCount(item) >= qty);
 }
 
 export async function craft(id) {
   await loadRecipes();
+  await loadBlueprints();
   await loadItems();
   if (!craftingAllowed) return false;
-  if (!isRecipeUnlocked(id)) return false;
+  const recipe = recipes[id] || blueprints[id];
+  if (!recipe) return false;
+  if (blueprints[id] && !isBlueprintUnlocked(id)) return false;
+  if (recipes[id] && !isRecipeUnlocked(id)) return false;
   if (!canCraft(id)) return false;
-  const recipe = recipes[id];
   for (const [item, qty] of Object.entries(recipe.ingredients)) {
     removeItem(item, qty);
   }
@@ -54,6 +76,15 @@ export async function craft(id) {
   if (data) {
     addItem({ ...data, id: recipe.result, quantity: recipe.quantity || 1 });
     craftState.lastCrafted = recipe.result;
+    const bonus = getItemBonuses(recipe.result);
+    if (bonus && bonus.slot && !getEquippedItem(bonus.slot)) {
+      equipItem(recipe.result);
+    }
+    if (bonus && bonus.slot) {
+      document.dispatchEvent(
+        new CustomEvent('equipmentCrafted', { detail: recipe.result })
+      );
+    }
     return true;
   }
   return false;

--- a/scripts/craft_state.js
+++ b/scripts/craft_state.js
@@ -1,3 +1,13 @@
 export const craftState = {
   lastCrafted: null,
+  unlockedBlueprints: new Set(),
 };
+
+export function unlockBlueprint(id) {
+  craftState.unlockedBlueprints.add(id);
+  document.dispatchEvent(new CustomEvent('blueprintUnlocked', { detail: id }));
+}
+
+export function isBlueprintUnlocked(id) {
+  return craftState.unlockedBlueprints.has(id);
+}

--- a/scripts/craft_ui.js
+++ b/scripts/craft_ui.js
@@ -1,0 +1,48 @@
+import { loadRecipes, loadBlueprints, getRecipe, getBlueprint, canCraft, craft } from './craft.js';
+import { isRecipeUnlocked } from './recipe_state.js';
+import { isBlueprintUnlocked } from './craft_state.js';
+
+export async function updateCraftUI() {
+  const list = document.getElementById('craft-list');
+  if (!list) return;
+  await loadRecipes();
+  await loadBlueprints();
+  list.innerHTML = '';
+  const ids = [
+    ...Object.keys(await loadRecipes()).filter(id => isRecipeUnlocked(id)),
+    ...Object.keys(await loadBlueprints()).filter(id => isBlueprintUnlocked(id))
+  ];
+  ids.forEach(id => {
+    const data = getRecipe(id) || getBlueprint(id);
+    if (!data) return;
+    const row = document.createElement('div');
+    row.classList.add('craft-item');
+    const btn = document.createElement('button');
+    btn.textContent = 'Craft';
+    btn.disabled = !canCraft(id);
+    btn.addEventListener('click', async () => {
+      const ok = await craft(id);
+      if (ok) updateCraftUI();
+    });
+    row.innerHTML = `<strong>${data.name}</strong>`;
+    row.appendChild(btn);
+    list.appendChild(row);
+  });
+  if (ids.length === 0) {
+    list.innerHTML = '<em>No known recipes</em>';
+  }
+}
+
+export function toggleCraftView() {
+  const overlay = document.getElementById('craft-overlay');
+  if (!overlay) return;
+  if (overlay.classList.contains('active')) {
+    overlay.classList.remove('active');
+  } else {
+    updateCraftUI();
+    overlay.classList.add('active');
+  }
+}
+
+document.addEventListener('inventoryUpdated', updateCraftUI);
+document.addEventListener('blueprintUnlocked', updateCraftUI);

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -1,6 +1,7 @@
 import { getItemData } from './item_loader.js';
 import { player } from './player.js';
 import { getItemBonuses } from './item_stats.js';
+import { unlockBlueprint } from './craft_state.js';
 
 export const inventory = [];
 
@@ -21,6 +22,9 @@ export function addItem(item) {
     return true;
   }
   inventory.push({ ...item, quantity: qty });
+  if (item.id && item.id.startsWith('blueprint_')) {
+    unlockBlueprint(item.id.replace('blueprint_', ''));
+  }
   document.dispatchEvent(new CustomEvent('inventoryUpdated'));
   return true;
 }

--- a/scripts/menu/status.js
+++ b/scripts/menu/status.js
@@ -58,3 +58,4 @@ document.addEventListener('passivesUpdated', updateStatusPanel);
 document.addEventListener('playerXpChanged', updateStatusPanel);
 document.addEventListener('playerLevelUp', updateStatusPanel);
 document.addEventListener('equipmentChanged', updateStatusPanel);
+document.addEventListener('equipmentCrafted', updateStatusPanel);


### PR DESCRIPTION
## Summary
- introduce `blueprints.json` with gear recipes
- extend crafting logic to support blueprints and auto-equip crafted gear
- track unlocked blueprints in `craft_state.js`
- unlock blueprints automatically when blueprint items are added to inventory
- provide a basic crafting UI to list known recipes
- update the status panel whenever crafted gear is equipped

## Testing
- `node -e "require('./scripts/craft.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684729cc09048331a9932281e46cf530