### PR TITLE
Update Krealer modules with titles and memory

### DIFF
--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -12,7 +12,8 @@ import {
   getForkChoice,
   recordEchoConversation,
   setIdeologyReward,
-  incrementLoreRelicCount
+  incrementLoreRelicCount,
+  setKrealerFlag
 } from './player_memory.js';
 import { getEchoConversationCount } from './player_memory.js';
 import { recordEnding } from './ending_manager.js';
@@ -34,6 +35,7 @@ export function getActiveDialogue() {
 
 export function setMemory(flag) {
   dialogueMemory.add(flag);
+  if (flag && flag.startsWith('flag_krealer')) setKrealerFlag(flag);
 }
 
 export function hasMemory(flag) {
@@ -255,57 +257,57 @@ export async function krealerDialogue() {
 
 export const krealer1Dialogue = [
   {
-    text: 'What do you fear most within yourself?',
-    options: [{ label: 'Contemplate', goto: null }]
+    text: 'Doubt is a weapon. Who truly commands your thoughts?',
+    options: [{ label: 'Proceed', goto: null, memoryFlag: 'flag_krealer1' }]
   }
 ];
 
 export const krealer2Dialogue = [
   {
-    text: 'Which memory keeps you awake at night?',
-    options: [{ label: 'Consider', goto: null }]
+    text: 'Trust is a mask you offer willingly. Whose face lies beneath?',
+    options: [{ label: 'Proceed', goto: null, memoryFlag: 'flag_krealer2' }]
   }
 ];
 
 export const krealer3Dialogue = [
   {
-    text: 'When did doubt first take root in your mind?',
-    options: [{ label: 'Reflect', goto: null }]
+    text: 'Feeling or thinking— which do you bury deepest?',
+    options: [{ label: 'Proceed', goto: null, memoryFlag: 'flag_krealer3' }]
   }
 ];
 
 export const krealer4Dialogue = [
   {
-    text: 'What truth about yourself is hardest to accept?',
-    options: [{ label: 'Acknowledge', goto: null }]
+    text: 'Every step is watched. Do you see yourself reflected?',
+    options: [{ label: 'Proceed', goto: null, memoryFlag: 'flag_krealer4' }]
   }
 ];
 
 export const krealer5Dialogue = [
   {
-    text: 'If you could erase one regret, what would it be?',
-    options: [{ label: 'Ponder', goto: null }]
+    text: 'Predict your rival and the game is won before it begins.',
+    options: [{ label: 'Proceed', goto: null, memoryFlag: 'flag_krealer5' }]
   }
 ];
 
 export const krealer6Dialogue = [
   {
-    text: 'What future possibility frightens you the most?',
-    options: [{ label: 'Muse', goto: null }]
+    text: 'Memories fade. Which one would you erase first?',
+    options: [{ label: 'Proceed', goto: null, memoryFlag: 'flag_krealer6' }]
   }
 ];
 
 export const krealer7Dialogue = [
   {
-    text: 'When you dream, who do you wish to become?',
-    options: [{ label: 'Envision', goto: null }]
+    text: 'Consequences blur when apathy reigns. Does choice matter to you?',
+    options: [{ label: 'Proceed', goto: null, memoryFlag: 'flag_krealer7' }]
   }
 ];
 
 export const krealer8Dialogue = [
   {
-    text: 'What would you sacrifice for perfect peace?',
-    options: [{ label: 'Deliberate', goto: null }]
+    text: 'You are the story you build. Which parts are real?',
+    options: [{ label: 'Proceed', goto: null, memoryFlag: 'flag_krealer8' }]
   }
 ];
 

--- a/scripts/npc/krealer1.js
+++ b/scripts/npc/krealer1.js
@@ -1,6 +1,8 @@
-import { startDialogueTree } from '../dialogueSystem.js';
+import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
 import { krealer1Dialogue } from '../dialogue_state.js';
+import { npcAppearance } from '../npc_data.js';
 
 export function interact() {
-  startDialogueTree(krealer1Dialogue);
+  const title = npcAppearance.krealer1.displayTitle || 'Krealer';
+  showDialogue(title, () => startDialogueTree(krealer1Dialogue));
 }

--- a/scripts/npc/krealer2.js
+++ b/scripts/npc/krealer2.js
@@ -1,6 +1,8 @@
-import { startDialogueTree } from '../dialogueSystem.js';
+import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
 import { krealer2Dialogue } from '../dialogue_state.js';
+import { npcAppearance } from '../npc_data.js';
 
 export function interact() {
-  startDialogueTree(krealer2Dialogue);
+  const title = npcAppearance.krealer2.displayTitle || 'Krealer';
+  showDialogue(title, () => startDialogueTree(krealer2Dialogue));
 }

--- a/scripts/npc/krealer3.js
+++ b/scripts/npc/krealer3.js
@@ -1,6 +1,8 @@
-import { startDialogueTree } from '../dialogueSystem.js';
+import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
 import { krealer3Dialogue } from '../dialogue_state.js';
+import { npcAppearance } from '../npc_data.js';
 
 export function interact() {
-  startDialogueTree(krealer3Dialogue);
+  const title = npcAppearance.krealer3.displayTitle || 'Krealer';
+  showDialogue(title, () => startDialogueTree(krealer3Dialogue));
 }

--- a/scripts/npc/krealer4.js
+++ b/scripts/npc/krealer4.js
@@ -1,6 +1,8 @@
-import { startDialogueTree } from '../dialogueSystem.js';
+import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
 import { krealer4Dialogue } from '../dialogue_state.js';
+import { npcAppearance } from '../npc_data.js';
 
 export function interact() {
-  startDialogueTree(krealer4Dialogue);
+  const title = npcAppearance.krealer4.displayTitle || 'Krealer';
+  showDialogue(title, () => startDialogueTree(krealer4Dialogue));
 }

--- a/scripts/npc/krealer5.js
+++ b/scripts/npc/krealer5.js
@@ -1,6 +1,8 @@
-import { startDialogueTree } from '../dialogueSystem.js';
+import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
 import { krealer5Dialogue } from '../dialogue_state.js';
+import { npcAppearance } from '../npc_data.js';
 
 export function interact() {
-  startDialogueTree(krealer5Dialogue);
+  const title = npcAppearance.krealer5.displayTitle || 'Krealer';
+  showDialogue(title, () => startDialogueTree(krealer5Dialogue));
 }

--- a/scripts/npc/krealer6.js
+++ b/scripts/npc/krealer6.js
@@ -1,6 +1,8 @@
-import { startDialogueTree } from '../dialogueSystem.js';
+import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
 import { krealer6Dialogue } from '../dialogue_state.js';
+import { npcAppearance } from '../npc_data.js';
 
 export function interact() {
-  startDialogueTree(krealer6Dialogue);
+  const title = npcAppearance.krealer6.displayTitle || 'Krealer';
+  showDialogue(title, () => startDialogueTree(krealer6Dialogue));
 }

--- a/scripts/npc/krealer7.js
+++ b/scripts/npc/krealer7.js
@@ -1,6 +1,8 @@
-import { startDialogueTree } from '../dialogueSystem.js';
+import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
 import { krealer7Dialogue } from '../dialogue_state.js';
+import { npcAppearance } from '../npc_data.js';
 
 export function interact() {
-  startDialogueTree(krealer7Dialogue);
+  const title = npcAppearance.krealer7.displayTitle || 'Krealer';
+  showDialogue(title, () => startDialogueTree(krealer7Dialogue));
 }

--- a/scripts/npc/krealer8.js
+++ b/scripts/npc/krealer8.js
@@ -1,6 +1,8 @@
-import { startDialogueTree } from '../dialogueSystem.js';
+import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
 import { krealer8Dialogue } from '../dialogue_state.js';
+import { npcAppearance } from '../npc_data.js';
 
 export function interact() {
-  startDialogueTree(krealer8Dialogue);
+  const title = npcAppearance.krealer8.displayTitle || 'Krealer';
+  showDialogue(title, () => startDialogueTree(krealer8Dialogue));
 }

--- a/scripts/npc_data.js
+++ b/scripts/npc_data.js
@@ -1,10 +1,50 @@
 export const npcAppearance = {
-  krealer1: { nameColor: '#ff9999', font: 'monospace', border: '#ff9999' },
-  krealer2: { nameColor: '#ffcc99', font: 'monospace', border: '#ffcc99' },
-  krealer3: { nameColor: '#ffff99', font: 'monospace', border: '#ffff99' },
-  krealer4: { nameColor: '#ccff99', font: 'monospace', border: '#ccff99' },
-  krealer5: { nameColor: '#99ffcc', font: 'monospace', border: '#99ffcc' },
-  krealer6: { nameColor: '#99ccff', font: 'monospace', border: '#99ccff' },
-  krealer7: { nameColor: '#cc99ff', font: 'monospace', border: '#cc99ff' },
-  krealer8: { nameColor: '#ff99cc', font: 'monospace', border: '#ff99cc' }
+  krealer1: {
+    nameColor: '#ff9999',
+    font: 'monospace',
+    border: '#ff9999',
+    displayTitle: 'Cognitive Warfare Training'
+  },
+  krealer2: {
+    nameColor: '#ffcc99',
+    font: 'monospace',
+    border: '#ffcc99',
+    displayTitle: 'Social Engineering Laboratory'
+  },
+  krealer3: {
+    nameColor: '#ffff99',
+    font: 'monospace',
+    border: '#ffff99',
+    displayTitle: 'Emotional Control Calibration'
+  },
+  krealer4: {
+    nameColor: '#ccff99',
+    font: 'monospace',
+    border: '#ccff99',
+    displayTitle: 'The Observation Deck'
+  },
+  krealer5: {
+    nameColor: '#99ffcc',
+    font: 'monospace',
+    border: '#99ffcc',
+    displayTitle: 'Strategic Scenario Simulations'
+  },
+  krealer6: {
+    nameColor: '#99ccff',
+    font: 'monospace',
+    border: '#99ccff',
+    displayTitle: 'The White Room Archive'
+  },
+  krealer7: {
+    nameColor: '#cc99ff',
+    font: 'monospace',
+    border: '#cc99ff',
+    displayTitle: 'Moral Apathy Drills'
+  },
+  krealer8: {
+    nameColor: '#ff99cc',
+    font: 'monospace',
+    border: '#ff99cc',
+    displayTitle: 'Persona Architecture'
+  }
 };

--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -7,6 +7,7 @@ const memory = {
   skills: new Set(),
   lore: new Set(),
   maps: new Set(),
+  krealerFlags: new Set(),
   forkChoice: null,
   forksVisited: { left: false, right: false },
   sealPuzzleSolved: false,
@@ -45,6 +46,8 @@ function loadMemory() {
       memory.corruptionPuzzleSolved = data.corruptionPuzzleSolved;
     if (typeof data.rotationPuzzleSolved === 'boolean')
       memory.rotationPuzzleSolved = data.rotationPuzzleSolved;
+    if (Array.isArray(data.krealerFlags))
+      memory.krealerFlags = new Set(data.krealerFlags);
     if (Array.isArray(data.echoes)) memory.echoes = new Set(data.echoes);
     if (typeof data.shadowFightTriggered === 'boolean')
       memory.shadowFightTriggered = data.shadowFightTriggered;
@@ -72,6 +75,7 @@ function saveMemory() {
     mirrorPuzzleSolved: memory.mirrorPuzzleSolved,
     corruptionPuzzleSolved: memory.corruptionPuzzleSolved,
     rotationPuzzleSolved: memory.rotationPuzzleSolved,
+    krealerFlags: Array.from(memory.krealerFlags),
     echoes: Array.from(memory.echoes),
     shadowFightTriggered: memory.shadowFightTriggered,
     ideologyReward: memory.ideologyReward,
@@ -187,7 +191,9 @@ export function recordEchoConversation(id) {
     memory.echoes.add(id);
     saveMemory();
     document.dispatchEvent(
-      new CustomEvent('echoesUpdated', { detail: { count: memory.echoes.size } })
+      new CustomEvent('echoesUpdated', {
+        detail: { count: memory.echoes.size }
+      })
     );
   }
 }
@@ -223,4 +229,16 @@ export function incrementLoreRelicCount() {
 
 export function getLoreRelicCount() {
   return memory.loreRelicCount;
+}
+
+export function setKrealerFlag(id) {
+  if (!id) return;
+  if (!memory.krealerFlags.has(id)) {
+    memory.krealerFlags.add(id);
+    saveMemory();
+  }
+}
+
+export function hasKrealerFlag(id) {
+  return memory.krealerFlags.has(id);
 }


### PR DESCRIPTION
## Summary
- give each Krealer NPC a unique `displayTitle`
- show the title before each Krealer dialogue
- rewrite all Krealer dialogues with thematic text
- persist Krealer interaction flags in `player_memory`
- store flags when dialogue choices are taken

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684811f5c1c08331b11bf004e9ec9dc7