### PR TITLE
Enhance map03 with decayed outpost and new lore

### DIFF
--- a/data/maps/map03.json
+++ b/data/maps/map03.json
@@ -5,17 +5,32 @@
     "GGGGGGGGGGGGGGGGGGGG",
     "GGGGGGGGGGGGGGGGGGGG",
     "GGGGGGGGGGGGGGGGGGGG",
-    "GGGGGGGGGGGGGGGGGGGG",
     [
       "G",
       "G",
       "G",
+      {
+        "type": "G",
+        "opacity": 0.8
+      },
       "G",
       "G",
       "G",
       "G",
       "G",
       "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G"
+    ],
+    [
       "G",
       "G",
       "G",
@@ -24,6 +39,15 @@
         "type": "E",
         "enemyId": "goblin_archer"
       },
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
       "G",
       "G",
       "G",
@@ -42,7 +66,7 @@
         "enemyId": "goblin_scout"
       },
       "G",
-      "G",
+      "t",
       "G",
       "G",
       "G",
@@ -56,10 +80,9 @@
       "G",
       "G"
     ],
-    "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGTGGGGGGGGGGGGG",
     "GGGGGGGGGGGGGGGGGGGG",
     [
-      "G",
       "G",
       "G",
       "G",
@@ -76,6 +99,10 @@
       "G",
       {
         "type": "E",
+        "enemyId": "rotting_warrior"
+      },
+      {
+        "type": "E",
         "enemyId": "scout_commander"
       },
       "G",
@@ -88,7 +115,7 @@
       "G",
       {
         "type": "N",
-        "npc": "arvalin"
+        "npc": "lioran"
       },
       "G",
       "G",
@@ -96,11 +123,9 @@
       "G",
       "G",
       "G",
-      "G",
-      {
-        "type": "t"
-      },
-      "G",
+      "F",
+      "F",
+      "F",
       "G",
       "G",
       "G",
@@ -130,9 +155,7 @@
       {
         "type": "t"
       },
-      {
-        "type": "C"
-      },
+      "G",
       {
         "type": "T"
       },
@@ -172,33 +195,14 @@
       "G",
       "G"
     ],
-    [
-      "G",
-      "G",
-      "G",
-      "G",
-      "G",
-      "G",
-      {
-        "type": "E",
-        "enemyId": "rotting_warrior"
-      },
-      "G",
-      "G",
-      "G",
-      "G",
-      "G",
-      "G",
-      "G",
-      "G",
-      "G",
-      "G",
-      "G",
-      "G",
-      "G"
-    ],
     "GGGGGGGGGGGGGGGGGGGG",
+    "GGGGGGGGFGGGGGGGGGGG",
     [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
       "G",
       "G",
       "G",
@@ -216,6 +220,26 @@
         "enemyId": "goblin_archer"
       },
       "G",
+      "G"
+    ],
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "N",
+        "npc": "field_note_disintegration"
+      },
+      "G",
+      "F",
+      "G",
+      "F",
+      "G",
+      "G",
+      "G",
+      "G",
       "G",
       "G",
       "G",
@@ -223,8 +247,31 @@
       "G",
       "G"
     ],
-    "GGGGGGGGGGGGGGGGGGGG",
-    "GGGGGGGGGGGGGGGGGGGG",
+    [
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "F",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      {
+        "type": "G",
+        "opacity": 0.8
+      },
+      "G",
+      "G",
+      "G"
+    ],
     "GGGGGGGGGGGGGGGGGGGG",
     "GGGGGGGGGGGGGGGGGGGG",
     [
@@ -242,7 +289,16 @@
       "G",
       "G",
       "G",
-      "G",
+      {
+        "type": "D",
+        "target": "map04.json",
+        "locked": true,
+        "requiresItem": "commander_badge",
+        "spawn": {
+          "x": 10,
+          "y": 1
+        }
+      },
       "G",
       "G",
       "G",

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -17,7 +17,10 @@ const chestContents = {
     memoryFlag: 'empty_chest_seen'
   },
   'map02:15,15': { item: 'potion_of_health' },
-  'map03:10,10': { item: 'health_amulet' },
+  'map03:10,10': {
+    item: 'health_amulet',
+    message: 'A pedestal glows softly, revealing a radiant amulet.'
+  },
   'map05:10,9': {
     item: 'mysterious_key',
     message: 'The chest clicks open revealing a strange key.'

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -179,6 +179,12 @@ export function dreamEchoTwo() {
   });
 }
 
