### PR TITLE
Add Lore tab support

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,12 +54,14 @@
         <div class="info-tab-btn" data-target="items">Items</div>
         <div class="info-tab-btn" data-target="skills">Skills</div>
         <div class="info-tab-btn" data-target="status">Status</div>
+        <div class="info-tab-btn" data-target="lore">Lore</div>
       </div>
       <div id="info-npcs" class="info-tab-content"></div>
       <div id="info-enemies" class="info-tab-content" style="display:none;"></div>
       <div id="info-items" class="info-tab-content" style="display:none;"></div>
       <div id="info-skills" class="info-tab-content" style="display:none;"></div>
       <div id="info-status" class="info-tab-content" style="display:none;"></div>
+      <div id="info-lore" class="info-tab-content" style="display:none;"></div>
     </div>
   </div>
   <div id="settings-overlay" class="settings-overlay">

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -1,7 +1,7 @@
 import { unlockBlueprint } from './craft_state.js';
 import { upgradeItem, rerollEnchantment } from './forge.js';
 import { addRelic } from './relic_state.js';
-import { discover } from './player_memory.js';
+import { discover, discoverLore as recordLore } from './player_memory.js';
 
 export const dialogueMemory = new Set();
 
@@ -47,5 +47,13 @@ export async function triggerReroll(id) {
 
 // Give a relic to the player
 export function giveRelic(id) {
-  if (id) addRelic(id);
+  if (id) {
+    addRelic(id);
+    recordLore(id);
+  }
+}
+
+// Unlock a lore entry
+export function discoverLore(id) {
+  if (id) recordLore(id);
 }

--- a/scripts/info_panel.js
+++ b/scripts/info_panel.js
@@ -4,6 +4,7 @@ import { loadItemInfo, getAllItems } from './itemInfo.js';
 import { getDiscovered } from './player_memory.js';
 import { getAllSkillsInfo } from './skillsInfo.js';
 import { getStatusMetadata } from './status_effects.js';
+import { getLoreEntries } from './lore_entries.js';
 
 function createEntry(obj) {
   const row = document.createElement('div');
@@ -40,7 +41,8 @@ export async function updateInfoPanel() {
   const itemContainer = document.getElementById('info-items');
   const skillContainer = document.getElementById('info-skills');
   const statusContainer = document.getElementById('info-status');
-  if (!npcContainer || !enemyContainer || !itemContainer || !skillContainer || !statusContainer) return;
+  const loreContainer = document.getElementById('info-lore');
+  if (!npcContainer || !enemyContainer || !itemContainer || !skillContainer || !statusContainer || !loreContainer) return;
 
   npcContainer.innerHTML = '';
   const seenNpcs = getDiscovered('npcs');
@@ -113,6 +115,26 @@ export async function updateInfoPanel() {
   sorted.forEach(eff => {
     statusContainer.appendChild(createStatusEntry(eff));
   });
+
+  loreContainer.innerHTML = '';
+  const seenLore = getDiscovered('lore');
+  if (seenLore.length === 0) {
+    const msg = document.createElement('div');
+    msg.classList.add('info-empty');
+    msg.textContent = 'No lore discovered yet.';
+    loreContainer.appendChild(msg);
+  } else {
+    const allLore = getLoreEntries();
+    seenLore.forEach(id => {
+      const data = allLore.find(l => l.id === id);
+      if (data) {
+        const row = document.createElement('div');
+        row.classList.add('info-entry', 'lore-entry');
+        row.innerHTML = `<strong>${data.title}</strong><div class="desc">${data.text}</div>`;
+        loreContainer.appendChild(row);
+      }
+    });
+  }
 }
 
 function showTab(name) {
@@ -126,6 +148,7 @@ function showTab(name) {
   document.getElementById('info-items').style.display = name === 'items' ? 'block' : 'none';
   document.getElementById('info-skills').style.display = name === 'skills' ? 'block' : 'none';
   document.getElementById('info-status').style.display = name === 'status' ? 'block' : 'none';
+  document.getElementById('info-lore').style.display = name === 'lore' ? 'block' : 'none';
 }
 
 export async function toggleInfoPanel() {

--- a/scripts/lore_entries.js
+++ b/scripts/lore_entries.js
@@ -1,0 +1,21 @@
+export const loreEntries = [
+  {
+    id: 'lorebound',
+    title: 'The Lorebound',
+    text: 'An ancient order sworn to preserve knowledge. Few remain today.'
+  },
+  {
+    id: 'goblin_tribes',
+    title: 'Goblin Tribes',
+    text: 'Scattered clans of goblins roam the wilds, each with their own customs.'
+  },
+  {
+    id: 'ancient_relics',
+    title: 'Ancient Relics',
+    text: 'Relics from forgotten wars lie buried across the realm, waiting to be claimed.'
+  }
+];
+
+export function getLoreEntries() {
+  return loreEntries;
+}

--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -5,6 +5,7 @@ const memory = {
   enemies: new Set(),
   items: new Set(),
   skills: new Set(),
+  lore: new Set(),
 };
 
 function loadMemory() {
@@ -16,6 +17,7 @@ function loadMemory() {
     if (Array.isArray(data.enemies)) memory.enemies = new Set(data.enemies);
     if (Array.isArray(data.items)) memory.items = new Set(data.items);
     if (Array.isArray(data.skills)) memory.skills = new Set(data.skills);
+    if (Array.isArray(data.lore)) memory.lore = new Set(data.lore);
   } catch {
     // ignore
   }
@@ -27,6 +29,7 @@ function saveMemory() {
     enemies: Array.from(memory.enemies),
     items: Array.from(memory.items),
     skills: Array.from(memory.skills),
+    lore: Array.from(memory.lore),
   };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 }
@@ -54,4 +57,8 @@ export function getDiscovered(type) {
 
 export function discoverSkill(id) {
   discover('skills', id);
+}
+
+export function discoverLore(id) {
+  discover('lore', id);
 }

--- a/style/main.css
+++ b/style/main.css
@@ -748,6 +748,15 @@ body {
   color: #336;
 }
 
+.lore-entry {
+  background: #fff8e1;
+}
+
+.lore-entry .desc {
+  font-size: 13px;
+  color: #444;
+}
+
 .info-empty {
   text-align: center;
   color: #666;


### PR DESCRIPTION
## Summary
- track discovered lore entries in player memory
- include Lore tab in info panel with entry rendering
- create a small set of example lore entries
- unlock lore from dialogue interactions and relic rewards
- style lore entries in info panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684745a3a00c8331a5373870297ff370