### PR TITLE
Fix inventory level variable conflict

### DIFF
--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -40,8 +40,8 @@ export async function updateInventoryUI() {
     }
     row.innerHTML = `<strong>${displayName}${qty}</strong><div class="desc">${item.description}</div>`;
     if (enchantId) row.classList.add('enchanted');
-    const level = getItemLevel(item.id);
-    if (level > 0) {
+    const upgradeLevel = getItemLevel(item.id);
+    if (upgradeLevel > 0) {
       row.classList.add('gear-upgraded');
     }
     row.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- fix syntax error from duplicate `level` variable declaration in `inventory_state.js`

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684755f24a848331a769b7158dbe6246