### PR TITLE
Add hub map and wandering shade

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -84,5 +84,16 @@
     "behavior": "cautious",
     "drops": [ { "item": "commander_badge", "quantity": 1 } ],
     "onDefeatMessage": "The commander falls. A silence settles over the hills."
+  },
+  "wandering_shade": {
+    "name": "Wandering Shade",
+    "hp": 55,
+    "xp": 10,
+    "description": "A spectral remnant drifting between realms.",
+    "intro": "A chill fills the air as a shadowy figure emerges!",
+    "portrait": "💮",
+    "skills": ["weaken"],
+    "behavior": "aggressive",
+    "drops": []
   }
 }

--- a/data/maps/map04.json
+++ b/data/maps/map04.json
@@ -1,0 +1,355 @@
+{
+  "name": "Central Hub",
+  "environment": "clear",
+  "grid": [
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "D",
+        "target": "map_warrior.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      "G",
+      "G",
+      "G",
+      {
+        "type": "E",
+        "enemyId": "wandering_shade"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      {
+        "type": "D",
+        "target": "map_alchemist.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "N",
+        "npc": "shade_sage"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "D",
+        "target": "map_mystic.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      }
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      "G",
+      "G",
+      "G"
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      "G",
+      "G",
+      "G"
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      "G",
+      "G",
+      "G"
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      {
+        "type": "W"
+      },
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "D",
+        "target": "map_guardian.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ]
+  ]
+}

--- a/data/maps/map_alchemist.json
+++ b/data/maps/map_alchemist.json
@@ -94,7 +94,11 @@
       {
         "type": "C"
       },
-      "G"
+      {
+        "type": "D",
+        "target": "map04.json",
+        "spawn": { "x": 10, "y": 10 }
+      }
     ],
     "GGGGGGGGGGGGGGGGGGGG"
   ]

--- a/data/maps/map_guardian.json
+++ b/data/maps/map_guardian.json
@@ -94,7 +94,11 @@
       {
         "type": "C"
       },
-      "G"
+      {
+        "type": "D",
+        "target": "map04.json",
+        "spawn": { "x": 10, "y": 10 }
+      }
     ],
     "GGGGGGGGGGGGGGGGGGGG"
   ]

--- a/data/maps/map_warrior.json
+++ b/data/maps/map_warrior.json
@@ -94,7 +94,11 @@
       {
         "type": "C"
       },
-      "G"
+      {
+        "type": "D",
+        "target": "map04.json",
+        "spawn": { "x": 10, "y": 10 }
+      }
     ],
     "GGGGGGGGGGGGGGGGGGGG"
   ]

--- a/scripts/lore_entries.js
+++ b/scripts/lore_entries.js
@@ -13,6 +13,11 @@ export const loreEntries = [
     id: 'ancient_relics',
     title: 'Ancient Relics',
     text: 'Relics from forgotten wars lie buried across the realm, waiting to be claimed.'
+  },
+  {
+    id: 'hub_origins',
+    title: 'Origins of the Hub',
+    text: 'Legends tell of a nexus binding the paths of aspiring heroes.'
   }
 ];
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -22,6 +22,7 @@ import * as goblinQuestGiver from './npc/goblin_quest_giver.js';
 import * as arvalin from './npc/arvalin.js';
 import * as grindle from './npc/grindle.js';
 import * as forgeNpc from './npc/forge_npc.js';
+import * as shadeSage from './npc/shade_sage.js';
 import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
@@ -43,7 +44,8 @@ const npcModules = {
   goblinQuestGiver,
   arvalin,
   grindle,
-  forgeNpc
+  forgeNpc,
+  shadeSage
 };
 
 let hpDisplay;

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -62,3 +62,9 @@ document.addEventListener('classChosen', async (e) => {
   const { movePlayerTo } = await import('./map.js');
   await movePlayerTo(`map_${id}`, { x: 1, y: 1 });
 });
+
+// When a trial is completed, send the player back to the central hub
+document.addEventListener('exitTrial', async () => {
+  const { movePlayerTo } = await import('./map.js');
+  await movePlayerTo('map04', { x: 10, y: 10 });
+});

