### PR TITLE
Add dream realm and relic slot upgrade

### DIFF
--- a/data/maps/map14.json
+++ b/data/maps/map14.json
@@ -1,0 +1,1134 @@
+{
+  "name": "Dream Nexus",
+  "environment": "dream",
+  "grid": [
+    [
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N",
+        "npc": "dream_echo1"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N",
+        "npc": "dream_echo2"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "N",
+        "npc": "second_voice"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "N",
+        "npc": "relic_chamber"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "glow": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G",
+        "flow": true
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "D",
+        "target": "map15.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        },
+        "locked": true
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      {
+        "type": "G"
+      },
+      "N"
+    ],
+    [
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N",
+      "N"
+    ]
+  ]
+}

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -11,6 +11,7 @@ import { showDialogue } from './dialogueSystem.js';
 import { chooseClass as selectClass } from './class_state.js';
 import { player } from './player.js';
 import { clearCorruption } from './corruption_state.js';
+import { unlockRelicSlot, unlockPortal15 } from './player_state.js';
 
 export const dialogueMemory = new Set();
 
@@ -139,13 +140,35 @@ export function vaultkeeperHints() {
 }
 
 export function mirrorBossIntro() {
-  showDialogue(
-    'The mirror stirs, reflecting every step you have taken.'
-  );
+  showDialogue('The mirror stirs, reflecting every step you have taken.');
 }
 
 export function loreObelisk() {
   showDialogue('Ancient glyphs shift with your reflection.', () => {
     discoverLore('reflections_deepself');
+  });
+}
+
+export function dreamEchoOne() {
+  showDialogue('A soft whisper floats by.', () => {
+    discoverLore('dream_fragment_one');
+  });
+}
+
+export function dreamEchoTwo() {
+  showDialogue('Shimmering motes form fleeting words.', () => {
+    discoverLore('dream_fragment_two');
+  });
+}
+
+export function relicChamber() {
+  showDialogue('The chamber resonates with ancient power.', () => {
+    unlockRelicSlot();
+  });
+}
+
+export function secondVoice() {
+  showDialogue('You face a reflection that is wholly your own.', () => {
+    unlockPortal15();
   });
 }

--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -7,8 +7,8 @@ export function renderGrid(grid, container, environment = 'clear') {
   container.style.gridTemplateColumns = `repeat(${cols}, 32px)`;
 
   Array.from(container.classList)
-    .filter(c => c.startsWith('env-'))
-    .forEach(c => container.classList.remove(c));
+    .filter((c) => c.startsWith('env-'))
+    .forEach((c) => container.classList.remove(c));
   if (environment) {
     container.classList.add(`env-${environment}`);
   }
@@ -55,6 +55,10 @@ export function renderGrid(grid, container, environment = 'clear') {
         default:
           div.classList.add('ground');
       }
+
+      if (cell.flow) div.classList.add('flowing');
+      if (cell.glow) div.classList.add('glowing');
+      if (typeof cell.opacity === 'number') div.style.opacity = cell.opacity;
 
       div.classList.add('fog-hidden');
 

--- a/scripts/lore_entries.js
+++ b/scripts/lore_entries.js
@@ -58,6 +58,16 @@ export const loreEntries = [
     id: 'reflections_deepself',
     title: 'Reflections of the Deepself',
     text: 'Those who confront the Whispered Mirror glimpse echoes of their inner truth.'
+  },
+  {
+    id: 'dream_fragment_one',
+    title: 'Fragment of Slumber',
+    text: 'Dreams weave a veil between heart and world within the Nexus.'
+  },
+  {
+    id: 'dream_fragment_two',
+    title: 'Echoes of the Inner Voice',
+    text: 'Whispers in the dreamscape reveal truths long hidden.'
   }
 ];
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -34,6 +34,10 @@ import * as breathlessNight from './npc/breathless_night.js';
 import * as corruptionShrine from './npc/corruption_shrine.js';
 import * as vaultkeeper from './npc/vaultkeeper.js';
 import * as loreObelisk from './npc/lore_obelisk.js';
+import * as dreamEcho1 from './npc/dream_echo1.js';
+import * as dreamEcho2 from './npc/dream_echo2.js';
+import * as relicChamber from './npc/relic_chamber.js';
+import * as secondVoice from './npc/second_voice.js';
 import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
