### PR TITLE
Add Info panel with NPC, enemy and item tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <div class="tab inventory-tab">Inventory</div>
     <div class="tab quests-tab">Quests</div>
     <div class="tab status-tab">Status</div>
+    <div class="tab info-tab">Info</div>
     <div class="tab save-tab">Save</div>
     <div class="tab load-tab">Load</div>
   </div>
@@ -42,6 +43,19 @@
       <div id="status-info"></div>
       <h3>Passive Skills</h3>
       <div id="status-passives"></div>
+    </div>
+  </div>
+  <div id="info-overlay" class="info-overlay">
+    <div id="info-panel">
+      <button class="close-btn">&times;</button>
+      <div class="info-tabs">
+        <div class="info-tab-btn active" data-target="npcs">NPCs</div>
+        <div class="info-tab-btn" data-target="enemies">Enemies</div>
+        <div class="info-tab-btn" data-target="items">Items</div>
+      </div>
+      <div id="info-npcs" class="info-tab-content"></div>
+      <div id="info-enemies" class="info-tab-content" style="display:none;"></div>
+      <div id="info-items" class="info-tab-content" style="display:none;"></div>
     </div>
   </div>
   <div id="settings-overlay" class="settings-overlay">

--- a/scripts/enemyInfo.js
+++ b/scripts/enemyInfo.js
@@ -1,0 +1,33 @@
+import { loadEnemyData } from './enemy.js';
+import { loadItems, getItemData } from './item_loader.js';
+
+let enemyInfoList = [];
+let loaded = false;
+
+export async function loadEnemyInfo() {
+  if (loaded) return enemyInfoList;
+  const enemies = await loadEnemyData();
+  await loadItems();
+  enemyInfoList = Object.keys(enemies).map(id => {
+    const e = enemies[id];
+    let drops = '';
+    if (Array.isArray(e.drops) && e.drops.length) {
+      drops = e.drops.map(d => {
+        const item = getItemData(d.item) || { name: d.item };
+        return `${item.name} x${d.quantity}`;
+      }).join(', ');
+    }
+    return {
+      id,
+      name: e.name,
+      description: e.description,
+      drops
+    };
+  });
+  loaded = true;
+  return enemyInfoList;
+}
+
+export function getAllEnemies() {
+  return enemyInfoList;
+}

--- a/scripts/info_panel.js
+++ b/scripts/info_panel.js
@@ -1,0 +1,65 @@
+import { getAllNpcs } from './npcInfo.js';
+import { loadEnemyInfo, getAllEnemies } from './enemyInfo.js';
+import { loadItemInfo, getAllItems } from './itemInfo.js';
+
+function createEntry(obj) {
+  const row = document.createElement('div');
+  row.classList.add('info-entry');
+  let extra = obj.drops ? `<div class="desc">Drops: ${obj.drops}</div>` : '';
+  row.innerHTML = `<strong>${obj.name}</strong><div class="desc">${obj.description}</div>${extra}`;
+  return row;
+}
+
+export async function updateInfoPanel() {
+  const npcContainer = document.getElementById('info-npcs');
+  const enemyContainer = document.getElementById('info-enemies');
+  const itemContainer = document.getElementById('info-items');
+  if (!npcContainer || !enemyContainer || !itemContainer) return;
+
+  npcContainer.innerHTML = '';
+  getAllNpcs().forEach(n => npcContainer.appendChild(createEntry(n)));
+
+  await loadEnemyInfo();
+  enemyContainer.innerHTML = '';
+  getAllEnemies().forEach(e => enemyContainer.appendChild(createEntry(e)));
+
+  await loadItemInfo();
+  itemContainer.innerHTML = '';
+  getAllItems().forEach(i => itemContainer.appendChild(createEntry(i)));
+}
+
+function showTab(name) {
+  const tabs = document.querySelectorAll('#info-panel .info-tab-btn');
+  tabs.forEach(t => {
+    if (t.dataset.target === name) t.classList.add('active');
+    else t.classList.remove('active');
+  });
+  document.getElementById('info-npcs').style.display = name === 'npcs' ? 'block' : 'none';
+  document.getElementById('info-enemies').style.display = name === 'enemies' ? 'block' : 'none';
+  document.getElementById('info-items').style.display = name === 'items' ? 'block' : 'none';
+}
+
+export async function toggleInfoPanel() {
+  const overlay = document.getElementById('info-overlay');
+  if (!overlay) return;
+  if (overlay.classList.contains('active')) {
+    overlay.classList.remove('active');
+  } else {
+    await updateInfoPanel();
+    overlay.classList.add('active');
+    showTab('npcs');
+  }
+}
+
+export function initInfoPanel() {
+  const buttons = document.querySelectorAll('#info-panel .info-tab-btn');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => showTab(btn.dataset.target));
+  });
+  const closeBtn = document.querySelector('#info-panel .close-btn');
+  if (closeBtn) closeBtn.addEventListener('click', toggleInfoPanel);
+  const overlay = document.getElementById('info-overlay');
+  if (overlay) overlay.addEventListener('click', e => {
+    if (e.target === overlay) toggleInfoPanel();
+  });
+}

