### PR TITLE
Add skills info panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,10 +52,12 @@
         <div class="info-tab-btn active" data-target="npcs">NPCs</div>
         <div class="info-tab-btn" data-target="enemies">Enemies</div>
         <div class="info-tab-btn" data-target="items">Items</div>
+        <div class="info-tab-btn" data-target="skills">Skills</div>
       </div>
       <div id="info-npcs" class="info-tab-content"></div>
       <div id="info-enemies" class="info-tab-content" style="display:none;"></div>
       <div id="info-items" class="info-tab-content" style="display:none;"></div>
+      <div id="info-skills" class="info-tab-content" style="display:none;"></div>
     </div>
   </div>
   <div id="settings-overlay" class="settings-overlay">

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -21,7 +21,7 @@ import { useDefensePotion } from './item_logic.js';
 import { updateInventoryUI } from './inventory_state.js';
 import { showDialogue } from './dialogueSystem.js';
 import { gameState } from './game_state.js';
-import { discover } from './player_memory.js';
+import { discover, discoverSkill } from './player_memory.js';
 import {
   setupTabs,
   updateStatusUI,
@@ -293,6 +293,7 @@ export async function startCombat(enemy, player) {
   async function handleAction(skill) {
     if (!playerTurn || playerHp <= 0 || enemyHp <= 0) return;
     log(`Player uses ${skill.name}`);
+    discoverSkill(skill.id);
     const result = skill.effect({
       damageEnemy,
       healPlayer,
@@ -432,6 +433,7 @@ export async function startCombat(enemy, player) {
 
     if (skill) {
       log(`${enemy.name} uses ${skill.name}`);
+      discoverSkill(skill.id);
       skill.effect({
         player,
         enemy,

--- a/scripts/info_panel.js
+++ b/scripts/info_panel.js
@@ -2,6 +2,7 @@ import { getAllNpcs } from './npcInfo.js';
 import { loadEnemyInfo, getAllEnemies } from './enemyInfo.js';
 import { loadItemInfo, getAllItems } from './itemInfo.js';
 import { getDiscovered } from './player_memory.js';
+import { getAllSkillsInfo } from './skillsInfo.js';
 
 function createEntry(obj) {
   const row = document.createElement('div');
@@ -11,11 +12,22 @@ function createEntry(obj) {
   return row;
 }
 
+function createSkillEntry(skill) {
+  const row = document.createElement('div');
+  row.classList.add('info-entry', 'skill-entry');
+  row.innerHTML = `
+    <strong>${skill.name}</strong>
+    <div class="desc">${skill.description}</div>
+    <div class="meta">${skill.type} - ${skill.origin}</div>`;
+  return row;
+}
+
 export async function updateInfoPanel() {
   const npcContainer = document.getElementById('info-npcs');
   const enemyContainer = document.getElementById('info-enemies');
   const itemContainer = document.getElementById('info-items');
-  if (!npcContainer || !enemyContainer || !itemContainer) return;
+  const skillContainer = document.getElementById('info-skills');
+  if (!npcContainer || !enemyContainer || !itemContainer || !skillContainer) return;
 
   npcContainer.innerHTML = '';
   const seenNpcs = getDiscovered('npcs');
@@ -63,6 +75,21 @@ export async function updateInfoPanel() {
       if (data) itemContainer.appendChild(createEntry(data));
     });
   }
+
+  skillContainer.innerHTML = '';
+  const seenSkills = getDiscovered('skills');
+  if (seenSkills.length === 0) {
+    const msg = document.createElement('div');
+    msg.classList.add('info-empty');
+    msg.textContent = 'No skills discovered yet.';
+    skillContainer.appendChild(msg);
+  } else {
+    const allSkills = getAllSkillsInfo();
+    seenSkills.forEach(id => {
+      const data = allSkills.find(s => s.id === id);
+      if (data) skillContainer.appendChild(createSkillEntry(data));
+    });
+  }
 }
 
 function showTab(name) {
@@ -74,6 +101,7 @@ function showTab(name) {
   document.getElementById('info-npcs').style.display = name === 'npcs' ? 'block' : 'none';
   document.getElementById('info-enemies').style.display = name === 'enemies' ? 'block' : 'none';
   document.getElementById('info-items').style.display = name === 'items' ? 'block' : 'none';
+  document.getElementById('info-skills').style.display = name === 'skills' ? 'block' : 'none';
 }
 
 export async function toggleInfoPanel() {

--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -4,6 +4,7 @@ const memory = {
   npcs: new Set(),
   enemies: new Set(),
   items: new Set(),
+  skills: new Set(),
 };
 
 function loadMemory() {
@@ -14,6 +15,7 @@ function loadMemory() {
     if (Array.isArray(data.npcs)) memory.npcs = new Set(data.npcs);
     if (Array.isArray(data.enemies)) memory.enemies = new Set(data.enemies);
     if (Array.isArray(data.items)) memory.items = new Set(data.items);
+    if (Array.isArray(data.skills)) memory.skills = new Set(data.skills);
   } catch {
     // ignore
   }
@@ -24,6 +26,7 @@ function saveMemory() {
     npcs: Array.from(memory.npcs),
     enemies: Array.from(memory.enemies),
     items: Array.from(memory.items),
+    skills: Array.from(memory.skills),
   };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 }
@@ -47,4 +50,8 @@ export function hasDiscovered(type, id) {
 
 export function getDiscovered(type) {
   return memory[type] ? Array.from(memory[type]) : [];
+}
+
+export function discoverSkill(id) {
+  discover('skills', id);
 }

--- a/scripts/skillsInfo.js
+++ b/scripts/skillsInfo.js
@@ -1,0 +1,53 @@
+import { getAllSkills as getPlayerSkills } from './skills.js';
+import { getAllEnemySkills } from './enemy_skills.js';
+import { getAllPassives } from './passive_skills.js';
+
+let skillInfoList = null;
+
+function buildList() {
+  if (skillInfoList) return skillInfoList;
+  skillInfoList = [];
+  const playerSkills = getPlayerSkills();
+  Object.values(playerSkills).forEach(s => {
+    skillInfoList.push({
+      id: s.id,
+      name: s.name,
+      description: s.description || '',
+      type: s.statuses || s.cleanse ? 'status' : 'active',
+      origin: 'player',
+    });
+  });
+  const enemySkills = getAllEnemySkills();
+  Object.values(enemySkills).forEach(s => {
+    skillInfoList.push({
+      id: s.id,
+      name: s.name,
+      description: s.description || '',
+      type: s.statuses || s.applies ? 'status' : 'active',
+      origin: 'enemy',
+    });
+  });
+  const passives = getAllPassives();
+  Object.values(passives).forEach(p => {
+    skillInfoList.push({
+      id: p.id,
+      name: p.name,
+      description: p.description || '',
+      type: 'passive',
+      origin: 'player',
+    });
+  });
+  return skillInfoList;
+}
+
+export function loadSkillInfo() {
+  return buildList();
+}
+
+export function getAllSkillsInfo() {
+  return buildList();
+}
+
+export function getSkillInfo(id) {
+  return buildList().find(s => s.id === id);
+}

--- a/style/main.css
+++ b/style/main.css
@@ -726,6 +726,15 @@ body {
   color: #555;
 }
 
+.skill-entry {
+  background: #eef6ff;
+}
+
+.skill-entry .meta {
+  font-size: 11px;
+  color: #336;
+}
+
 .info-empty {
   text-align: center;
   color: #666;


### PR DESCRIPTION
## Summary
- track discovered skills in `player_memory`
- show discovered skills in a new tab of the info panel
- import skill data from new `skillsInfo` module
- record skill use in combat for player and enemy
- style skill entries

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68473f320c748331b8d9a5653b580964