@@ -66,7 +70,11 @@ const npcModules = {
   breathlessNight,
   corruptionShrine,
   vaultkeeper,
-  loreObelisk
+  loreObelisk,
+  dreamEcho1,
+  dreamEcho2,
+  relicChamber,
+  secondVoice
 };
 
 let hpDisplay;

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -11,6 +11,7 @@ import {
 } from './player_memory.js';
 import { isEnemyDefeated } from './enemy.js';
 import { showDialogue } from './dialogueSystem.js';
+import { isPortal15Unlocked } from './player_state.js';
 
 let currentGrid = null;
 let currentEnvironment = 'clear';
@@ -99,6 +100,15 @@ export async function loadMap(name) {
         }
       }
     }
+    if (name === 'map14' && isPortal15Unlocked()) {
+      for (const row of data.grid) {
+        for (const cell of row) {
+          if (cell && cell.type === 'D' && cell.target === 'map15.json') {
+            cell.locked = false;
+          }
+        }
+      }
+    }
   } catch (err) {
     console.error(err);
     showError(`Failed to load map ${name}`);
@@ -160,4 +170,15 @@ document.addEventListener('goRightPath', async () => {
 document.addEventListener('goConvergence', async () => {
   const { movePlayerTo } = await import('./map.js');
   await movePlayerTo('map07', { x: 1, y: 1 });
+});
+
+document.addEventListener('portal15Unlocked', () => {
+  if (!currentGrid) return;
+  for (const row of currentGrid) {
+    for (const cell of row) {
+      if (cell && cell.type === 'D' && cell.target === 'map15.json') {
+        cell.locked = false;
+      }
+    }
+  }
 });

--- a/scripts/npc/dream_echo1.js
+++ b/scripts/npc/dream_echo1.js
@@ -1,0 +1,5 @@
+import { dreamEchoOne } from '../dialogue_state.js';
+
+export function interact() {
+  dreamEchoOne();
+}

--- a/scripts/npc/dream_echo2.js
+++ b/scripts/npc/dream_echo2.js
@@ -1,0 +1,5 @@
+import { dreamEchoTwo } from '../dialogue_state.js';
+
+export function interact() {
+  dreamEchoTwo();
+}

--- a/scripts/npc/relic_chamber.js
+++ b/scripts/npc/relic_chamber.js
@@ -1,0 +1,5 @@
+import { relicChamber } from '../dialogue_state.js';
+
+export function interact() {
+  relicChamber();
+}

--- a/scripts/npc/second_voice.js
+++ b/scripts/npc/second_voice.js
@@ -1,0 +1,5 @@
+import { secondVoice } from '../dialogue_state.js';
+
+export function interact() {
+  secondVoice();
+}

--- a/scripts/player_state.js
+++ b/scripts/player_state.js
@@ -1,0 +1,67 @@
+const STORAGE_KEY = 'gridquest.player_state';
+
+const state = {
+  relicSlots: 1,
+  portal15Unlocked: false
+};
+
+function load() {
+  const json = localStorage.getItem(STORAGE_KEY);
+  if (!json) return;
+  try {
+    const data = JSON.parse(json);
+    if (typeof data.relicSlots === 'number') state.relicSlots = data.relicSlots;
+    if (typeof data.portal15Unlocked === 'boolean')
+      state.portal15Unlocked = data.portal15Unlocked;
+  } catch {
+    // ignore
+  }
+}
+
+function save() {
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      relicSlots: state.relicSlots,
+      portal15Unlocked: state.portal15Unlocked
+    })
+  );
+}
+
+load();
+
+export function getRelicSlots() {
+  return state.relicSlots;
+}
+
+export function setRelicSlots(count) {
+  if (typeof count === 'number' && count > 0) {
+    state.relicSlots = count;
+    save();
+    document.dispatchEvent(
+      new CustomEvent('relicSlotsChanged', {
+        detail: { count: state.relicSlots }
+      })
+    );
+  }
+}
+
+export function unlockRelicSlot() {
+  if (state.relicSlots < 2) {
+    setRelicSlots(2);
+  }
+}
+
+export function unlockPortal15() {
+  if (!state.portal15Unlocked) {
+    state.portal15Unlocked = true;
+    save();
+    document.dispatchEvent(new CustomEvent('portal15Unlocked'));
+  }
+}
+
+export function isPortal15Unlocked() {
+  return state.portal15Unlocked;
+}
+
+export const playerState = state;

