### PR TITLE
Add sealed tower exterior map and puzzle

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -151,6 +151,17 @@
     "behavior": "aggressive",
     "drops": []
   },
+  "relic_guardian": {
+    "name": "Relic Guardian",
+    "hp": 120,
+    "xp": 20,
+    "description": "An ancient construct protecting forgotten treasures.",
+    "intro": "Stone grinds as the relic guardian awakens!",
+    "portrait": "🛡️",
+    "skills": ["strike", "weaken"],
+    "behavior": "aggressive",
+    "drops": []
+  },
   "shadow_pyromancer": {
     "name": "Shadow Pyromancer",
     "hp": 80,

--- a/data/maps/map08.json
+++ b/data/maps/map08.json
@@ -1,0 +1,26 @@
+{
+  "name": "Sealed Approach",
+  "environment": "night",
+  "grid": [
+    [ { "type": "D", "target": "map07.json", "spawn": { "x": 10, "y": 18 } }, "G", "G", "G", "G", "G", "G", "G", "G", "G", "G", "G", "G", "G", "G", "G", "G", "G", "G", "G" ],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    ["G","G","G","G","G","G","G","G","G","G", {"type":"N","npc":"lore_statue"}, "G","G","G","G","G","G","G","G","G"],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    ["G","G","G","G","G","G","G","G","G","G", {"type":"E","enemyId":"relic_guardian"}, "G","G","G","G","G","G","G","G","G"],
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGGG1GGGGGGGGGG",
+    "GGGGGGGGGG2GGGGGGGGGG",
+    "GGGGGGGGGG3GGGGGGGGGG",
+    "GGGGGGGGGGGGGGGGGGGG",
+    ["G","G","G","G","G","G","G","G","G","G", {"type":"D","target":"map09.json", "spawn": { "x": 1, "y": 1 } }, "G","G","G","G","G","G","G","G","G"]
+  ]
+}

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -92,3 +92,9 @@ export function arbiterDialogue() {
     showDialogue('Only those who walk both paths may claim the mirror\'s power.');
   }
 }
+
+export function loreStatue() {
+  showDialogue('Weathered runes speak of times long past.', () => {
+    discoverLore('before_the_seal');
+  });
+}

--- a/scripts/gameEngine.js
+++ b/scripts/gameEngine.js
@@ -2,6 +2,7 @@
 import { showDialogue } from './dialogueSystem.js';
 import { healFull } from './player.js';
 import { applyDamage } from './logic.js';
