### PR TITLE
Add blueprint rewards and persistence

### DIFF
--- a/scripts/craft_state.js
+++ b/scripts/craft_state.js
@@ -1,13 +1,42 @@
+const STORAGE_KEY = 'gridquest.blueprints';
+
 export const craftState = {
   lastCrafted: null,
   unlockedBlueprints: new Set(),
 };
 
+function loadUnlockedBlueprints() {
+  const json = localStorage.getItem(STORAGE_KEY);
+  if (!json) return [];
+  try {
+    const arr = JSON.parse(json);
+    if (Array.isArray(arr)) return arr;
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function saveUnlockedBlueprints(list) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+}
+
+craftState.unlockedBlueprints = new Set(loadUnlockedBlueprints());
+document.dispatchEvent(new CustomEvent('blueprintsLoaded'));
+
 export function unlockBlueprint(id) {
-  craftState.unlockedBlueprints.add(id);
-  document.dispatchEvent(new CustomEvent('blueprintUnlocked', { detail: id }));
+  if (!craftState.unlockedBlueprints.has(id)) {
+    craftState.unlockedBlueprints.add(id);
+    saveUnlockedBlueprints(Array.from(craftState.unlockedBlueprints));
+    document.dispatchEvent(new CustomEvent('blueprintUnlocked', { detail: id }));
+  }
 }
 
 export function isBlueprintUnlocked(id) {
   return craftState.unlockedBlueprints.has(id);
+}
+
+export function loadBlueprintState() {
+  craftState.unlockedBlueprints = new Set(loadUnlockedBlueprints());
+  document.dispatchEvent(new CustomEvent('blueprintsLoaded'));
 }

--- a/scripts/craft_ui.js
+++ b/scripts/craft_ui.js
@@ -46,3 +46,4 @@ export function toggleCraftView() {
 
 document.addEventListener('inventoryUpdated', updateCraftUI);
 document.addEventListener('blueprintUnlocked', updateCraftUI);
+document.addEventListener('blueprintsLoaded', updateCraftUI);

--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -2,7 +2,7 @@ import { addItem, removeItem, inventory } from './inventory.js';
 import { updateInventoryUI } from './inventory_state.js';
 import { loadItems, getItemData } from './item_loader.js';
 import { unlockSkillsFromItem, getAllSkills } from './skills.js';
-import { dialogueMemory, setMemory } from './dialogue_state.js';
+import { dialogueMemory, setMemory, giveBlueprint } from './dialogue_state.js';
 import { getQuests, completeQuest } from './quest_state.js';
 import { showError } from './errorPrompt.js';
 
@@ -238,6 +238,9 @@ export async function startDialogueTree(dialogue, index = 0) {
             }
           });
         }
+      }
+      if (opt.giveBlueprint) {
+        giveBlueprint(opt.giveBlueprint);
       }
       if (opt.completeQuest) {
         completeQuest(opt.completeQuest);

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -1,3 +1,5 @@
+import { unlockBlueprint } from './craft_state.js';
+
 export const dialogueMemory = new Set();
 
 const state = {
@@ -25,3 +27,8 @@ export function endSession() {
 }
 
 export const dialogueState = state;
+
+// Allow dialogue options to grant blueprints as rewards
+export function giveBlueprint(id) {
+  if (id) unlockBlueprint(id);
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -20,6 +20,7 @@ import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
 import { saveState, loadState, gameState } from './game_state.js';
+import { saveGame, loadGame } from './save_system.js';
 import {
   loadSettings,
   saveSettings,
@@ -186,11 +187,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   saveTab.addEventListener('click', () => {
     saveState();
+    saveGame();
     showDialogue('Game saved!');
   });
 
   loadTab.addEventListener('click', async () => {
     loadState();
+    loadGame();
     const mapName = gameState.currentMap || 'map01';
     try {
       const { cols: newCols } = await router.loadMap(mapName);

--- a/scripts/npc_dialogue.js
+++ b/scripts/npc_dialogue.js
@@ -1,0 +1,8 @@
+export const testNpcDialogue = [
+  {
+    text: 'Hello adventurer, I have a special blueprint for you.',
+    options: [
+      { label: 'Thanks!', goto: null, giveBlueprint: 'cracked_helmet' }
+    ]
+  }
+];

--- a/scripts/save_system.js
+++ b/scripts/save_system.js
@@ -1,0 +1,24 @@
+import { craftState } from './craft_state.js';
+
+const STORAGE_KEY = 'gridquest.save';
+
+export function saveGame() {
+  const data = {
+    blueprints: Array.from(craftState.unlockedBlueprints),
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+export function loadGame() {
+  const json = localStorage.getItem(STORAGE_KEY);
+  if (!json) return;
+  try {
+    const data = JSON.parse(json);
+    if (Array.isArray(data.blueprints)) {
+      craftState.unlockedBlueprints = new Set(data.blueprints);
+      document.dispatchEvent(new CustomEvent('blueprintsLoaded'));
+    }
+  } catch {
+    // ignore malformed saves
+  }
+}


### PR DESCRIPTION
## Summary
- add persistent blueprint state
- support giving blueprints via dialogue options
- refresh craft UI when blueprints unlock
- allow saving/loading blueprint progress
- add test NPC dialogue that grants a blueprint

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68472c5abcb08331914cb83e89f62a63