--- a/scripts/relic_inventory.js
+++ b/scripts/relic_inventory.js
@@ -1,0 +1,70 @@
+import { getRelicData } from './relic_state.js';
+import { getRelicSlots } from './player_state.js';
+
+const STORAGE_KEY = 'gridquest.equipped_relics';
+
+const state = {
+  equipped: new Set()
+};
+
+function load() {
+  const json = localStorage.getItem(STORAGE_KEY);
+  if (!json) return;
+  try {
+    const arr = JSON.parse(json);
+    if (Array.isArray(arr)) state.equipped = new Set(arr);
+  } catch {
+    // ignore
+  }
+}
+
+function save() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(state.equipped)));
+}
+
+load();
+
+document.addEventListener('relicSlotsChanged', () => {
+  while (state.equipped.size > getRelicSlots()) {
+    const id = state.equipped.values().next().value;
+    state.equipped.delete(id);
+  }
+  save();
+  document.dispatchEvent(new CustomEvent('relicsUpdated'));
+});
+
+export function getEquippedRelics() {
+  return Array.from(state.equipped);
+}
+
+export function equipRelic(id) {
+  if (!id || state.equipped.has(id)) return false;
+  if (state.equipped.size >= getRelicSlots()) return false;
+  state.equipped.add(id);
+  save();
+  document.dispatchEvent(new CustomEvent('relicsUpdated'));
+  return true;
+}
+
+export function unequipRelic(id) {
+  if (state.equipped.has(id)) {
+    state.equipped.delete(id);
+    save();
+    document.dispatchEvent(new CustomEvent('relicsUpdated'));
+  }
+}
+
+export function getEquippedBonuses() {
+  const totals = {};
+  state.equipped.forEach((id) => {
+    const data = getRelicData(id);
+    if (data && data.bonuses) {
+      Object.entries(data.bonuses).forEach(([k, v]) => {
+        totals[k] = (totals[k] || 0) + v;
+      });
+    }
+  });
+  return totals;
+}
+
+export const relicInventory = state;

--- a/scripts/relic_state.js
+++ b/scripts/relic_state.js
@@ -72,9 +72,11 @@ export function removeRelic(id) {
   }
 }
 
