### PR TITLE
Add final approach map and ideology features

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -216,6 +216,17 @@
     "behavior": "aggressive",
     "drops": []
   },
+  "unmoving_shadow": {
+    "name": "Unmoving Shadow",
+    "hp": 80,
+    "xp": 0,
+    "description": "A dark figure that barely reacts to your presence.",
+    "intro": "A silent shadow looms, unmoving.",
+    "portrait": "🌑",
+    "skills": ["strike"],
+    "behavior": "passive",
+    "drops": []
+  },
   "mirror_clone": {
     "name": "Mirror Clone",
     "hp": 80,

--- a/data/maps/map16.json
+++ b/data/maps/map16.json
@@ -1,0 +1,670 @@
+{
+  "name": "Final Approach",
+  "environment": "fracture",
+  "grid": [
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "G",
+      "G",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "G",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "E",
+        "enemyId": "unmoving_shadow"
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "N",
+        "npc": "ember"
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "N",
+        "npc": "relic_chamber"
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "N",
+        "npc": "veil"
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      }
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "D",
+        "target": "map17.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        },
+        "locked": true
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "B",
+        "memoryType": {
+          "left": "B",
+          "right": "F"
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ]
+  ]
+}

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -1,13 +1,17 @@
 import { unlockBlueprint } from './craft_state.js';
 import { upgradeItem, rerollEnchantment } from './forge.js';
 import { addRelic } from './relic_state.js';
+import { addItem } from './inventory.js';
+import { loadItems, getItemData } from './item_loader.js';
 import {
   discover,
   discoverLore as recordLore,
   setForkChoice,
   visitedBothForks,
   getForkChoice,
-  recordEchoConversation
+  recordEchoConversation,
+  setIdeologyReward,
+  incrementLoreRelicCount
 } from './player_memory.js';
 import { showDialogue } from './dialogueSystem.js';
 import { chooseClass as selectClass } from './class_state.js';
@@ -62,6 +66,7 @@ export function giveRelic(id) {
   if (id) {
     addRelic(id);
     recordLore(id);
+    incrementLoreRelicCount();
   }
 }
 
@@ -207,5 +212,29 @@ export function echoMemory() {
   showDialogue('Fragments swirl, revealing what never came to pass.', () => {
     discoverLore('memory_not');
     recordEchoConversation('memory');
+  });
+}
+
+export async function emberDialogue() {
+  await loadItems();
+  const data = getItemData('mystic_dust') || {
+    name: 'Mystic Dust',
+    description: ''
+  };
+  showDialogue('Embers gather, offering you their spark.', () => {
+    addItem({ ...data, id: 'mystic_dust', quantity: 1 });
+    setIdeologyReward('ember');
+  });
+}
+
+export async function veilDialogue() {
+  await loadItems();
+  const data = getItemData('arcane_crystal') || {
+    name: 'Arcane Crystal',
+    description: ''
+  };
+  showDialogue('A cool hush surrounds you with hidden promise.', () => {
+    addItem({ ...data, id: 'arcane_crystal', quantity: 1 });
+    setIdeologyReward('veil');
   });
 }

--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -1,4 +1,5 @@
 import { getForkChoice } from './player_memory.js';
