### PR TITLE
Add status info tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,11 +53,13 @@
         <div class="info-tab-btn" data-target="enemies">Enemies</div>
         <div class="info-tab-btn" data-target="items">Items</div>
         <div class="info-tab-btn" data-target="skills">Skills</div>
+        <div class="info-tab-btn" data-target="status">Status</div>
       </div>
       <div id="info-npcs" class="info-tab-content"></div>
       <div id="info-enemies" class="info-tab-content" style="display:none;"></div>
       <div id="info-items" class="info-tab-content" style="display:none;"></div>
       <div id="info-skills" class="info-tab-content" style="display:none;"></div>
+      <div id="info-status" class="info-tab-content" style="display:none;"></div>
     </div>
   </div>
   <div id="settings-overlay" class="settings-overlay">

--- a/scripts/info_panel.js
+++ b/scripts/info_panel.js
@@ -3,6 +3,7 @@ import { loadEnemyInfo, getAllEnemies } from './enemyInfo.js';
 import { loadItemInfo, getAllItems } from './itemInfo.js';
 import { getDiscovered } from './player_memory.js';
 import { getAllSkillsInfo } from './skillsInfo.js';
+import { getStatusMetadata } from './status_effects.js';
 
 function createEntry(obj) {
   const row = document.createElement('div');
@@ -22,12 +23,24 @@ function createSkillEntry(skill) {
   return row;
 }
 
+function createStatusEntry(effect) {
+  const row = document.createElement('div');
+  row.classList.add('info-entry', effect.type);
+  const durationLabel = effect.temporary ? 'Temporary' : 'Passive';
+  row.innerHTML = `
+    <strong>${effect.name}</strong>
+    <div class="desc">${effect.description}</div>
+    <div class="meta">${durationLabel}</div>`;
+  return row;
+}
+
 export async function updateInfoPanel() {
   const npcContainer = document.getElementById('info-npcs');
   const enemyContainer = document.getElementById('info-enemies');
   const itemContainer = document.getElementById('info-items');
   const skillContainer = document.getElementById('info-skills');
-  if (!npcContainer || !enemyContainer || !itemContainer || !skillContainer) return;
+  const statusContainer = document.getElementById('info-status');
+  if (!npcContainer || !enemyContainer || !itemContainer || !skillContainer || !statusContainer) return;
 
   npcContainer.innerHTML = '';
   const seenNpcs = getDiscovered('npcs');
@@ -90,6 +103,16 @@ export async function updateInfoPanel() {
       if (data) skillContainer.appendChild(createSkillEntry(data));
     });
   }
+
+  statusContainer.innerHTML = '';
+  const effects = getStatusMetadata();
+  const sorted = effects.sort((a, b) => {
+    if (a.type === b.type) return a.name.localeCompare(b.name);
+    return a.type === 'positive' ? -1 : 1;
+  });
+  sorted.forEach(eff => {
+    statusContainer.appendChild(createStatusEntry(eff));
+  });
 }
 
 function showTab(name) {
@@ -102,6 +125,7 @@ function showTab(name) {
   document.getElementById('info-enemies').style.display = name === 'enemies' ? 'block' : 'none';
   document.getElementById('info-items').style.display = name === 'items' ? 'block' : 'none';
   document.getElementById('info-skills').style.display = name === 'skills' ? 'block' : 'none';
+  document.getElementById('info-status').style.display = name === 'status' ? 'block' : 'none';
 }
 
 export async function toggleInfoPanel() {

--- a/scripts/status_effects.js
+++ b/scripts/status_effects.js
@@ -248,3 +248,13 @@ export function getStatusEffect(id) {
 export function getAllStatusEffects() {
   return statusEffects;
 }
+
+export function getStatusMetadata() {
+  return Object.values(statusEffects).map(e => ({
+    id: e.id,
+    name: e.name,
+    description: e.description,
+    type: e.type,
+    temporary: typeof e.duration === 'number',
+  }));
+}

--- a/style/main.css
+++ b/style/main.css
@@ -613,6 +613,14 @@ body {
   text-shadow: 0 0 4px rgba(179, 71, 255, 0.7);
 }
 
+.positive {
+  color: #2ecc71;
+}
+
+.negative {
+  color: #e74c3c;
+}
+
 .item-tooltip {
   position: absolute;
   background: rgba(0, 0, 0, 0.85);
@@ -724,6 +732,11 @@ body {
 .info-entry .desc {
   font-size: 12px;
   color: #555;
+}
+
+.info-entry .meta {
+  font-size: 11px;
+  color: #336;
 }
 
 .skill-entry {


### PR DESCRIPTION
## Summary
- add Status tab to info panel and list effects
- expose metadata of status effects
- style positive and negative entries
- add info-entry meta style and new tab in UI

## Testing
- `python3 -m http.server` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68474331e9e083318dc96428b15a3563