### PR TITLE
Add gear enchantment reroll feature

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -49,5 +49,13 @@
     "description": "Increases defense by 1 for this fight.",
     "type": "combat",
     "effect": { "temporaryDefense": 1 }
+  },
+  "mystic_dust": {
+    "name": "Mystic Dust",
+    "description": "Powder pulsating with magical energy."
+  },
+  "arcane_crystal": {
+    "name": "Arcane Crystal",
+    "description": "A crystal infused with raw arcana."
   }
 }

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
       <h2>Inventory</h2>
       <div id="player-stats"></div>
       <div id="inventory-list"></div>
+      <div id="forge-log" class="forge-log"></div>
     </div>
   </div>
   <div id="quest-log-overlay" class="quest-overlay">

--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -2,7 +2,7 @@ import { addItem, removeItem, inventory } from './inventory.js';
 import { updateInventoryUI } from './inventory_state.js';
 import { loadItems, getItemData } from './item_loader.js';
 import { unlockSkillsFromItem, getAllSkills } from './skills.js';
-import { dialogueMemory, setMemory, giveBlueprint, triggerUpgrade } from './dialogue_state.js';
+import { dialogueMemory, setMemory, giveBlueprint, triggerUpgrade, triggerReroll } from './dialogue_state.js';
 import { getQuests, completeQuest } from './quest_state.js';
 import { showError } from './errorPrompt.js';
 
@@ -244,6 +244,9 @@ export async function startDialogueTree(dialogue, index = 0) {
       }
       if (opt.triggerUpgrade) {
         await triggerUpgrade(opt.triggerUpgrade);
+      }
+      if (opt.triggerReroll) {
+        await triggerReroll(opt.triggerReroll);
       }
       if (opt.completeQuest) {
         completeQuest(opt.completeQuest);

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -1,5 +1,5 @@
 import { unlockBlueprint } from './craft_state.js';
-import { upgradeItem } from './forge.js';
+import { upgradeItem, rerollEnchantment } from './forge.js';
 
 export const dialogueMemory = new Set();
 
@@ -36,4 +36,8 @@ export function giveBlueprint(id) {
 
 export async function triggerUpgrade(id) {
   if (id) await upgradeItem(id);
+}
+
+export async function triggerReroll(id) {
+  if (id) await rerollEnchantment(id);
 }

--- a/scripts/npc_dialogues/forge_npc.js
+++ b/scripts/npc_dialogues/forge_npc.js
@@ -1,4 +1,4 @@
-import { loadUpgradeData, listUpgradeableItems, beginForgeSession, canUpgrade } from '../forge.js';
+import { loadUpgradeData, listUpgradeableItems, listRerollableItems, beginForgeSession, canUpgrade, canReroll } from '../forge.js';
 import { showDialogue } from '../dialogueSystem.js';
 import { getItemDisplayName, parseItemId } from '../inventory.js';
 
@@ -6,6 +6,7 @@ export async function createForgeDialogue() {
   await loadUpgradeData();
   beginForgeSession();
   const items = listUpgradeableItems();
+  const rerollables = listRerollableItems();
   const options = items.map(it => ({
     label: `Upgrade ${getItemDisplayName(it.id)}`,
     goto: null,
@@ -17,6 +18,17 @@ export async function createForgeDialogue() {
       showDialogue(`Your ${getItemDisplayName(newId)} has been strengthened.`);
     }
   }));
+  rerollables.forEach(it => {
+    options.push({
+      label: `Reroll ${getItemDisplayName(it.id)}`,
+      goto: null,
+      condition: () => canReroll(it.id),
+      triggerReroll: it.id,
+      onChoose: () => {
+        showDialogue('Let\'s see what magic emerges...');
+      }
+    });
+  });
   options.push({ label: 'Maybe later.', goto: null });
   return [
     {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -15,6 +15,11 @@ export function splitItemId(id) {
   return { baseId, level, enchant: enchant || null };
 }
 
+export function parseEnchantedId(id) {
+  const [cleanId, enchant] = id.split('#');
+  return { id: cleanId, enchant: enchant || null };
+}
+
 let tooltipEl;
 
 export function showItemTooltip(target, text) {

--- a/style/main.css
+++ b/style/main.css
@@ -463,6 +463,17 @@ body {
   padding: 2px 6px;
   font-size: 12px;
 }
+.inventory-item .reroll-btn {
+  margin-left: 4px;
+  padding: 2px 6px;
+  font-size: 12px;
+}
+
+.forge-log {
+  margin-top: 8px;
+  font-size: 14px;
+  color: #fff;
+}
 
 /* Quest Log UI */
 .quest-overlay {


### PR DESCRIPTION
## Summary
- support `mystic_dust` and `arcane_crystal` items
- implement `parseEnchantedId` util
- add `rerollEnchantment` logic and helpers in `forge.js`
- allow rerolling gear from inventory UI
- show reroll button in inventory and log results
- extend forge NPC dialogue with reroll options
- wire dialogue system to trigger rerolls
- style reroll button and forge log display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68473655fdf88331a47c147f7cd3a6e5