### PR TITLE
Add upgraded gear styling and tooltips

### DIFF
--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -1,7 +1,14 @@
-import { inventory, equipItem, getEquippedItem } from './inventory.js';
+import {
+  inventory,
+  equipItem,
+  getEquippedItem,
+  getItemDisplayName,
+  getItemLevel,
+} from './inventory.js';
 import { player, getTotalStats } from './player.js';
 import { useArmorPiece } from './item_logic.js';
 import { getItemBonuses } from './item_stats.js';
+import { showItemTooltip, hideItemTooltip } from './utils.js';
 
 export function updateInventoryUI() {
   const list = document.getElementById('inventory-list');
@@ -17,7 +24,12 @@ export function updateInventoryUI() {
     row.classList.add('inventory-item');
     row.dataset.id = item.id;
     const qty = item.quantity > 1 ? ` x${item.quantity}` : '';
-    row.innerHTML = `<strong>${item.name}${qty}</strong><div class="desc">${item.description}</div>`;
+    const displayName = getItemDisplayName(item.id);
+    row.innerHTML = `<strong>${displayName}${qty}</strong><div class="desc">${item.description}</div>`;
+    const level = getItemLevel(item.id);
+    if (level > 0) {
+      row.classList.add('gear-upgraded');
+    }
     row.addEventListener('click', () => {
       if (item.id === 'armor_piece') {
         useArmorPiece();
@@ -34,6 +46,20 @@ export function updateInventoryUI() {
         updateInventoryUI();
       });
       row.appendChild(btn);
+    }
+
+    let tooltipText = '';
+    if (bonus) {
+      const effects = [];
+      Object.keys(bonus).forEach(k => {
+        if (k === 'slot') return;
+        effects.push(`${k.charAt(0).toUpperCase() + k.slice(1)} +${bonus[k]}`);
+      });
+      tooltipText = effects.join(', ');
+    }
+    if (tooltipText) {
+      row.addEventListener('mouseenter', () => showItemTooltip(row, tooltipText));
+      row.addEventListener('mouseleave', hideItemTooltip);
     }
     list.appendChild(row);
   });

--- a/scripts/menu/status.js
+++ b/scripts/menu/status.js
@@ -1,6 +1,9 @@
 import { player } from '../player.js';
 import { getAllPassives } from '../passive_skills.js';
 import { getItemData } from '../item_loader.js';
+import { getItemDisplayName, getItemLevel } from '../inventory.js';
+import { getItemBonuses } from '../item_stats.js';
+import { showItemTooltip, hideItemTooltip } from '../utils.js';
 
 export function updateStatusPanel() {
   const list = document.getElementById('status-passives');
@@ -25,8 +28,30 @@ export function updateStatusPanel() {
     const item = id ? getItemData(id) : null;
     const row = document.createElement('div');
     row.classList.add('status-equip');
-    const name = item ? item.name : 'None';
-    row.textContent = `${slot.charAt(0).toUpperCase() + slot.slice(1)}: ${name}`;
+    let display = 'None';
+    let level = 0;
+    if (id) {
+      display = getItemDisplayName(id);
+      level = getItemLevel(id);
+    }
+    row.innerHTML = `${slot.charAt(0).toUpperCase() + slot.slice(1)}: <span>${display}</span>`;
+    if (level > 0) {
+      row.querySelector('span').classList.add('gear-upgraded');
+    }
+    const bonus = id ? getItemBonuses(id) : null;
+    let tooltip = '';
+    if (bonus) {
+      const effects = [];
+      Object.keys(bonus).forEach(k => {
+        if (k === 'slot') return;
+        effects.push(`${k.charAt(0).toUpperCase() + k.slice(1)} +${bonus[k]}`);
+      });
+      tooltip = effects.join(', ');
+    }
+    if (tooltip) {
+      row.addEventListener('mouseenter', () => showItemTooltip(row, tooltip));
+      row.addEventListener('mouseleave', hideItemTooltip);
+    }
     equipList.appendChild(row);
   });
   info.textContent = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}`;

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,25 @@
+export function getUpgradeLevel(id) {
+  const match = /^.+\+(\d+)$/.exec(id);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+let tooltipEl;
+
+export function showItemTooltip(target, text) {
+  if (!tooltipEl) {
+    tooltipEl = document.createElement('div');
+    tooltipEl.className = 'item-tooltip';
+    document.body.appendChild(tooltipEl);
+  }
+  tooltipEl.textContent = text;
+  const rect = target.getBoundingClientRect();
+  tooltipEl.style.top = window.scrollY + rect.bottom + 4 + 'px';
+  tooltipEl.style.left = window.scrollX + rect.left + 'px';
+  tooltipEl.style.display = 'block';
+}
+
+export function hideItemTooltip() {
+  if (tooltipEl) {
+    tooltipEl.style.display = 'none';
+  }
+}

--- a/style/main.css
+++ b/style/main.css
@@ -587,6 +587,24 @@ body {
   font-size: 14px;
 }
 
+.gear-upgraded {
+  color: #1e8b1e;
+  font-weight: bold;
+}
+
+.item-tooltip {
+  position: absolute;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  pointer-events: none;
+  white-space: nowrap;
+  z-index: 1000;
+  display: none;
+}
+
 @media (max-width: 500px) {
   .status-content {
     width: 95%;


### PR DESCRIPTION
## Summary
- highlight upgraded gear with `.gear-upgraded` styling
- display upgrade info via simple tooltip on hover
- show equipment upgrade bonuses in status panel
- include small utility module for upgrade helpers

## Testing
- `node --check scripts/inventory_state.js`
- `node --check scripts/menu/status.js`
- `node --check scripts/utils.js`

------
https://chatgpt.com/codex/tasks/task_e_6847321c70748331bc5f995f6e1c9665