### PR TITLE
Add map12 rotating vault puzzle

### DIFF
--- a/data/maps/map12.json
+++ b/data/maps/map12.json
@@ -1,0 +1,1259 @@
+{
+  "name": "Rotating Vault",
+  "environment": "dusk",
+  "grid": [
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "E",
+        "enemyId": "goblin"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "rotate": "A"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "rotate": "B"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "C"
+      },
+      {
+        "type": "N",
+        "npc": "vaultkeeper"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "D",
+        "target": "map13.json",
+        "locked": true,
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "E",
+        "enemyId": "goblin"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "rotate": "C"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "rotate": "D"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N"
+      }
+    ],
+    [
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      },
+      {
+        "type": "N"
+      }
+    ]
+  ]
+}

--- a/data/relics.json
+++ b/data/relics.json
@@ -31,5 +31,10 @@
     "name": "Mirror Shard",
     "description": "Reflects the trials of shadow and flame, empowering the bearer.",
     "bonuses": { "attack": 1, "defense": 1 }
+  },
+  "compass_core": {
+    "name": "Compass Core",
+    "description": "A magnetized relic that expands your sight in haze.",
+    "bonuses": { "visibility": 3 }
   }
 }

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -12,7 +12,10 @@ const chestContents = {
   'map02:8,12': { message: 'This chest was empty.' },
   'map02:15,15': { item: 'potion_of_health' },
   'map03:10,10': { item: 'health_amulet' },
-  'map05:10,9': { item: 'mysterious_key', message: 'The chest clicks open revealing a strange key.' },
+  'map05:10,9': {
+    item: 'mysterious_key',
+    message: 'The chest clicks open revealing a strange key.'
+  },
   'map_warrior:18,18': {
     relic: 'warrior_sigil',
     message: 'You obtained the Warrior Sigil!'
@@ -24,6 +27,10 @@ const chestContents = {
   'map_alchemist:18,18': {
     relic: 'alchemist_catalyst',
     message: 'You obtained the Alchemist Catalyst!'
+  },
+  'map12:9,9': {
+    relic: 'compass_core',
+    message: 'You obtained the Compass Core!'
   }
 };
 

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -131,3 +131,9 @@ export function corruptionShrine() {
     clearCorruption();
   });
 }
+
+export function vaultkeeperHints() {
+  showDialogue(
+    'The floor obeys the sigils. Step upon them and the vault shall turn.'
+  );
+}

--- a/scripts/gameEngine.js
+++ b/scripts/gameEngine.js
@@ -4,6 +4,8 @@ import { healFull } from './player.js';
 import { applyDamage } from './logic.js';
 import { triggerDarkTrap, triggerFireTrap } from './trap_logic.js';
 import { stepSymbol } from './puzzle_state.js';
