### PR TITLE
Add forked path region with branching

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -95,5 +95,27 @@
     "skills": ["weaken"],
     "behavior": "aggressive",
     "drops": []
+  },
+  "stone_beetle": {
+    "name": "Stone Beetle",
+    "hp": 70,
+    "xp": 12,
+    "description": "A heavy-shelled insect that rumbles with each step.",
+    "intro": "Stones crack as a massive beetle scuttles toward you!",
+    "portrait": "🐞",
+    "skills": ["strike"],
+    "behavior": "aggressive",
+    "drops": []
+  },
+  "phantom_mage": {
+    "name": "Phantom Mage",
+    "hp": 60,
+    "xp": 12,
+    "description": "A ghostly spellcaster muttering forgotten words.",
+    "intro": "The air grows cold as a phantom mage materializes!",
+    "portrait": "👻",
+    "skills": ["weaken"],
+    "behavior": "aggressive",
+    "drops": []
   }
 }

--- a/data/items.json
+++ b/data/items.json
@@ -2,6 +2,7 @@
   "mysterious_key": { "name": "Mysterious Key", "description": "It hums faintly." },
   "rusty_key": { "name": "Rusty Key", "description": "Old and corroded, but it might still work." },
   "silver_key": { "name": "Silver Key", "description": "Shines with a dull luster." },
+  "forked_key": { "name": "Forked Key", "description": "Opens a chest at the crossroads." },
   "potion_of_health": { "name": "Potion of Health", "description": "Increases maximum health permanently." },
   "ancient_scroll": { "name": "Ancient Scroll", "description": "Faded text hints at forgotten lore." },
   "mysterious_token": {

--- a/data/maps/map04.json
+++ b/data/maps/map04.json
@@ -321,7 +321,35 @@
       "G"
     ],
     "GGGGGGGGGGGGGGGGGGGG",