--- a/scripts/npc/shade_sage.js
+++ b/scripts/npc/shade_sage.js
@@ -1,0 +1,6 @@
+import { startDialogueTree } from '../dialogueSystem.js';
+import { shadeSageDialogue } from '../npc_dialogues/shade_sage_dialogue.js';
+
+export function interact() {
+  startDialogueTree(shadeSageDialogue);
+}

--- a/scripts/npcInfo.js
+++ b/scripts/npcInfo.js
@@ -4,7 +4,8 @@ export const npcInfoList = [
   { id: 'goblin_quest_giver', name: 'Goblin Trader', description: 'Trades goblin gear for mysterious rewards.' },
   { id: 'arvalin', name: 'Arvalin', description: 'A scholar fascinated by cursed artifacts.' },
   { id: 'grindle', name: 'Grindle', description: 'A gruff craftsman skilled in forging.' },
-  { id: 'forge_npc', name: 'Forge Master', description: 'Offers upgrades and rerolls for equipment.' }
+  { id: 'forge_npc', name: 'Forge Master', description: 'Offers upgrades and rerolls for equipment.' },
+  { id: 'shade_sage', name: 'Shade Sage', description: 'A mysterious figure lingering in the hub.' }
 ];
 
 export function getAllNpcs() {

--- a/scripts/npc_dialogues/shade_sage_dialogue.js
+++ b/scripts/npc_dialogues/shade_sage_dialogue.js
@@ -1,0 +1,22 @@
+export const shadeSageDialogue = [
+  {
+    text: "...A whisper on the wind. Few find this place.",
+    options: [
+      { label: "Who are you?", goto: 1 },
+      { label: "I'll be going.", goto: null }
+    ]
+  },
+  {
+    text: "Names fade like mist. Seek the trials, and the hub will reveal more.",
+    options: [
+      { label: "What is this hub?", goto: 2 },
+      { label: "Farewell.", goto: null }
+    ]
+  },
+  {
+    text: "It binds the paths of heroes. Remember what you learn here.",
+    options: [
+      { label: "I understand.", goto: null, onChoose: () => import('../dialogue_state.js').then(m => m.discoverLore('hub_origins')) }
+    ]
+  }
+];

--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -6,6 +6,7 @@ const memory = {
   items: new Set(),
   skills: new Set(),
   lore: new Set(),
+  maps: new Set(),
 };
 
 function loadMemory() {
@@ -18,6 +19,7 @@ function loadMemory() {
     if (Array.isArray(data.items)) memory.items = new Set(data.items);
     if (Array.isArray(data.skills)) memory.skills = new Set(data.skills);
     if (Array.isArray(data.lore)) memory.lore = new Set(data.lore);
+    if (Array.isArray(data.maps)) memory.maps = new Set(data.maps);
   } catch {
     // ignore
   }
@@ -30,6 +32,7 @@ function saveMemory() {
     items: Array.from(memory.items),
     skills: Array.from(memory.skills),
     lore: Array.from(memory.lore),
+    maps: Array.from(memory.maps),
   };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 }
@@ -61,4 +64,8 @@ export function discoverSkill(id) {
 
 export function discoverLore(id) {
   discover('lore', id);
+}
+
+export function discoverMap(id) {
+  discover('maps', id);
 }

--- a/scripts/router.js
+++ b/scripts/router.js
@@ -1,6 +1,7 @@
 import { loadMap as loadMapData } from './mapLoader.js';
 import { renderGrid } from './grid.js';
 import { gameState } from './game_state.js';
+import { discoverMap } from './player_memory.js';
 
 let container = null;
 let player = null;
@@ -40,6 +41,7 @@ export async function loadMap(filename, spawnPoint) {
   const { grid, environment } = await loadMapData(name);
   gameState.currentMap = name;
   gameState.environment = environment;
+  discoverMap(name);
   cols = grid[0].length;
   renderGrid(grid, container, environment);
 


### PR DESCRIPTION
## Summary
- create `map04.json` central hub with doors to trials
- add Wandering Shade enemy
- connect trial maps back to the hub
- new Shade Sage NPC with lore dialogue
- track visited maps and record map visits
- support hub transitions and map discovery

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475bf9c8d083318564f3215af55802