+import { stepSymbol } from './puzzle_state.js';
 
 /**
  * Applies effects based on the tile symbol the player stepped on.
@@ -10,6 +11,7 @@ import { applyDamage } from './logic.js';
  * @param {{hp:number,maxHp:number}} player
  */
 export function handleTileEffects(tileSymbol, player) {
+  stepSymbol(tileSymbol);
   if (tileSymbol === 't') {
     applyDamage(player, 1);
     showDialogue('A hidden snare cuts at your feet.');

--- a/scripts/lore_entries.js
+++ b/scripts/lore_entries.js
@@ -33,6 +33,11 @@ export const loreEntries = [
     id: 'two_flames_crossed',
     title: 'The Two Flames Crossed',
     text: 'Few manage to master both shadow and flame. Their convergence unveils hidden power.'
+  },
+  {
+    id: 'before_the_seal',
+    title: 'Before the Seal',
+    text: 'Records speak of the tower thriving before its gates were sealed by arcane dust.'
   }
 ];
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -27,6 +27,7 @@ import * as forkGuide from './npc/fork_guide.js';
 import * as watcher from './npc/watcher.js';
 import * as flamebound from './npc/flamebound.js';
 import * as arbiter from './npc/arbiter.js';
+import * as loreStatue from './npc/lore_statue.js';
 import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
@@ -53,7 +54,8 @@ const npcModules = {
   forkGuide,
   watcher,
   flamebound,
-  arbiter
+  arbiter,
+  loreStatue
 };
 
 let hpDisplay;

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -1,5 +1,11 @@
 import { showError } from './errorPrompt.js';
-import { markForkVisited, visitedBothForks } from './player_memory.js';
+import {
+  markForkVisited,
+  visitedBothForks,
+  hasSealingDust,
+  consumeSealingDust,
+  isSealPuzzleSolved
+} from './player_memory.js';
 import { showDialogue } from './dialogueSystem.js';
 
 let currentGrid = null;
@@ -21,6 +27,10 @@ export function normalizeGrid(grid, size = 20) {
 }
 
 export async function loadMap(name) {
+  if (name === 'map09' && !hasSealingDust() && !isSealPuzzleSolved()) {
+    showDialogue('A shimmering seal bars your way.');
+    return null;
+  }
   let data;
   try {
     const response = await fetch(`data/maps/${name}.json`);
@@ -32,6 +42,9 @@ export async function loadMap(name) {
     if (name === 'map06_right') markForkVisited('right');
     if (name === 'map07' && visitedBothForks()) {
       showDialogue('The air hums as the twin trials align.');
+    }
+    if (name === 'map09' && hasSealingDust()) {
+      consumeSealingDust();
     }
   } catch (err) {
     console.error(err);

--- a/scripts/npc/lore_statue.js
+++ b/scripts/npc/lore_statue.js
@@ -1,0 +1,5 @@
+import { loreStatue } from '../dialogue_state.js';
+
+export function interact() {
+  loreStatue();
+}

--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -9,6 +9,8 @@ const memory = {
   maps: new Set(),
   forkChoice: null,
   forksVisited: { left: false, right: false },
+  sealPuzzleSolved: false,
+  sealingDust: false,
 };
 
 function loadMemory() {
@@ -24,6 +26,8 @@ function loadMemory() {
     if (Array.isArray(data.maps)) memory.maps = new Set(data.maps);
     if (typeof data.forkChoice === 'string') memory.forkChoice = data.forkChoice;
     if (data.forksVisited) memory.forksVisited = { ...memory.forksVisited, ...data.forksVisited };
+    if (typeof data.sealPuzzleSolved === 'boolean') memory.sealPuzzleSolved = data.sealPuzzleSolved;
+    if (typeof data.sealingDust === 'boolean') memory.sealingDust = data.sealingDust;
   } catch {
     // ignore
   }
@@ -39,6 +43,8 @@ function saveMemory() {
     maps: Array.from(memory.maps),
     forkChoice: memory.forkChoice,
     forksVisited: memory.forksVisited,
+    sealPuzzleSolved: memory.sealPuzzleSolved,
+    sealingDust: memory.sealingDust,
   };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 }
@@ -94,4 +100,25 @@ export function markForkVisited(path) {
 
 export function visitedBothForks() {
   return memory.forksVisited.left && memory.forksVisited.right;
+}
+
+export function solveSealPuzzle() {
+  memory.sealPuzzleSolved = true;
+  memory.sealingDust = true;
+  saveMemory();
+}
+
+export function isSealPuzzleSolved() {
+  return memory.sealPuzzleSolved;
+}
+
+export function hasSealingDust() {
+  return memory.sealingDust;
+}
+
+export function consumeSealingDust() {
+  if (memory.sealingDust) {
+    memory.sealingDust = false;
+    saveMemory();
+  }
 }

--- a/scripts/puzzle_state.js
+++ b/scripts/puzzle_state.js
@@ -1,0 +1,18 @@
+const sequence = ['1','2','3'];
+const state = {
+  index: 0
+};
+import { solveSealPuzzle, isSealPuzzleSolved } from './player_memory.js';
+
+export function stepSymbol(symbol) {
+  if (isSealPuzzleSolved()) return;
+  const expected = sequence[state.index];
+  if (symbol === expected) {
+    state.index++;
+    if (state.index === sequence.length) {
+      solveSealPuzzle();
+    }
+  } else if (sequence.includes(symbol)) {
+    state.index = 0;
+  }
+}

--- a/scripts/router.js
+++ b/scripts/router.js
@@ -1,4 +1,4 @@
-import { loadMap as loadMapData } from './mapLoader.js';
+import { loadMap as loadMapData, getCurrentGrid } from './mapLoader.js';
 import { renderGrid } from './grid.js';
 import { gameState } from './game_state.js';
 import { discoverMap } from './player_memory.js';
@@ -37,8 +37,12 @@ export function init(gameContainer, playerObj) {
 
 export async function loadMap(filename, spawnPoint) {
   const name = filename.replace(/\.json$/, '');
+  const result = await loadMapData(name);
+  if (!result) {
+    return { grid: getCurrentGrid(), cols };
+  }
+  const { grid, environment } = result;
   currentMap = name;
-  const { grid, environment } = await loadMapData(name);
   gameState.currentMap = name;
   gameState.environment = environment;
   discoverMap(name);


### PR DESCRIPTION
## Summary
- create map08 with sealed tower approach, lore statue, puzzle tiles, and guardian enemy
- add relic_guardian enemy stats
- add lore entry "Before the Seal" and lore statue interaction
- track puzzle and sealing dust state in player memory
- implement step-based puzzle logic and tie into tile effects
- gate map09 behind puzzle completion
- load lore statue NPC

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68476803fe80833198c48eea5f794207