-    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "D",
+        "target": "map05.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
     [
       "G",
       "G",

--- a/data/maps/map05.json
+++ b/data/maps/map05.json
@@ -1,0 +1,165 @@
+{
+  "name": "Forked Pass",
+  "environment": "clear",
+  "grid": [
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "D",
+        "target": "map04.json",
+        "spawn": {
+          "x": 10,
+          "y": 18
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "C",
+        "key": "forked_key",
+        "consumeItem": true
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "N",
+        "npc": "fork_guide"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      {
+        "type": "E",
+        "enemyId": "stone_beetle"
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "E",
+        "enemyId": "phantom_mage"
+      },
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "D",
+        "target": "map06_left.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "D",
+        "target": "map06_right.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      },
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    "GGGGGGGGGGGGGGGGGGGG"
+  ]
+}

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -12,6 +12,7 @@ const chestContents = {
   'map02:8,12': { message: 'This chest was empty.' },
   'map02:15,15': { item: 'potion_of_health' },
   'map03:10,10': { item: 'health_amulet' },
+  'map05:10,9': { item: 'mysterious_key', message: 'The chest clicks open revealing a strange key.' },
   'map_warrior:18,18': {
     relic: 'warrior_sigil',
     message: 'You obtained the Warrior Sigil!'

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -1,7 +1,7 @@
 import { unlockBlueprint } from './craft_state.js';
 import { upgradeItem, rerollEnchantment } from './forge.js';
 import { addRelic } from './relic_state.js';
-import { discover, discoverLore as recordLore } from './player_memory.js';
+import { discover, discoverLore as recordLore, setForkChoice } from './player_memory.js';
 import { chooseClass as selectClass } from './class_state.js';
 import { player } from './player.js';
 
@@ -65,4 +65,8 @@ export function chooseClass(id) {
   if (id && selectClass(id)) {
     player.classId = id;
   }
+}
+
+export function chooseForkPath(path) {
+  if (path) setForkChoice(path);
 }

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -83,7 +83,16 @@ export async function handleTileInteraction(
     }
     case 'C': {
       const chestId = `${router.getCurrentMapName()}:${x},${y}`;
+      const required = tile.key || tile.requiresItem;
+      if (required && !hasItem(required)) {
+        showDialogue('The chest is locked.');
+        break;
+      }
       if (!isChestOpened(chestId)) {
+        if (required && tile.consumeItem) {
+          removeItem(required);
+          updateInventoryUI();
+        }
         const result = await openChest(chestId, player);
         if (result) {
           if (result.message) {

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -66,6 +66,14 @@ export function hasItem(nameOrId) {
   return getItemCount(nameOrId) > 0;
 }
 
+export function useForkedKey() {
+  if (hasItem('forked_key')) {
+    removeItem('forked_key');
+    return true;
+  }
+  return false;
+}
+
 export function removeItem(nameOrId, qty = 1) {
   if (isRelic(parseItemId(nameOrId).baseId)) return false;
   const item = inventory.find(

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -23,6 +23,7 @@ import * as arvalin from './npc/arvalin.js';
 import * as grindle from './npc/grindle.js';
 import * as forgeNpc from './npc/forge_npc.js';
 import * as shadeSage from './npc/shade_sage.js';
+import * as forkGuide from './npc/fork_guide.js';
 import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
@@ -45,7 +46,8 @@ const npcModules = {
   arvalin,
   grindle,
   forgeNpc,
-  shadeSage
+  shadeSage,
+  forkGuide
 };
 
 let hpDisplay;

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -68,3 +68,18 @@ document.addEventListener('exitTrial', async () => {
   const { movePlayerTo } = await import('./map.js');
   await movePlayerTo('map04', { x: 10, y: 10 });
 });
+
+document.addEventListener('goFork', async () => {
+  const { movePlayerTo } = await import('./map.js');
+  await movePlayerTo('map05', { x: 1, y: 1 });
+});
+
+document.addEventListener('goLeftPath', async () => {
+  const { movePlayerTo } = await import('./map.js');
+  await movePlayerTo('map06_left', { x: 1, y: 1 });
+});
+
+document.addEventListener('goRightPath', async () => {
+  const { movePlayerTo } = await import('./map.js');
+  await movePlayerTo('map06_right', { x: 1, y: 1 });
+});

--- a/scripts/npc/fork_guide.js
+++ b/scripts/npc/fork_guide.js
@@ -1,0 +1,6 @@
+import { startDialogueTree } from '../dialogueSystem.js';
+import { forkGuideDialogue } from '../npc_dialogues/fork_guide_dialogue.js';
+
+export function interact() {
+  startDialogueTree(forkGuideDialogue);
+}

--- a/scripts/npcInfo.js
+++ b/scripts/npcInfo.js
@@ -5,7 +5,8 @@ export const npcInfoList = [
   { id: 'arvalin', name: 'Arvalin', description: 'A scholar fascinated by cursed artifacts.' },
   { id: 'grindle', name: 'Grindle', description: 'A gruff craftsman skilled in forging.' },
   { id: 'forge_npc', name: 'Forge Master', description: 'Offers upgrades and rerolls for equipment.' },
-  { id: 'shade_sage', name: 'Shade Sage', description: 'A mysterious figure lingering in the hub.' }
+  { id: 'shade_sage', name: 'Shade Sage', description: 'A mysterious figure lingering in the hub.' },
+  { id: 'fork_guide', name: 'Pathseer', description: 'Guides travelers through the forked pass.' }
 ];
 
 export function getAllNpcs() {

--- a/scripts/npc_dialogues/fork_guide_dialogue.js
+++ b/scripts/npc_dialogues/fork_guide_dialogue.js
@@ -1,0 +1,25 @@
+export const forkGuideDialogue = [
+  {
+    text: "Two paths diverge ahead. Each will shape your fate.",
+    options: [
+      { label: "Tell me of the left path.", goto: 1 },
+      { label: "Tell me of the right path.", goto: 2 },
+      { label: "I'm ready to choose.", goto: 3 }
+    ]
+  },
+  {
+    text: "The left road winds through ancient stone ruins guarded by creatures of earth.",
+    options: [ { label: "Back", goto: 0 } ]
+  },
+  {
+    text: "The right road descends into haunted woods where phantoms lurk.",
+    options: [ { label: "Back", goto: 0 } ]
+  },
+  {
+    text: "Which way calls to you?",
+    options: [
+      { label: "I walk the left path.", goto: null, onChoose: () => import('../dialogue_state.js').then(m => m.chooseForkPath('left')) },
+      { label: "I walk the right path.", goto: null, onChoose: () => import('../dialogue_state.js').then(m => m.chooseForkPath('right')) }
+    ]
+  }
+];

--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -7,6 +7,7 @@ const memory = {
   skills: new Set(),
   lore: new Set(),
   maps: new Set(),
+  forkChoice: null,
 };
 
 function loadMemory() {
@@ -20,6 +21,7 @@ function loadMemory() {
     if (Array.isArray(data.skills)) memory.skills = new Set(data.skills);
     if (Array.isArray(data.lore)) memory.lore = new Set(data.lore);
     if (Array.isArray(data.maps)) memory.maps = new Set(data.maps);
+    if (typeof data.forkChoice === 'string') memory.forkChoice = data.forkChoice;
   } catch {
     // ignore
   }
@@ -33,6 +35,7 @@ function saveMemory() {
     skills: Array.from(memory.skills),
     lore: Array.from(memory.lore),
     maps: Array.from(memory.maps),
+    forkChoice: memory.forkChoice,
   };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 }
@@ -68,4 +71,13 @@ export function discoverLore(id) {
 
 export function discoverMap(id) {
   discover('maps', id);
+}
+
+export function setForkChoice(path) {
+  memory.forkChoice = path;
+  saveMemory();
+}
+
+export function getForkChoice() {
+  return memory.forkChoice;
 }


### PR DESCRIPTION
## Summary
- introduce map05 with left and right forks
- add stone_beetle and phantom_mage enemies
- extend player memory for fork choice
- implement locked chest logic requiring forked_key
- support fork path NPC and dialogues
- link maps through mapLoader and update central hub

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_68475ef2bb9c8331b0698c1c14b07e92