### PR TITLE
Update map02 with ruins and add Coren NPC

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -28,7 +28,7 @@
     ],
     "drops": [
       {
-        "item": "rotten_tooth",
+        "item": "bone_fragment",
         "quantity": 1
       }
     ]

--- a/data/maps/map02.json
+++ b/data/maps/map02.json
@@ -107,12 +107,19 @@
       "G",
       "G",
       "G",
-      "G",
+      {
+        "type": "G",
+        "opacity": 0.8
+      },
       {
         "type": "N",
-        "npc": "lioran"
+        "npc": "coren",
+        "glow": true
       },
-      "G",
+      {
+        "type": "G",
+        "opacity": 0.8
+      },
       "G",
       "G",
       "G",
@@ -136,13 +143,19 @@
       {
         "type": "T"
       },
+      "F",
+      "F",
       "G",
       "G",
       "G",
-      "G",
-      "G",
-      "G",
-      "G",
+      {
+        "type": "G",
+        "opacity": 0.8
+      },
+      {
+        "type": "G",
+        "opacity": 0.8
+      },
       "G",
       "G",
       "G",
@@ -164,8 +177,8 @@
         "type": "t"
       },
       "G",
-      "G",
-      "G",
+      "F",
+      "F",
       "G",
       "G",
       "G",
@@ -267,16 +280,20 @@
       "G",
       "G",
       {
-        "type": "W"
+        "type": "W",
+        "flow": true
       },
       {
-        "type": "W"
+        "type": "W",
+        "flow": true
       },
       {
-        "type": "W"
+        "type": "W",
+        "flow": true
       },
       {
-        "type": "W"
+        "type": "W",
+        "flow": true
       },
       "G",
       "G",

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -1,7 +1,7 @@
 import { gameState } from './game_state.js';
 import { addItem } from './inventory.js';
 import { updateInventoryUI } from './inventory_state.js';
-import { giveRelic } from './dialogue_state.js';
+import { giveRelic, setMemory } from './dialogue_state.js';
 import { getItemData, loadItems } from './item_loader.js';
 import { increaseMaxHp } from './player.js';
 import { unlockSkillsFromItem, unlockSkillsFromRelic } from './skills.js';
@@ -12,7 +12,10 @@ const chestContents = {
     message: 'Nestled within are a rusty key and a timeworn letter.'
   },
   'map02:5,5': { item: 'silver_key', message: 'You found a silver key.' },
