### PR TITLE
Track discovered entries for info panel

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -21,6 +21,7 @@ import { useDefensePotion } from './item_logic.js';
 import { updateInventoryUI } from './inventory_state.js';
 import { showDialogue } from './dialogueSystem.js';
 import { gameState } from './game_state.js';
+import { discover } from './player_memory.js';
 import {
   setupTabs,
   updateStatusUI,
@@ -309,6 +310,7 @@ export async function startCombat(enemy, player) {
     if (result === false) return; // invalid action
     if (enemyHp <= 0) {
       log(`${enemy.name} was defeated!`);
+      discover('enemies', enemy.id);
       await giveDrops();
       showVictoryMessage();
       setTimeout(endCombat, 800);
@@ -459,6 +461,7 @@ export async function startCombat(enemy, player) {
     }
     if (enemyHp <= 0) {
       log(`${enemy.name} was defeated!`);
+      discover('enemies', enemy.id);
       giveDrops();
       showVictoryMessage();
       setTimeout(endCombat, 800);

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -1,6 +1,7 @@
 import { unlockBlueprint } from './craft_state.js';
 import { upgradeItem, rerollEnchantment } from './forge.js';
 import { addRelic } from './relic_state.js';
+import { discover } from './player_memory.js';
 
 export const dialogueMemory = new Set();
 
@@ -20,8 +21,9 @@ export function hasMemory(flag) {
   return dialogueMemory.has(flag);
 }
 
-export function startSession(dialogue) {
+export function startSession(dialogue, npcId) {
   state.activeDialogue = dialogue;
+  if (npcId) discover('npcs', npcId);
 }
 
 export function endSession() {

--- a/scripts/info_panel.js
+++ b/scripts/info_panel.js
@@ -1,6 +1,7 @@
 import { getAllNpcs } from './npcInfo.js';
 import { loadEnemyInfo, getAllEnemies } from './enemyInfo.js';
 import { loadItemInfo, getAllItems } from './itemInfo.js';
+import { getDiscovered } from './player_memory.js';
 
 function createEntry(obj) {
   const row = document.createElement('div');
@@ -17,15 +18,51 @@ export async function updateInfoPanel() {
   if (!npcContainer || !enemyContainer || !itemContainer) return;
 
   npcContainer.innerHTML = '';
-  getAllNpcs().forEach(n => npcContainer.appendChild(createEntry(n)));
+  const seenNpcs = getDiscovered('npcs');
+  if (seenNpcs.length === 0) {
+    const msg = document.createElement('div');
+    msg.classList.add('info-empty');
+    msg.textContent = "You haven't met any NPCs yet.";
+    npcContainer.appendChild(msg);
+  } else {
+    const all = getAllNpcs();
+    seenNpcs.forEach(id => {
+      const data = all.find(n => n.id === id);
+      if (data) npcContainer.appendChild(createEntry(data));
+    });
+  }
 
   await loadEnemyInfo();
   enemyContainer.innerHTML = '';
-  getAllEnemies().forEach(e => enemyContainer.appendChild(createEntry(e)));
+  const seenEnemies = getDiscovered('enemies');
+  if (seenEnemies.length === 0) {
+    const msg = document.createElement('div');
+    msg.classList.add('info-empty');
+    msg.textContent = 'No enemies encountered yet.';
+    enemyContainer.appendChild(msg);
+  } else {
+    const all = getAllEnemies();
+    seenEnemies.forEach(id => {
+      const data = all.find(e => e.id === id);
+      if (data) enemyContainer.appendChild(createEntry(data));
+    });
+  }
 
   await loadItemInfo();
   itemContainer.innerHTML = '';
-  getAllItems().forEach(i => itemContainer.appendChild(createEntry(i)));
+  const seenItems = getDiscovered('items');
+  if (seenItems.length === 0) {
+    const msg = document.createElement('div');
+    msg.classList.add('info-empty');
+    msg.textContent = 'You have not collected any items yet.';
+    itemContainer.appendChild(msg);
+  } else {
+    const all = getAllItems();
+    seenItems.forEach(id => {
+      const data = all.find(i => i.id === id);
+      if (data) itemContainer.appendChild(createEntry(data));
+    });
+  }
 }
 
 function showTab(name) {

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -2,6 +2,7 @@ import { getItemData } from './item_loader.js';
 import { player } from './player.js';
 import { getItemBonuses } from './item_stats.js';
 import { unlockBlueprint } from './craft_state.js';
+import { discover } from './player_memory.js';
 
 export const inventory = [];
 
@@ -37,6 +38,7 @@ export function addItem(item) {
   if (existing) {
     if ((existing.quantity || 0) >= 99) return false;
     existing.quantity = Math.min(99, (existing.quantity || 0) + qty);
+    discover('items', parseItemId(item.id).baseId);
     document.dispatchEvent(new CustomEvent('inventoryUpdated'));
     return true;
   }
@@ -46,6 +48,7 @@ export function addItem(item) {
   if (item.id && item.id.startsWith('blueprint_')) {
     unlockBlueprint(item.id.replace('blueprint_', ''));
   }
+  discover('items', parseItemId(item.id).baseId);
   document.dispatchEvent(new CustomEvent('inventoryUpdated'));
   return true;
 }

--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -1,0 +1,50 @@
+const STORAGE_KEY = 'gridquest.memory';
+
+const memory = {
+  npcs: new Set(),
+  enemies: new Set(),
+  items: new Set(),
+};
+
+function loadMemory() {
+  const json = localStorage.getItem(STORAGE_KEY);
+  if (!json) return;
+  try {
+    const data = JSON.parse(json);
+    if (Array.isArray(data.npcs)) memory.npcs = new Set(data.npcs);
+    if (Array.isArray(data.enemies)) memory.enemies = new Set(data.enemies);
+    if (Array.isArray(data.items)) memory.items = new Set(data.items);
+  } catch {
+    // ignore
+  }
+}
+
+function saveMemory() {
+  const data = {
+    npcs: Array.from(memory.npcs),
+    enemies: Array.from(memory.enemies),
+    items: Array.from(memory.items),
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+
+loadMemory();
+
+export function discover(type, id) {
+  if (!id || !memory[type]) return;
+  if (!memory[type].has(id)) {
+    memory[type].add(id);
+    saveMemory();
+    document.dispatchEvent(
+      new CustomEvent('memoryUpdated', { detail: { type, id } })
+    );
+  }
+}
+
+export function hasDiscovered(type, id) {
+  return !!memory[type] && memory[type].has(id);
+}
+
+export function getDiscovered(type) {
+  return memory[type] ? Array.from(memory[type]) : [];
+}

--- a/style/main.css
+++ b/style/main.css
@@ -726,6 +726,13 @@ body {
   color: #555;
 }
 
+.info-empty {
+  text-align: center;
+  color: #666;
+  font-style: italic;
+  padding: 6px 0;
+}
+
 /* Settings UI */
 .settings-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- add `player_memory.js` to track discovered NPCs, enemies and items
- show only discovered entries in `info_panel.js`
- register NPC discovery in `dialogue_state.js`
- record enemy defeats and item pickups in their respective systems
- style empty states for the info panel

## Testing
- `node -e "require('./scripts/player_memory.js');"` *(fails: localStorage not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68473d21322083318f790e6a5bdce9c9