### PR TITLE
Add class trials and relic rewards

### DIFF
--- a/data/maps/map_alchemist.json
+++ b/data/maps/map_alchemist.json
@@ -1,0 +1,101 @@
+{
+  "name": "Alchemist Trial",
+  "environment": "lab",
+  "grid": [
+    [
+      {
+        "type": "D",
+        "target": "map01.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "E",
+        "enemyId": "zombie01"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "C"
+      },
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG"
+  ]
+}

--- a/data/maps/map_guardian.json
+++ b/data/maps/map_guardian.json
@@ -1,0 +1,101 @@
+{
+  "name": "Guardian Trial",
+  "environment": "crypt",
+  "grid": [
+    [
+      {
+        "type": "D",
+        "target": "map01.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "E",
+        "enemyId": "S"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "C"
+      },
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG"
+  ]
+}

--- a/data/maps/map_warrior.json
+++ b/data/maps/map_warrior.json
@@ -1,0 +1,101 @@
+{
+  "name": "Warrior Trial",
+  "environment": "arena",
+  "grid": [
+    [
+      {
+        "type": "D",
+        "target": "map01.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "E",
+        "enemyId": "B"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "C"
+      },
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG"
+  ]
+}

--- a/data/relics.json
+++ b/data/relics.json
@@ -8,5 +8,20 @@
     "name": "Defender's Emblem",
     "description": "An ancient badge that bolsters defense.",
     "bonuses": { "defense": 2 }
+  },
+  "warrior_sigil": {
+    "name": "Warrior Sigil",
+    "description": "Awarded for proving your strength in combat.",
+    "bonuses": { "attack": 2 }
+  },
+  "guardian_emblem": {
+    "name": "Guardian Emblem",
+    "description": "A token that reinforces protective instincts.",
+    "bonuses": { "defense": 2 }
+  },
+  "alchemist_catalyst": {
+    "name": "Alchemist Catalyst",
+    "description": "A mysterious powder that empowers concoctions.",
+    "bonuses": { "itemHealBonus": 1 }
   }
 }

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -1,6 +1,8 @@
 import { gameState } from './game_state.js';
 import { addItem } from './inventory.js';
 import { updateInventoryUI } from './inventory_state.js';
+import { addRelic } from './relic_state.js';
+import { discoverLore } from './player_memory.js';
 import { getItemData, loadItems } from './item_loader.js';
 import { increaseMaxHp } from './player.js';
 import { unlockSkillsFromItem } from './skills.js';
@@ -11,6 +13,18 @@ const chestContents = {
   'map02:8,12': { message: 'This chest was empty.' },
   'map02:15,15': { item: 'potion_of_health' },
   'map03:10,10': { item: 'health_amulet' },
+  'map_warrior:18,18': {
+    relic: 'warrior_sigil',
+    message: 'You obtained the Warrior Sigil!'
+  },
+  'map_guardian:18,18': {
+    relic: 'guardian_emblem',
+    message: 'You obtained the Guardian Emblem!'
+  },
+  'map_alchemist:18,18': {
+    relic: 'alchemist_catalyst',
+    message: 'You obtained the Alchemist Catalyst!'
+  }
 };
 
 export function isChestOpened(id) {
@@ -45,6 +59,10 @@ export async function openChest(id, player) {
       updateInventoryUI();
       unlockedSkills = unlockSkillsFromItem(config.item);
     }
+  }
+  if (config.relic) {
+    await addRelic(config.relic);
+    discoverLore(config.relic);
   }
   return { item, message: config.message || null, unlockedSkills };
 }