-  'map02:8,12': { message: 'This chest was empty.' },
+  'map02:8,12': {
+    message: 'This chest was empty. A whisper stirs in your thoughts.',
+    memoryFlag: 'empty_chest_seen'
+  },
   'map02:15,15': { item: 'potion_of_health' },
   'map03:10,10': { item: 'health_amulet' },
   'map05:10,9': {
@@ -46,6 +49,9 @@ export async function openChest(id, player) {
   gameState.openedChests.add(id);
   await loadItems();
   const config = chestContents[id] || {};
+  if (config.memoryFlag) {
+    setMemory(config.memoryFlag);
+  }
   let item = null;
   let items = null;
   let unlockedSkills = [];

--- a/scripts/gameEngine.js
+++ b/scripts/gameEngine.js
@@ -17,15 +17,30 @@ export async function handleTileEffects(tileSymbol, player, x, y) {
   await stepSymbol(tileSymbol);
   const grid = getCurrentGrid();
   const tile = grid?.[y]?.[x];
+  const container = document.getElementById('game-grid');
+  const index = y * grid[0].length + x;
+  const tileEl = container?.children[index];
   if (tile && tile.rotate) {
     triggerRotation(tile.rotate);
   }
   if (tileSymbol === 't') {
     triggerDarkTrap(player, applyDamage, showDialogue, x, y);
+    if (tileEl) {
+      tileEl.classList.add('triggered');
+      setTimeout(() => tileEl.classList.remove('triggered'), 400);
+    }
   } else if (tileSymbol === 'T') {
     triggerFireTrap(player, applyDamage, showDialogue, x, y);
+    if (tileEl) {
+      tileEl.classList.add('triggered');
+      setTimeout(() => tileEl.classList.remove('triggered'), 400);
+    }
   } else if (tileSymbol === 'W') {
     healFull();
     showDialogue('The cool water rejuvenates you. HP fully restored.');
+    if (tileEl) {
+      tileEl.classList.add('ripple');
+      setTimeout(() => tileEl.classList.remove('ripple'), 800);
+    }
   }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -20,7 +20,7 @@ import { isMovementDisabled } from './movement.js';
 import { hasCodeFile, hasItem } from './inventory.js';
 import { movePlayerTo, spawnEnemy } from './map.js';
 import * as eryndor from './npc/eryndor.js';
-import * as lioran from './npc/lioran.js';
+import * as coren from './npc/coren.js';
 import * as goblinQuestGiver from './npc/goblin_quest_giver.js';
 import * as arvalin from './npc/arvalin.js';
 import * as grindle from './npc/grindle.js';
@@ -75,7 +75,7 @@ import {
 let isInBattle = false;
 const npcModules = {
   eryndor,
-  lioran,
+  coren,
   goblinQuestGiver,
   arvalin,
   grindle,
@@ -368,6 +368,9 @@ document.addEventListener('DOMContentLoaded', async () => {
           ) {
             completeQuest('scout_tracking');
           }
+        }
+        if (enemyId === 'zombie01') {
+          setMemory('flag_zombie_defeated');
         }
       }
     });

--- a/scripts/npc/coren.js
+++ b/scripts/npc/coren.js
@@ -1,0 +1,6 @@
+import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
+import { corenDialogue } from '../npc_dialogues/coren_dialogue.js';
+
+export function interact() {
+  showDialogue('Coren', () => startDialogueTree(corenDialogue));
+}

--- a/scripts/npcInfo.js
+++ b/scripts/npcInfo.js
@@ -10,6 +10,11 @@ export const npcInfoList = [
     description: 'An eccentric mystic who speaks in riddles.'
   },
   {
+    id: 'coren',
+    name: 'Coren',
+    description: 'A wary scout who still answers to his commander.'
+  },
+  {
     id: 'goblin_quest_giver',
     name: 'Goblin Trader',
     description: 'Trades goblin gear for mysterious rewards.'

--- a/scripts/npc_dialogues/coren_dialogue.js
+++ b/scripts/npc_dialogues/coren_dialogue.js
@@ -1,0 +1,15 @@
+export const corenDialogue = [
+  {
+    text: "Halt... you're no scout of his. I'm Coren.",
+    options: [
+      { label: "Who is 'his'?", goto: 1 },
+      { label: "Just passing through.", goto: null }
+    ]
+  },
+  {
+    text: "Our commander watches the ruins still. More relics lie ahead if you have courage to seek them.",
+    options: [
+      { label: "I'll keep that in mind.", goto: null, memoryFlag: 'coren_commander_hint' }
+    ]
+  }
+];

--- a/scripts/trap_logic.js
+++ b/scripts/trap_logic.js
@@ -1,13 +1,16 @@
 import { reveal } from './fog_system.js';
+import { applyStatus } from './statusManager.js';
 
 export function triggerDarkTrap(player, applyDamage, showDialogue, x, y) {
   applyDamage(player, 2);
+  applyStatus(player, 'weakened', 2);
   showDialogue('Shadows coil around you, draining your strength.');
   reveal(x, y);
 }
 
 export function triggerFireTrap(player, applyDamage, showDialogue, x, y) {
   applyDamage(player, 3);
+  applyStatus(player, 'burned', 2);
   showDialogue('Fire erupts beneath your feet!');
   reveal(x, y);
 }

--- a/style/main.css
+++ b/style/main.css
@@ -130,6 +130,23 @@ body {
   background-color: #999;
 }
 
+.tile.trap-dark,
+.tile.trap-light {
+  position: relative;
+}
+
+.tile.trap-dark.triggered,
+.tile.trap-light.triggered {
+  animation: shake 0.3s;
+}
+
+@keyframes shake {
+  0%,100% { transform: translateX(0); }
+  25% { transform: translateX(-2px); }
+  50% { transform: translateX(2px); }
+  75% { transform: translateX(-2px); }
+}
+
 .tile.trap-dark {
   background-color: #555;
 }
@@ -138,8 +155,30 @@ body {
   background-color: #00bfff;
 }
 
+.tile.water.ripple::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255,255,255,0.3), transparent 70%);
+  animation: ripple 1.5s infinite;
+  pointer-events: none;
+}
+
+@keyframes ripple {
+  0% { transform: scale(0.9); opacity: 0.4; }
+  50% { transform: scale(1.05); opacity: 0.2; }
+  100% { transform: scale(0.9); opacity: 0.4; }
+}
+
 .tile.glowing {
   box-shadow: 0 0 8px rgba(255, 255, 255, 0.7);
+  animation: pulseGlow 2s infinite;
+}
+
+@keyframes pulseGlow {
+  0%, 100% { box-shadow: 0 0 8px rgba(255,255,255,0.7); }
+  50% { box-shadow: 0 0 12px rgba(255,255,255,1); }
 }
 
 @keyframes float {


### PR DESCRIPTION
## Summary
- add new Coren NPC and dialogue
- convert map02 to wetter ruins with damaged tiles, mist overlays and water effects
- apply mild status effects from traps
- update zombie drop and defeat flag
- add memory flag and whisper on empty chest
- visual feedback for water, traps and glowing lore nodes

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848286fc03c83319a7805acee616d43