### PR TITLE
Fix starting map visibility

### DIFF
--- a/scripts/fog_system.js
+++ b/scripts/fog_system.js
@@ -19,6 +19,18 @@ export function initFog(gridContainer, colsCount) {
   });
 }
 
+export function revealAll() {
+  if (!container) return;
+  container.querySelectorAll('.tile').forEach((tile) => {
+    tile.classList.remove('fog-hidden');
+    const x = Number(tile.dataset.x);
+    const y = Number(tile.dataset.y);
+    if (!Number.isNaN(x) && !Number.isNaN(y)) {
+      revealed.add(`${x},${y}`);
+    }
+  });
+}
+
 export function reveal(x, y) {
   if (!container) return;
   const key = `${x},${y}`;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,7 +3,7 @@ import { handleTileEffects } from './gameEngine.js';
 import { toggleInventoryView } from './inventory_state.js';
 import { toggleQuestLog } from './quest_log.js';
 import { player, getTotalStats, stepTo } from './player.js';
-import { initFog, reveal } from './fog_system.js';
+import { initFog, reveal, revealAll } from './fog_system.js';
 import { getRelicBonuses } from './relic_state.js';
 import { loadEnemyData, defeatEnemy } from './enemy.js';
 import { setMemory } from './dialogue_state.js';
@@ -310,6 +310,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     try {
       const { cols: newCols } = await router.loadMap(mapName);
       cols = newCols;
+      initFog(container, cols);
+      if (router.getCurrentMapName() === 'map01') {
+        revealAll();
+      } else {
+        reveal(player.x, player.y);
+      }
       player.maxHp = 100 + (gameState.maxHpBonus || 0);
       player.hp = Math.min(player.hp, player.maxHp);
       updateHpDisplay();
@@ -324,7 +330,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     const { cols: newCols } = await router.loadMap('map01');
     cols = newCols;
     initFog(container, cols);
-    reveal(player.x, player.y);
+    if (router.getCurrentMapName() === 'map01') {
+      revealAll();
+    } else {
+      reveal(player.x, player.y);
+    }
     updateHpDisplay();
     updateXpDisplay();
 
@@ -343,7 +353,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (newCols) {
         cols = newCols;
         initFog(container, cols);
-        reveal(player.x, player.y);
+        if (router.getCurrentMapName() === 'map01') {
+          revealAll();
+        } else {
+          reveal(player.x, player.y);
+        }
         updateHpDisplay();
       }
     });
@@ -381,6 +395,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     document.addEventListener('playerRespawned', (e) => {
       cols = e.detail.cols;
+      initFog(container, cols);
+      revealAll();
       updateHpDisplay();
       updateDefenseDisplay();
       updateXpDisplay();


### PR DESCRIPTION
## Summary
- expose `revealAll` in fog system to uncover whole maps
- show all tiles on map01 by calling `revealAll`
- reveal tiles on load, after interactions, and when respawning

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848304dab388331bc866aa0a0be6b52