--- a/scripts/info_panel.js
+++ b/scripts/info_panel.js
@@ -59,7 +59,16 @@ export async function updateInfoPanel() {
   const statusContainer = document.getElementById('info-status');
   const loreContainer = document.getElementById('info-lore');
   const classContainer = document.getElementById('info-class');
-  if (!npcContainer || !enemyContainer || !itemContainer || !skillContainer || !statusContainer || !loreContainer || !classContainer) return;
+  if (
+    !npcContainer ||
+    !enemyContainer ||
+    !itemContainer ||
+    !skillContainer ||
+    !statusContainer ||
+    !loreContainer ||
+    !classContainer
+  )
+    return;
 
   npcContainer.innerHTML = '';
   const seenNpcs = getDiscovered('npcs');
@@ -70,8 +79,8 @@ export async function updateInfoPanel() {
     npcContainer.appendChild(msg);
   } else {
     const all = getAllNpcs();
-    seenNpcs.forEach(id => {
-      const data = all.find(n => n.id === id);
+    seenNpcs.forEach((id) => {
+      const data = all.find((n) => n.id === id);
       if (data) npcContainer.appendChild(createEntry(data));
     });
   }
@@ -86,8 +95,8 @@ export async function updateInfoPanel() {
     enemyContainer.appendChild(msg);
   } else {
     const all = getAllEnemies();
-    seenEnemies.forEach(id => {
-      const data = all.find(e => e.id === id);
+    seenEnemies.forEach((id) => {
+      const data = all.find((e) => e.id === id);
       if (data) enemyContainer.appendChild(createEntry(data));
     });
   }
@@ -102,8 +111,8 @@ export async function updateInfoPanel() {
     itemContainer.appendChild(msg);
   } else {
     const all = getAllItems();
-    seenItems.forEach(id => {
-      const data = all.find(i => i.id === id);
+    seenItems.forEach((id) => {
+      const data = all.find((i) => i.id === id);
       if (data) itemContainer.appendChild(createEntry(data));
     });
   }
@@ -117,8 +126,8 @@ export async function updateInfoPanel() {
     skillContainer.appendChild(msg);
   } else {
     const allSkills = getAllSkillsInfo();
-    seenSkills.forEach(id => {
-      const data = allSkills.find(s => s.id === id);
+    seenSkills.forEach((id) => {
+      const data = allSkills.find((s) => s.id === id);
       if (data) skillContainer.appendChild(createSkillEntry(data));
     });
   }
@@ -129,7 +138,7 @@ export async function updateInfoPanel() {
     if (a.type === b.type) return a.name.localeCompare(b.name);
     return a.type === 'positive' ? -1 : 1;
   });
-  sorted.forEach(eff => {
+  sorted.forEach((eff) => {
     statusContainer.appendChild(createStatusEntry(eff));
   });
 
@@ -142,8 +151,8 @@ export async function updateInfoPanel() {
     loreContainer.appendChild(msg);
   } else {
     const allLore = getLoreEntries();
-    seenLore.forEach(id => {
-      const data = allLore.find(l => l.id === id);
+    seenLore.forEach((id) => {
+      const data = allLore.find((l) => l.id === id);
       if (data) {
         const row = document.createElement('div');
         row.classList.add('info-entry', 'lore-entry');
@@ -156,7 +165,7 @@ export async function updateInfoPanel() {
   classContainer.innerHTML = '';
   const chosen = getChosenClass();
   const allClasses = getAllClasses();
-  allClasses.forEach(cls => {
+  allClasses.forEach((cls) => {
     const entry = createClassEntry(cls, cls.id === chosen);
     classContainer.appendChild(entry);
   });
@@ -164,17 +173,24 @@ export async function updateInfoPanel() {
 
 function showTab(name) {
   const tabs = document.querySelectorAll('#info-panel .info-tab-btn');
-  tabs.forEach(t => {
+  tabs.forEach((t) => {
     if (t.dataset.target === name) t.classList.add('active');
     else t.classList.remove('active');
   });
-  document.getElementById('info-npcs').style.display = name === 'npcs' ? 'block' : 'none';
-  document.getElementById('info-enemies').style.display = name === 'enemies' ? 'block' : 'none';
-  document.getElementById('info-items').style.display = name === 'items' ? 'block' : 'none';
-  document.getElementById('info-skills').style.display = name === 'skills' ? 'block' : 'none';
-  document.getElementById('info-status').style.display = name === 'status' ? 'block' : 'none';
-  document.getElementById('info-lore').style.display = name === 'lore' ? 'block' : 'none';
-  document.getElementById('info-class').style.display = name === 'class' ? 'block' : 'none';
+  document.getElementById('info-npcs').style.display =
+    name === 'npcs' ? 'block' : 'none';
+  document.getElementById('info-enemies').style.display =
+    name === 'enemies' ? 'block' : 'none';
+  document.getElementById('info-items').style.display =
+    name === 'items' ? 'block' : 'none';
+  document.getElementById('info-skills').style.display =
+    name === 'skills' ? 'block' : 'none';
+  document.getElementById('info-status').style.display =
+    name === 'status' ? 'block' : 'none';
+  document.getElementById('info-lore').style.display =
+    name === 'lore' ? 'block' : 'none';
+  document.getElementById('info-class').style.display =
+    name === 'class' ? 'block' : 'none';
 }
 
 export async function toggleInfoPanel() {
@@ -205,13 +221,24 @@ export function initInfoPanel() {
     panel.appendChild(div);
   }
   const buttons = document.querySelectorAll('#info-panel .info-tab-btn');
-  buttons.forEach(btn => {
+  buttons.forEach((btn) => {
     btn.addEventListener('click', () => showTab(btn.dataset.target));
   });
   const closeBtn = document.querySelector('#info-panel .close-btn');
   if (closeBtn) closeBtn.addEventListener('click', toggleInfoPanel);
   const overlay = document.getElementById('info-overlay');
-  if (overlay) overlay.addEventListener('click', e => {
-    if (e.target === overlay) toggleInfoPanel();
+  if (overlay)
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) toggleInfoPanel();
+    });
+  document.addEventListener('relicsUpdated', () => {
+    const ov = document.getElementById('info-overlay');
+    if (ov && ov.classList.contains('active')) updateInfoPanel();
+  });
+  document.addEventListener('memoryUpdated', (e) => {
+    if (e.detail.type === 'lore') {
+      const ov = document.getElementById('info-overlay');
+      if (ov && ov.classList.contains('active')) updateInfoPanel();
+    }
   });
 }

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -7,9 +7,9 @@ export function normalizeGrid(grid, size = 20) {
   const normalized = [];
   for (let y = 0; y < size; y++) {
     const row = grid[y] || [];
-    const paddedRow = row.slice(0, size).map(cell =>
-      typeof cell === 'string' ? { type: cell } : cell
-    );
+    const paddedRow = row
+      .slice(0, size)
+      .map((cell) => (typeof cell === 'string' ? { type: cell } : cell));
     for (let i = paddedRow.length; i < size; i++) {
       paddedRow.push({ type: 'G' });
     }
@@ -32,11 +32,11 @@ export async function loadMap(name) {
     throw err;
   }
   currentEnvironment = data.environment || 'clear';
-  currentGrid = data.grid.map(row => {
+  currentGrid = data.grid.map((row) => {
     if (typeof row === 'string') {
-      return row.split('').map(ch => ({ type: ch }));
+      return row.split('').map((ch) => ({ type: ch }));
     }
-    return row.map(cell => {
+    return row.map((cell) => {
       if (typeof cell === 'string') {
         return { type: cell };
       }
@@ -55,3 +55,10 @@ export function getCurrentEnvironment() {
   return currentEnvironment;
 }
 
+// After a class is chosen, send the player to that class's trial map
+document.addEventListener('classChosen', async (e) => {
+  const id = e?.detail?.id;
+  if (!id) return;
+  const { movePlayerTo } = await import('./map.js');
+  await movePlayerTo(`map_${id}`, { x: 1, y: 1 });
+});


### PR DESCRIPTION
## Summary
- add trial maps for Warrior, Guardian and Alchemist
- award class relics from new trial chests
- update map loader to send players to trials when class chosen
- refresh info panel when lore or relic is obtained

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npx prettier --write data/relics.json scripts/chest.js scripts/mapLoader.js scripts/info_panel.js data/maps/map_warrior.json data/maps/map_guardian.json data/maps/map_alchemist.json`

------
https://chatgpt.com/codex/tasks/task_e_68474d0bad4c8331b6bfdd5f8f5efec6