### PR TITLE
Add forge upgrade system

### DIFF
--- a/data/upgrade_data.json
+++ b/data/upgrade_data.json
@@ -1,0 +1,7 @@
+{
+  "cracked_helmet": {
+    "material": "armor_piece",
+    "cost": 2,
+    "maxLevel": 3
+  }
+}

--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -2,7 +2,7 @@ import { addItem, removeItem, inventory } from './inventory.js';
 import { updateInventoryUI } from './inventory_state.js';
 import { loadItems, getItemData } from './item_loader.js';
 import { unlockSkillsFromItem, getAllSkills } from './skills.js';
-import { dialogueMemory, setMemory, giveBlueprint } from './dialogue_state.js';
+import { dialogueMemory, setMemory, giveBlueprint, triggerUpgrade } from './dialogue_state.js';
 import { getQuests, completeQuest } from './quest_state.js';
 import { showError } from './errorPrompt.js';
 
@@ -241,6 +241,9 @@ export async function startDialogueTree(dialogue, index = 0) {
       }
       if (opt.giveBlueprint) {
         giveBlueprint(opt.giveBlueprint);
+      }
+      if (opt.triggerUpgrade) {
+        await triggerUpgrade(opt.triggerUpgrade);
       }
       if (opt.completeQuest) {
         completeQuest(opt.completeQuest);

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -1,4 +1,5 @@
 import { unlockBlueprint } from './craft_state.js';
+import { upgradeItem } from './forge.js';
 
 export const dialogueMemory = new Set();
 
@@ -31,4 +32,8 @@ export const dialogueState = state;
 // Allow dialogue options to grant blueprints as rewards
 export function giveBlueprint(id) {
   if (id) unlockBlueprint(id);
+}
+
+export async function triggerUpgrade(id) {
+  if (id) await upgradeItem(id);
 }

--- a/scripts/forge.js
+++ b/scripts/forge.js
@@ -1,0 +1,61 @@
+import { loadJson } from './dataService.js';
+import { inventory, removeItem, addItem } from './inventory.js';
+import { getItemData } from './item_loader.js';
+import { parseItemId, getItemDisplayName } from './inventory.js';
+
+let upgrades = {};
+let loaded = false;
+let sessionActive = false;
+
+export async function loadUpgradeData() {
+  if (loaded) return upgrades;
+  const data = await loadJson('data/upgrade_data.json');
+  if (data) upgrades = data;
+  loaded = true;
+  return upgrades;
+}
+
+export function beginForgeSession() {
+  sessionActive = true;
+}
+
+export function endForgeSession() {
+  sessionActive = false;
+}
+
+export function canUpgrade(id) {
+  if (!sessionActive) return false;
+  const info = getUpgradeInfo(id);
+  if (!info) return false;
+  const { material, cost } = info;
+  const have = inventory.find(it => it.id === material)?.quantity || 0;
+  return have >= cost;
+}
+
+export function getUpgradeInfo(id) {
+  const { baseId, level } = parseItemId(id);
+  const info = upgrades[baseId];
+  if (!info) return null;
+  if (level >= info.maxLevel) return null;
+  return info;
+}
+
+export async function upgradeItem(id) {
+  await loadUpgradeData();
+  const info = getUpgradeInfo(id);
+  if (!info) return false;
+  if (!canUpgrade(id)) return false;
+  removeItem(info.material, info.cost);
+  removeItem(id, 1);
+  const { baseId, level } = parseItemId(id);
+  const newLevel = level + 1;
+  const newId = `${baseId}+${newLevel}`;
+  const base = getItemData(baseId) || { name: baseId, description: '' };
+  addItem({ id: newId, name: `${base.name} +${newLevel}`, description: base.description, quantity: 1 });
+  return newId;
+}
+
+export function listUpgradeableItems() {
+  return inventory.filter(it => canUpgrade(it.id));
+}
+

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -5,6 +5,25 @@ import { unlockBlueprint } from './craft_state.js';
 
 export const inventory = [];
 
+export function parseItemId(id) {
+  const match = /^(.+)\+(\d+)$/.exec(id);
+  if (match) {
+    return { baseId: match[1], level: parseInt(match[2], 10) };
+  }
+  return { baseId: id, level: 0 };
+}
+
+export function getItemLevel(id) {
+  return parseItemId(id).level;
+}
+
+export function getItemDisplayName(id) {
+  const { baseId, level } = parseItemId(id);
+  const data = getItemData(baseId);
+  const baseName = data?.name || baseId;
+  return level > 0 ? `${baseName} +${level}` : baseName;
+}
+
 export function getItemCount(nameOrId) {
   const item = inventory.find(
     it => it.name === nameOrId || it.id === nameOrId
@@ -21,7 +40,9 @@ export function addItem(item) {
     document.dispatchEvent(new CustomEvent('inventoryUpdated'));
     return true;
   }
-  inventory.push({ ...item, quantity: qty });
+  const name = item.name || getItemDisplayName(item.id);
+  const desc = item.description || getItemData(parseItemId(item.id).baseId)?.description || '';
+  inventory.push({ ...item, name, description: desc, quantity: qty });
   if (item.id && item.id.startsWith('blueprint_')) {
     unlockBlueprint(item.id.replace('blueprint_', ''));
   }
@@ -84,3 +105,4 @@ export function equipItem(itemId) {
 export function getEquippedItem(slot) {
   return player.equipment ? player.equipment[slot] : null;
 }
+

--- a/scripts/item_stats.js
+++ b/scripts/item_stats.js
@@ -1,7 +1,13 @@
 export const itemBonuses = {
   cracked_helmet: { slot: 'armor', defense: 1 },
+  'cracked_helmet+1': { slot: 'armor', defense: 2 },
+  'cracked_helmet+2': { slot: 'armor', defense: 3 },
+  'cracked_helmet+3': { slot: 'armor', defense: 4 },
   commander_badge: { slot: 'weapon', attack: 2 },
   health_amulet: { slot: 'accessory', maxHp: 5 },
+  'health_amulet+1': { slot: 'accessory', maxHp: 6 },
+  'health_amulet+2': { slot: 'accessory', maxHp: 7 },
+  'health_amulet+3': { slot: 'accessory', maxHp: 8 },
 };
 
 export function getItemBonuses(id) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -16,6 +16,7 @@ import * as lioran from './npc/lioran.js';
 import * as goblinQuestGiver from './npc/goblin_quest_giver.js';
 import * as arvalin from './npc/arvalin.js';
 import * as grindle from './npc/grindle.js';
+import * as forgeNpc from './npc/forge_npc.js';
 import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
@@ -30,7 +31,7 @@ import {
 // Inventory contents are managed in inventory.js
 
 let isInBattle = false;
-const npcModules = { eryndor, lioran, goblinQuestGiver, arvalin, grindle };
+const npcModules = { eryndor, lioran, goblinQuestGiver, arvalin, grindle, forgeNpc };
 
 let hpDisplay;
 let defenseDisplay;

--- a/scripts/npc/forge_npc.js
+++ b/scripts/npc/forge_npc.js
@@ -1,0 +1,7 @@
+import { startDialogueTree } from '../dialogueSystem.js';
+import { createForgeDialogue } from '../npc_dialogues/forge_npc.js';
+
+export async function interact() {
+  const dialogue = await createForgeDialogue();
+  startDialogueTree(dialogue);
+}

--- a/scripts/npc_dialogues/forge_npc.js
+++ b/scripts/npc_dialogues/forge_npc.js
@@ -1,0 +1,29 @@
+import { loadUpgradeData, listUpgradeableItems, beginForgeSession, canUpgrade } from '../forge.js';
+import { showDialogue } from '../dialogueSystem.js';
+import { getItemDisplayName, parseItemId } from '../inventory.js';
+
+export async function createForgeDialogue() {
+  await loadUpgradeData();
+  beginForgeSession();
+  const items = listUpgradeableItems();
+  const options = items.map(it => ({
+    label: `Upgrade ${getItemDisplayName(it.id)}`,
+    goto: null,
+    condition: () => canUpgrade(it.id),
+    triggerUpgrade: it.id,
+    onChoose: async () => {
+      const { baseId, level } = parseItemId(it.id);
+      const newId = `${baseId}+${level + 1}`;
+      showDialogue(`Your ${getItemDisplayName(newId)} has been strengthened.`);
+    }
+  }));
+  options.push({ label: 'Maybe later.', goto: null });
+  return [
+    {
+      text: 'Welcome to my forge. Care to reforge something?',
+      options
+    }
+  ];
+}
+
+


### PR DESCRIPTION
## Summary
- allow gear to be reforged with new `forge.js`
- add upgrade data file defining upgrade materials and limits
- support item level parsing and dynamic naming in inventory
- extend item stats for upgraded equipment
- handle `triggerUpgrade` in dialogue options
- create forge NPC with example dialogue offering upgrades

## Testing
- `npm test` *(fails: no test script)*


------
https://chatgpt.com/codex/tasks/task_e_68472f6757f88331b8fdd20c8ba6a1f5