+export function fieldNoteDisintegration() {
+  showDialogue('Fragments detail how decay reduces all to dust.', () => {
+    discoverLore('field_note_disintegration');
+  });
+}
+
 export function relicChamber() {
   showDialogue('The chamber resonates with ancient power.', () => {
     unlockRelicSlot();

--- a/scripts/lore_entries.js
+++ b/scripts/lore_entries.js
@@ -108,6 +108,11 @@ export const loreEntries = [
     id: 'null_factor_accessed',
     title: 'Null Factor Accessed',
     text: 'Your mind recalls every trial within the Null Factor.'
+  },
+  {
+    id: 'field_note_disintegration',
+    title: 'Field Note: Disintegration',
+    text: 'Scrawled observations describe matter crumbling into nothing.'
   }
 ];
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -23,6 +23,7 @@ import * as eryndor from './npc/eryndor.js';
 import * as coren from './npc/coren.js';
 import * as goblinQuestGiver from './npc/goblin_quest_giver.js';
 import * as arvalin from './npc/arvalin.js';
+import * as lioran from './npc/lioran.js';
 import * as grindle from './npc/grindle.js';
 import * as forgeNpc from './npc/forge_npc.js';
 import * as shadeSage from './npc/shade_sage.js';
@@ -56,6 +57,7 @@ import * as krealer5 from './npc/krealer5.js';
 import * as krealer6 from './npc/krealer6.js';
 import * as krealer7 from './npc/krealer7.js';
 import * as krealer8 from './npc/krealer8.js';
+import * as fieldNoteDisintegration from './npc/field_note_disintegration.js';
 import { initNullTab } from './ui_state.js';
 import { initNullSummary } from '../ui/null_summary.js';
 import { initSkillSystem } from './skills.js';
@@ -78,6 +80,7 @@ const npcModules = {
   coren,
   goblinQuestGiver,
   arvalin,
+  lioran,
   grindle,
   forgeNpc,
   shadeSage,
@@ -110,6 +113,7 @@ const npcModules = {
   krealer6,
   krealer7,
   krealer8,
+  fieldNoteDisintegration,
   firstMemory
 };
 

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -17,6 +17,7 @@ import { showDialogue } from './dialogueSystem.js';
 import { isPortal15Unlocked } from './player_state.js';
 import { finalFlags } from './memory_flags.js';
 import { hasItem } from './inventory.js';
+import { gameState } from './game_state.js';
 
 let currentGrid = null;
 let currentEnvironment = 'clear';
@@ -106,6 +107,20 @@ export async function loadMap(name) {
           if (cell && cell.type === 'D' && cell.target === 'map14.json') {
             cell.locked = false;
           }
+        }
+      }
+    }
+    if (name === 'map03' && isEnemyDefeated('scout_commander')) {
+      for (const row of data.grid) {
+        for (const cell of row) {
+          if (cell && cell.type === 'D' && cell.target === 'map04.json') {
+            cell.locked = false;
+          }
+        }
+      }
+      if (!gameState.openedChests.has('map03:10,10')) {
+        if (data.grid[10] && data.grid[10][10]) {
+          data.grid[10][10] = { type: 'C', glow: true };
         }
       }
     }

--- a/scripts/npc/field_note_disintegration.js
+++ b/scripts/npc/field_note_disintegration.js
@@ -1,0 +1,5 @@
+import { fieldNoteDisintegration } from '../dialogue_state.js';
+
+export function interact() {
+  fieldNoteDisintegration();
+}

--- a/scripts/npcInfo.js
+++ b/scripts/npcInfo.js
@@ -7,7 +7,7 @@ export const npcInfoList = [
   {
     id: 'lioran',
     name: 'Lioran',
-    description: 'An eccentric mystic who speaks in riddles.'
+    description: 'A fugitive scholar hiding among the ruins.'
   },
   {
     id: 'coren',

--- a/scripts/npc_dialogues/lioran_dialogue.js
+++ b/scripts/npc_dialogues/lioran_dialogue.js
@@ -47,6 +47,28 @@ export const lioranDialogue = [
       { label: "You’re not making any sense.", goto: 2 },
       { label: "I’ll be careful.", goto: null, memoryFlag: "lioran_warning_taken" }
     ]
+  },
+  {
+    text: "I saw how you handled that scout. The commander will notice your meddling.",
+    options: [
+      { label: "He won't be an issue either.", goto: null },
+      { label: "Why warn me?", goto: 6 }
+    ],
+    condition: (state) => state.memory.has('scout_defeated')
+  },
+  {
+    text: "Because I'm hiding from them. Call me a fugitive scholar, if titles matter.",
+    options: [
+      { label: "Need any help?", goto: 7 },
+      { label: "Stay safe, then.", goto: null }
+    ]
+  },
+  {
+    text: "Bring me any field notes you find. Knowledge deserves a keeper.",
+    options: [
+      { label: "I'll keep an eye out.", goto: null, memoryFlag: 'lioran_sidequest' },
+      { label: "Another time.", goto: null }
+    ]
   }
 ];
 


### PR DESCRIPTION
## Summary
- transform map03 into a decayed outpost with fog and ruins
- introduce Lioran NPC with updated dialogue
- spawn lore echo `Field Note: Disintegration`
- relocate enemies and add locked door to map04
- glow pedestal chest appears after commander defeat
- add supporting dialogue/lore data and scripts

## Testing
- `npm test` *(fails: jest not found)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68482c6983548331a487b2b31eb22e80