--- a/scripts/itemInfo.js
+++ b/scripts/itemInfo.js
@@ -1,0 +1,20 @@
+import { loadItems } from './item_loader.js';
+
+let itemInfoList = [];
+let loaded = false;
+
+export async function loadItemInfo() {
+  if (loaded) return itemInfoList;
+  const items = await loadItems();
+  itemInfoList = Object.keys(items).map(id => ({
+    id,
+    name: items[id].name,
+    description: items[id].description || ''
+  }));
+  loaded = true;
+  return itemInfoList;
+}
+
+export function getAllItems() {
+  return itemInfoList;
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -20,6 +20,7 @@ import * as forgeNpc from './npc/forge_npc.js';
 import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
+import { toggleInfoPanel, initInfoPanel } from './info_panel.js';
 import { saveState, loadState, gameState } from './game_state.js';
 import { saveGame, loadGame } from './save_system.js';
 import {
@@ -105,6 +106,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const statusTab = document.querySelector('.status-tab');
   const statusOverlay = document.getElementById('status-overlay');
   const statusClose = statusOverlay?.querySelector('.close-btn');
+  const infoTab = document.querySelector('.info-tab');
+  const infoOverlay = document.getElementById('info-overlay');
+  const infoClose = infoOverlay?.querySelector('.close-btn');
   const settingsTab = document.querySelector('.settings-tab');
   const settingsOverlay = document.getElementById('settings-overlay');
   const settingsClose = settingsOverlay.querySelector('.close-btn');
@@ -130,6 +134,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   router.init(container, player);
   initSkillSystem(player);
   initPassiveSystem(player);
+  initInfoPanel();
 
   try {
     await loadEnemyData();
@@ -152,6 +157,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (statusOverlay) {
     statusOverlay.addEventListener('click', e => {
       if (e.target === statusOverlay) toggleStatusPanel();
+    });
+  }
+  if (infoTab) infoTab.addEventListener('click', toggleInfoPanel);
+  if (infoClose) infoClose.addEventListener('click', toggleInfoPanel);
+  if (infoOverlay) {
+    infoOverlay.addEventListener('click', e => {
+      if (e.target === infoOverlay) toggleInfoPanel();
     });
   }
 

--- a/scripts/npcInfo.js
+++ b/scripts/npcInfo.js
@@ -1,0 +1,12 @@
+export const npcInfoList = [
+  { id: 'eryndor', name: 'Eryndor', description: 'Last of the Lorebound, keeper of forgotten tales.' },
+  { id: 'lioran', name: 'Lioran', description: 'An eccentric mystic who speaks in riddles.' },
+  { id: 'goblin_quest_giver', name: 'Goblin Trader', description: 'Trades goblin gear for mysterious rewards.' },
+  { id: 'arvalin', name: 'Arvalin', description: 'A scholar fascinated by cursed artifacts.' },
+  { id: 'grindle', name: 'Grindle', description: 'A gruff craftsman skilled in forging.' },
+  { id: 'forge_npc', name: 'Forge Master', description: 'Offers upgrades and rerolls for equipment.' }
+];
+
+export function getAllNpcs() {
+  return npcInfoList;
+}

--- a/style/main.css
+++ b/style/main.css
@@ -646,6 +646,86 @@ body {
   color: #555;
 }
 
+/* Info Panel */
+#info-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 900;
+}
+
+#info-overlay.active {
+  visibility: visible;
+  opacity: 1;
+}
+
+#info-panel {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 300px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  position: relative;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+#info-panel .close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+#info-panel .info-tabs {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 10px;
+}
+
+#info-panel .info-tab-btn {
+  background: #333;
+  color: #fff;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 6px 10px;
+  margin: 0 4px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+#info-panel .info-tab-btn.active {
+  background: #555;
+}
+
+.info-entry {
+  border-bottom: 1px solid #ddd;
+  padding: 6px 0;
+}
+
+.info-entry:last-child {
+  border-bottom: none;
+}
+
+.info-entry .desc {
+  font-size: 12px;
+  color: #555;
+}
+
 /* Settings UI */
 .settings-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- add new **Info** tab to the UI
- implement panel with tabs for NPCs, enemies and items
- provide data loaders for NPC, enemy and item descriptions
- support new panel toggling in main game script
- style the info overlay and entries

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68473b29ab6483318895f16084af237e