+import { getEquippedRelics } from './relic_inventory.js';
+
 export function getRelicBonuses() {
   const totals = {};
-  relicState.owned.forEach((id) => {
+  getEquippedRelics().forEach((id) => {
     const data = relicState.data[id];
     if (data && data.bonuses) {
       Object.entries(data.bonuses).forEach(([k, v]) => {

--- a/style/main.css
+++ b/style/main.css
@@ -54,13 +54,21 @@ body {
 
 /* Responsive adjustments so the 20x20 grid fits on small screens */
 @media (max-width: 700px) {
-  #game-grid.scale-medium { transform: scale(0.8); }
-  #game-grid.scale-large { transform: scale(1); }
+  #game-grid.scale-medium {
+    transform: scale(0.8);
+  }
+  #game-grid.scale-large {
+    transform: scale(1);
+  }
 }
 
 @media (max-width: 500px) {
-  #game-grid.scale-medium { transform: scale(0.6); }
-  #game-grid.scale-large { transform: scale(0.8); }
+  #game-grid.scale-medium {
+    transform: scale(0.6);
+  }
+  #game-grid.scale-large {
+    transform: scale(0.8);
+  }
 }
 
 #game-grid.no-animations * {
@@ -127,7 +135,25 @@ body {
 }
 
 .tile.water {
-  background-color: #00BFFF;
+  background-color: #00bfff;
+}
+
+.tile.glowing {
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.7);
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
+}
+
+.tile.flowing {
+  animation: float 2s ease-in-out infinite;
 }
 
 #ui-bar {
@@ -211,7 +237,9 @@ body {
 #battle-overlay.battle-transition {
   opacity: 0;
   transform: scale(0.9);
-  transition: opacity 0.5s ease, transform 0.5s ease;
+  transition:
+    opacity 0.5s ease,
+    transform 0.5s ease;
 }
 
 #battle-overlay.battle-transition.active {
@@ -862,7 +890,7 @@ body {
   font-family: 'Courier New', Courier, monospace;
   position: relative;
   border: 2px solid #666;
-  box-shadow: 0 0 10px rgba(0,0,0,0.7);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
 }
 
 .dialogue-advance {
@@ -878,7 +906,9 @@ body {
 }
 
 @keyframes blink {
-  50% { opacity: 0; }
+  50% {
+    opacity: 0;
+  }
 }
 
 .dialogue-choices {
@@ -895,7 +925,9 @@ body {
   padding: 6px 12px;
   border-radius: 4px;
   cursor: pointer;
-  transition: background 0.2s, transform 0.2s;
+  transition:
+    background 0.2s,
+    transform 0.2s;
 }
 
 .dialogue-choice:hover,
@@ -905,39 +937,52 @@ body {
 }
 
 .env-fog::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background: repeating-linear-gradient(135deg, rgba(255,255,255,0.05) 0px, rgba(255,255,255,0.1) 2px, transparent 4px);
+  background: repeating-linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.05) 0px,
+    rgba(255, 255, 255, 0.1) 2px,
+    transparent 4px
+  );
   backdrop-filter: blur(1.5px);
   pointer-events: none;
   animation: fogPulse 4s infinite alternate;
 }
 
 @keyframes fogPulse {
-  from { opacity: 0.1; }
-  to { opacity: 0.25; }
+  from {
+    opacity: 0.1;
+  }
+  to {
+    opacity: 0.25;
+  }
 }
 
 .env-rain::before {
-  content: "/////";
+  content: '/////';
   position: absolute;
   font-size: 40px;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  color: rgba(173,216,230,0.2);
+  color: rgba(173, 216, 230, 0.2);
   animation: rainMove 0.6s linear infinite;
   pointer-events: none;
 }
 
 @keyframes rainMove {
-  0% { transform: translateY(-100%); }
-  100% { transform: translateY(100%); }
+  0% {
+    transform: translateY(-100%);
+  }
+  100% {
+    transform: translateY(100%);
+  }
 }
 
 .env-dusk {
@@ -956,23 +1001,41 @@ body {
 }
 
 .env-night::before {
-  content: "";
+  content: '';
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
   background-image:
-    radial-gradient(2px 2px at 20% 30%, rgba(255,255,255,0.8), transparent 40%),
-    radial-gradient(2px 2px at 80% 40%, rgba(255,255,255,0.8), transparent 40%),
-    radial-gradient(2px 2px at 30% 70%, rgba(255,255,255,0.8), transparent 40%),
-    radial-gradient(2px 2px at 70% 80%, rgba(255,255,255,0.8), transparent 40%);
+    radial-gradient(
+      2px 2px at 20% 30%,
+      rgba(255, 255, 255, 0.8),
+      transparent 40%
+    ),
+    radial-gradient(
+      2px 2px at 80% 40%,
+      rgba(255, 255, 255, 0.8),
+      transparent 40%
+    ),
+    radial-gradient(
+      2px 2px at 30% 70%,
+      rgba(255, 255, 255, 0.8),
+      transparent 40%
+    ),
+    radial-gradient(
+      2px 2px at 70% 80%,
+      rgba(255, 255, 255, 0.8),
+      transparent 40%
+    );
   animation: starTwinkle 3s linear infinite;
   pointer-events: none;
 }
 
 @keyframes starTwinkle {
-  50% { opacity: 0.5; }
+  50% {
+    opacity: 0.5;
+  }
 }
 
 /* Error Prompt */
@@ -1021,4 +1084,3 @@ body {
 .error-content .error-ok:hover {
   background: #555;
 }
-


### PR DESCRIPTION
## Summary
- create dreamlike `map14.json`
- add inner self dialogue and relic chamber logic
- support multiple relic slots with new player state and relic inventory
- allow unlocking portal to `map15.json`
- add two dream-related lore entries
- style glowing/floating tiles

## Testing
- `npm test` *(fails: jest not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_684780041ffc83319eb6cb2cfff8a17c