+import { triggerRotation } from './rotation_puzzle.js';
+import { getCurrentGrid } from './mapLoader.js';
 
 /**
  * Applies effects based on the tile symbol the player stepped on.
@@ -13,6 +15,11 @@ import { stepSymbol } from './puzzle_state.js';
  */
 export async function handleTileEffects(tileSymbol, player, x, y) {
   await stepSymbol(tileSymbol);
+  const grid = getCurrentGrid();
+  const tile = grid?.[y]?.[x];
+  if (tile && tile.rotate) {
+    triggerRotation(tile.rotate);
+  }
   if (tileSymbol === 't') {
     triggerDarkTrap(player, applyDamage, showDialogue, x, y);
   } else if (tileSymbol === 'T') {

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -10,6 +10,7 @@ import { showDialogue } from './dialogueSystem.js';
 import { getAllSkills, unlockSkill } from './skills.js';
 import * as router from './router.js';
 import { gameState } from './game_state.js';
+import { triggerRotation } from './rotation_puzzle.js';
 
 /**
  * Handles double click interactions on tiles.
@@ -47,13 +48,16 @@ export async function handleTileInteraction(
       }
       const targetMap = tile.target;
       if (required === 'commander_badge') {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
           showDialogue('Your commander badge unlocks the way.', async () => {
             if (tile.consumeItem) {
               removeItem(required);
               updateInventoryUI();
             }
-            const { cols: newCols } = await router.loadMap(targetMap, tile.spawn);
+            const { cols: newCols } = await router.loadMap(
+              targetMap,
+              tile.spawn
+            );
             resolve(newCols);
           });
         });
@@ -102,7 +106,7 @@ export async function handleTileInteraction(
             showDialogue(`You obtained ${result.item.name}!`);
           }
           if (Array.isArray(result.unlockedSkills)) {
-            result.unlockedSkills.forEach(id => {
+            result.unlockedSkills.forEach((id) => {
               const skill = getAllSkills()[id];
               if (skill) {
                 showDialogue(`You've learned a new skill: ${skill.name}!`);
@@ -131,6 +135,12 @@ export async function handleTileInteraction(
       const npc = npcModules[npcId];
       if (npc && typeof npc.interact === 'function') {
         npc.interact();
+      }
+      break;
+    }
+    case 'G': {
+      if (tile.rotate) {
+        triggerRotation(tile.rotate);
       }
       break;
     }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -32,6 +32,7 @@ import * as loreStatue from './npc/lore_statue.js';
 import * as silentMonument from './npc/silent_monument.js';
 import * as breathlessNight from './npc/breathless_night.js';
 import * as corruptionShrine from './npc/corruption_shrine.js';
+import * as vaultkeeper from './npc/vaultkeeper.js';
 import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
@@ -62,7 +63,8 @@ const npcModules = {
   loreStatue,
   silentMonument,
   breathlessNight,
-  corruptionShrine
+  corruptionShrine,
+  vaultkeeper
 };
 
 let hpDisplay;

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -6,7 +6,8 @@ import {
   consumeSealingDust,
   isSealPuzzleSolved,
   isMirrorPuzzleSolved,
-  isCorruptionPuzzleSolved
+  isCorruptionPuzzleSolved,
+  isRotationPuzzleSolved
 } from './player_memory.js';
 import { showDialogue } from './dialogueSystem.js';
 
@@ -70,6 +71,19 @@ export async function loadMap(name) {
       for (const row of data.grid) {
         for (const cell of row) {
           if (cell && cell.type === 'D' && cell.target === 'map12.json') {
+            cell.locked = false;
+          }
+        }
+      }
+    }
+    if (name === 'map12' && isRotationPuzzleSolved()) {
+      for (const row of data.grid) {
+        for (const cell of row) {
+          if (
+            cell &&
+            cell.type === 'D' &&
+            (cell.target === 'map13.json' || cell.target === 'map12.json')
+          ) {
             cell.locked = false;
           }
         }

--- a/scripts/npc/vaultkeeper.js
+++ b/scripts/npc/vaultkeeper.js
@@ -1,0 +1,5 @@
+import { vaultkeeperHints } from '../dialogue_state.js';
+
+export function interact() {
+  vaultkeeperHints();
+}

--- a/scripts/npcInfo.js
+++ b/scripts/npcInfo.js
@@ -1,15 +1,64 @@
 export const npcInfoList = [
-  { id: 'eryndor', name: 'Eryndor', description: 'Last of the Lorebound, keeper of forgotten tales.' },
-  { id: 'lioran', name: 'Lioran', description: 'An eccentric mystic who speaks in riddles.' },
-  { id: 'goblin_quest_giver', name: 'Goblin Trader', description: 'Trades goblin gear for mysterious rewards.' },
-  { id: 'arvalin', name: 'Arvalin', description: 'A scholar fascinated by cursed artifacts.' },
-  { id: 'grindle', name: 'Grindle', description: 'A gruff craftsman skilled in forging.' },
-  { id: 'forge_npc', name: 'Forge Master', description: 'Offers upgrades and rerolls for equipment.' },
-  { id: 'shade_sage', name: 'Shade Sage', description: 'A mysterious figure lingering in the hub.' },
-  { id: 'fork_guide', name: 'Pathseer', description: 'Guides travelers through the forked pass.' },
-  { id: 'watcher', name: 'Watcher', description: 'A silent guardian hidden in the shadows.' },
-  { id: 'flamebound', name: 'Flamebound', description: 'A warrior devoted to the fires within the earth.' },
-  { id: 'arbiter', name: 'Arbiter', description: 'Keeper of balance between shadow and flame.' }
+  {
+    id: 'eryndor',
+    name: 'Eryndor',
+    description: 'Last of the Lorebound, keeper of forgotten tales.'
+  },
+  {
+    id: 'lioran',
+    name: 'Lioran',
+    description: 'An eccentric mystic who speaks in riddles.'
+  },
+  {
+    id: 'goblin_quest_giver',
+    name: 'Goblin Trader',
+    description: 'Trades goblin gear for mysterious rewards.'
+  },
+  {
+    id: 'arvalin',
+    name: 'Arvalin',
+    description: 'A scholar fascinated by cursed artifacts.'
+  },
+  {
+    id: 'grindle',
+    name: 'Grindle',
+    description: 'A gruff craftsman skilled in forging.'
+  },
+  {
+    id: 'forge_npc',
+    name: 'Forge Master',
+    description: 'Offers upgrades and rerolls for equipment.'
+  },
+  {
+    id: 'shade_sage',
+    name: 'Shade Sage',
+    description: 'A mysterious figure lingering in the hub.'
+  },
+  {
+    id: 'fork_guide',
+    name: 'Pathseer',
+    description: 'Guides travelers through the forked pass.'
+  },
+  {
+    id: 'watcher',
+    name: 'Watcher',
+    description: 'A silent guardian hidden in the shadows.'
+  },
+  {
+    id: 'flamebound',
+    name: 'Flamebound',
+    description: 'A warrior devoted to the fires within the earth.'
+  },
+  {
+    id: 'arbiter',
+    name: 'Arbiter',
+    description: 'Keeper of balance between shadow and flame.'
+  },
+  {
+    id: 'vaultkeeper',
+    name: 'Vaultkeeper',
+    description: 'Guardian of the rotating vault.'
+  }
 ];
 
 export function getAllNpcs() {

--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -12,7 +12,8 @@ const memory = {
   sealPuzzleSolved: false,
   sealingDust: false,
   mirrorPuzzleSolved: false,
-  corruptionPuzzleSolved: false
+  corruptionPuzzleSolved: false,
+  rotationPuzzleSolved: false
 };
 
 function loadMemory() {
@@ -38,6 +39,8 @@ function loadMemory() {
       memory.mirrorPuzzleSolved = data.mirrorPuzzleSolved;
     if (typeof data.corruptionPuzzleSolved === 'boolean')
       memory.corruptionPuzzleSolved = data.corruptionPuzzleSolved;
+    if (typeof data.rotationPuzzleSolved === 'boolean')
+      memory.rotationPuzzleSolved = data.rotationPuzzleSolved;
   } catch {
     // ignore
   }
@@ -56,7 +59,8 @@ function saveMemory() {
     sealPuzzleSolved: memory.sealPuzzleSolved,
     sealingDust: memory.sealingDust,
     mirrorPuzzleSolved: memory.mirrorPuzzleSolved,
-    corruptionPuzzleSolved: memory.corruptionPuzzleSolved
+    corruptionPuzzleSolved: memory.corruptionPuzzleSolved,
+    rotationPuzzleSolved: memory.rotationPuzzleSolved
   };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 }
@@ -151,4 +155,13 @@ export function solveCorruptionPuzzle() {
 
 export function isCorruptionPuzzleSolved() {
   return memory.corruptionPuzzleSolved;
+}
+
+export function solveRotationPuzzle() {
+  memory.rotationPuzzleSolved = true;
+  saveMemory();
+}
+
+export function isRotationPuzzleSolved() {
+  return memory.rotationPuzzleSolved;
 }

--- a/scripts/rotation_puzzle.js
+++ b/scripts/rotation_puzzle.js
@@ -1,0 +1,51 @@
+import { getCurrentGrid } from './mapLoader.js';
+import {
+  solveRotationPuzzle,
+  isRotationPuzzleSolved
+} from './player_memory.js';
+
+const state = {
+  A: 0,
+  B: 0,
+  C: 0,
+  D: 0
+};
+
+const QUADRANTS = {
+  A: { x: 1, y: 1 },
+  B: { x: 12, y: 1 },
+  C: { x: 1, y: 12 },
+  D: { x: 12, y: 12 }
+};
+const SIZE = 7;
+
+function rotateSubgrid(grid, sx, sy, size) {
+  const temp = [];
+  for (let y = 0; y < size; y++) {
+    temp[y] = [];
+    for (let x = 0; x < size; x++) {
+      temp[y][x] = { ...grid[sy + y][sx + x] };
+    }
+  }
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      grid[sy + x][sx + size - 1 - y] = temp[y][x];
+    }
+  }
+}
+
+export function triggerRotation(id) {
+  if (!QUADRANTS[id]) return;
+  const grid = getCurrentGrid();
+  if (!grid) return;
+  const { x, y } = QUADRANTS[id];
+  rotateSubgrid(grid, x, y, SIZE);
+  state[id] = (state[id] + 1) % 4;
+  if (Object.values(state).every((v) => v === 0)) {
+    if (!isRotationPuzzleSolved()) solveRotationPuzzle();
+  }
+}
+
+export function resetRotationPuzzle() {
+  state.A = state.B = state.C = state.D = 0;
+}


### PR DESCRIPTION
## Summary
- create new Rotating Vault map
- add compass_core relic and chest reward
- implement rotation puzzle logic and tracking
- trigger rotations on puzzle tiles
- unlock map13 exit when puzzle solved
- provide Vaultkeeper NPC hints

## Testing
- `npm test` *(fails: jest not found)*
- `npx prettier --write …`

------
https://chatgpt.com/codex/tasks/task_e_6847789922f083318ccd3c3d558b5f07