### PR TITLE
Add Null Factor summary overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,14 @@
         ></div>
       </div>
     </div>
+    <div id="null-summary-overlay" class="null-summary-overlay">
+      <div class="null-summary-content">
+        <button class="close-btn">&times;</button>
+        <h2>Null Factor Summary</h2>
+        <div id="null-summary-message"></div>
+        <div id="null-summary-list"></div>
+      </div>
+    </div>
     <div id="settings-overlay" class="settings-overlay">
       <div class="settings-content">
         <button class="close-btn">&times;</button>

--- a/scripts/lore_entries.js
+++ b/scripts/lore_entries.js
@@ -98,6 +98,11 @@ export const loreEntries = [
     id: 'relic_resonance',
     title: 'Relic Resonance',
     text: 'Your gathered relics fueled the echo\'s power.'
+  },
+  {
+    id: 'null_factor_accessed',
+    title: 'Null Factor Accessed',
+    text: 'Your mind recalls every trial within the Null Factor.'
   }
 ];
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -56,6 +56,7 @@ import * as krealer6 from './npc/krealer6.js';
 import * as krealer7 from './npc/krealer7.js';
 import * as krealer8 from './npc/krealer8.js';
 import { initNullTab } from './ui_state.js';
+import { initNullSummary } from '../ui/null_summary.js';
 import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
@@ -211,6 +212,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   initSkillSystem(player);
   initPassiveSystem(player);
   initInfoPanel();
+  initNullSummary();
 
   try {
     await loadEnemyData();

--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -242,3 +242,21 @@ export function setKrealerFlag(id) {
 export function hasKrealerFlag(id) {
   return memory.krealerFlags.has(id);
 }
+
+export function getKrealerFlags() {
+  return Array.from(memory.krealerFlags);
+}
+
+export function allKrealerFlagsSet() {
+  const ids = [
+    'flag_krealer1',
+    'flag_krealer2',
+    'flag_krealer3',
+    'flag_krealer4',
+    'flag_krealer5',
+    'flag_krealer6',
+    'flag_krealer7',
+    'flag_krealer8'
+  ];
+  return ids.every(id => memory.krealerFlags.has(id));
+}

--- a/scripts/ui_state.js
+++ b/scripts/ui_state.js
@@ -3,6 +3,7 @@ import { hasCodeFile } from './inventory.js';
 import { getCurrentMapName } from './router.js';
 import { player } from './player.js';
 import { showDialogue } from './dialogueSystem.js';
+import { allKrealerFlagsSet, toggleNullSummary } from '../ui/null_summary.js';
 
 let returnMap = null;
 let returnPos = null;
@@ -12,6 +13,10 @@ export function initNullTab(tab) {
   tab.addEventListener('click', async () => {
     const current = getCurrentMapName();
     if (current !== 'null_room') {
+      if (allKrealerFlagsSet()) {
+        toggleNullSummary();
+        return;
+      }
       if (!hasCodeFile()) {
         showDialogue('Obtain code file to enter.');
         return;

--- a/style/main.css
+++ b/style/main.css
@@ -1089,3 +1089,63 @@ body {
 .error-content .error-ok:hover {
   background: #555;
 }
+
+/* Null Factor Summary */
+.null-summary-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 900;
+}
+
+.null-summary-overlay.active {
+  visibility: visible;
+  opacity: 1;
+}
+
+.null-summary-content {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 300px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  position: relative;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.null-summary-content .close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.null-summary-entry {
+  margin-bottom: 12px;
+}
+
+.null-summary-entry .question {
+  font-size: 14px;
+  margin-top: 4px;
+}
+
+.null-summary-entry .answer {
+  font-size: 13px;
+  color: #555;
+  margin-top: 2px;
+}

--- a/ui/null_summary.js
+++ b/ui/null_summary.js
@@ -1,0 +1,79 @@
+import { npcAppearance } from '../scripts/npc_data.js';
+import {
+  krealer1Dialogue,
+  krealer2Dialogue,
+  krealer3Dialogue,
+  krealer4Dialogue,
+  krealer5Dialogue,
+  krealer6Dialogue,
+  krealer7Dialogue,
+  krealer8Dialogue
+} from '../scripts/dialogue_state.js';
+import { hasKrealerFlag } from '../scripts/player_memory.js';
+
+const modules = [
+  { id: 'krealer1', flag: 'flag_krealer1', data: krealer1Dialogue[0] },
+  { id: 'krealer2', flag: 'flag_krealer2', data: krealer2Dialogue[0] },
+  { id: 'krealer3', flag: 'flag_krealer3', data: krealer3Dialogue[0] },
+  { id: 'krealer4', flag: 'flag_krealer4', data: krealer4Dialogue[0] },
+  { id: 'krealer5', flag: 'flag_krealer5', data: krealer5Dialogue[0] },
+  { id: 'krealer6', flag: 'flag_krealer6', data: krealer6Dialogue[0] },
+  { id: 'krealer7', flag: 'flag_krealer7', data: krealer7Dialogue[0] },
+  { id: 'krealer8', flag: 'flag_krealer8', data: krealer8Dialogue[0] }
+];
+
+export function allKrealerFlagsSet() {
+  return modules.every(m => hasKrealerFlag(m.flag));
+}
+
+export function getMissingModules() {
+  return modules.filter(m => !hasKrealerFlag(m.flag)).map(m => m.id);
+}
+
+export function updateNullSummary() {
+  const list = document.getElementById('null-summary-list');
+  const msg = document.getElementById('null-summary-message');
+  if (!list || !msg) return;
+  list.innerHTML = '';
+  const missing = modules.filter(m => !hasKrealerFlag(m.flag));
+  if (missing.length > 0) {
+    const names = missing
+      .map(m => npcAppearance[m.id].displayTitle)
+      .join(', ');
+    msg.textContent = `Modules remaining: ${names}`;
+    return;
+  }
+  msg.textContent = '';
+  modules.forEach(m => {
+    const row = document.createElement('div');
+    row.classList.add('null-summary-entry');
+    const title = npcAppearance[m.id].displayTitle || m.id;
+    const question = m.data.text;
+    const response = m.data.options && m.data.options[0]
+      ? m.data.options[0].label
+      : '';
+    row.innerHTML = `<strong>${title}</strong><div class="question">${question}</div><div class="answer">${response}</div>`;
+    list.appendChild(row);
+  });
+}
+
+export function toggleNullSummary() {
+  const overlay = document.getElementById('null-summary-overlay');
+  if (!overlay) return;
+  if (overlay.classList.contains('active')) {
+    overlay.classList.remove('active');
+  } else {
+    updateNullSummary();
+    overlay.classList.add('active');
+  }
+}
+
+export function initNullSummary() {
+  const overlay = document.getElementById('null-summary-overlay');
+  const closeBtn = overlay?.querySelector('.close-btn');
+  if (closeBtn) closeBtn.addEventListener('click', toggleNullSummary);
+  if (overlay)
+    overlay.addEventListener('click', e => {
+      if (e.target === overlay) toggleNullSummary();
+    });
+}


### PR DESCRIPTION
## Summary
- show summary of Krealer modules once all flags are met
- load flags via player memory and expose helper functions
- render panel through new `ui/null_summary.js`
- update Null Factor tab logic to open the summary
- include new lore entry for the accomplishment
- style and layout for Null Factor summary panel

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481a172340833198b094fee3501422