+import { player } from './player.js';
 
 export function renderGrid(grid, container, environment = 'clear') {
   container.innerHTML = '';
@@ -15,6 +16,7 @@ export function renderGrid(grid, container, environment = 'clear') {
 
   grid.forEach((row, y) => {
     const choice = getForkChoice();
+    const cls = player.classId;
     row.forEach((cell, x) => {
       const div = document.createElement('div');
       div.classList.add('tile');
@@ -24,6 +26,9 @@ export function renderGrid(grid, container, environment = 'clear') {
       let type = cell.type;
       if (cell.memoryType && choice && cell.memoryType[choice]) {
         type = cell.memoryType[choice];
+      }
+      if (cell.classType && cls && cell.classType[cls]) {
+        type = cell.classType[cls];
       }
 
       switch (type) {

--- a/scripts/lore_entries.js
+++ b/scripts/lore_entries.js
@@ -73,6 +73,11 @@ export const loreEntries = [
     id: 'memory_not',
     title: 'A Memory of What Was Not',
     text: 'Within the fracture you glimpse paths forever untraveled.'
+  },
+  {
+    id: 'pattern_end',
+    title: 'The Pattern at the End',
+    text: 'Fragments reveal how every choice weaves the final doorway.'
   }
 ];
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -42,6 +42,8 @@ import * as echoSelfShadow from './npc/echo_self_shadow.js';
 import * as echoSelfFlame from './npc/echo_self_flame.js';
 import * as echoSelfPeace from './npc/echo_self_peace.js';
 import * as echoMemory from './npc/echo_memory.js';
+import * as ember from './npc/ember.js';
+import * as veil from './npc/veil.js';
 import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
@@ -82,7 +84,9 @@ const npcModules = {
   echoSelfShadow,
   echoSelfFlame,
   echoSelfPeace,
-  echoMemory
+  echoMemory,
+  ember,
+  veil
 };
 
 let hpDisplay;

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -8,7 +8,9 @@ import {
   isMirrorPuzzleSolved,
   isCorruptionPuzzleSolved,
   isRotationPuzzleSolved,
-  getEchoConversationCount
+  getEchoConversationCount,
+  getIdeologyReward,
+  getLoreRelicCount
 } from './player_memory.js';
 import { isEnemyDefeated } from './enemy.js';
 import { showDialogue } from './dialogueSystem.js';
@@ -126,6 +128,15 @@ export async function loadMap(name) {
             if (getEchoConversationCount() < 3 || isEnemyDefeated('shadow_inversion')) {
               cell.type = 'G';
             }
+          }
+        }
+      }
+    }
+    if (name === 'map16' && getIdeologyReward() && getLoreRelicCount() >= 3) {
+      for (const row of data.grid) {
+        for (const cell of row) {
+          if (cell && cell.type === 'D' && cell.target === 'map17.json') {
+            cell.locked = false;
           }
         }
       }

--- a/scripts/npc/ember.js
+++ b/scripts/npc/ember.js
@@ -1,0 +1,5 @@
+import { emberDialogue } from '../dialogue_state.js';
+
+export function interact() {
+  emberDialogue();
+}

--- a/scripts/npc/veil.js
+++ b/scripts/npc/veil.js
@@ -1,0 +1,5 @@
+import { veilDialogue } from '../dialogue_state.js';
+
+export function interact() {
+  veilDialogue();
+}

--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -15,7 +15,9 @@ const memory = {
   corruptionPuzzleSolved: false,
   rotationPuzzleSolved: false,
   echoes: new Set(),
-  shadowFightTriggered: false
+  shadowFightTriggered: false,
+  ideologyReward: null,
+  loreRelicCount: 0
 };
 
 function loadMemory() {
@@ -46,6 +48,10 @@ function loadMemory() {
     if (Array.isArray(data.echoes)) memory.echoes = new Set(data.echoes);
     if (typeof data.shadowFightTriggered === 'boolean')
       memory.shadowFightTriggered = data.shadowFightTriggered;
+    if (typeof data.ideologyReward === 'string')
+      memory.ideologyReward = data.ideologyReward;
+    if (typeof data.loreRelicCount === 'number')
+      memory.loreRelicCount = data.loreRelicCount;
   } catch {
     // ignore
   }
@@ -67,7 +73,9 @@ function saveMemory() {
     corruptionPuzzleSolved: memory.corruptionPuzzleSolved,
     rotationPuzzleSolved: memory.rotationPuzzleSolved,
     echoes: Array.from(memory.echoes),
-    shadowFightTriggered: memory.shadowFightTriggered
+    shadowFightTriggered: memory.shadowFightTriggered,
+    ideologyReward: memory.ideologyReward,
+    loreRelicCount: memory.loreRelicCount
   };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 }
@@ -197,4 +205,22 @@ export function markShadowFight() {
 
 export function isShadowFightMarked() {
   return memory.shadowFightTriggered;
+}
+
+export function setIdeologyReward(id) {
+  memory.ideologyReward = id;
+  saveMemory();
+}
+
+export function getIdeologyReward() {
+  return memory.ideologyReward;
+}
+
+export function incrementLoreRelicCount() {
+  memory.loreRelicCount += 1;
+  saveMemory();
+}
+
+export function getLoreRelicCount() {
+  return memory.loreRelicCount;
 }


### PR DESCRIPTION
## Summary
- create `map16.json` as the Final Approach map
- support Ember and Veil ideology NPCs
- track ideology reward and lore relic count in memory
- include Unmoving Shadow enemy
- add end-game lore entry
- gate transition to map17 via memory checks
- render tiles based on player class

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68478718d210833190ee417e81a9eb8f