### PR TITLE
Add optional fog-of-war per map

### DIFF
--- a/data/maps/map01.json
+++ b/data/maps/map01.json
@@ -1,6 +1,7 @@
 {
   "name": "Fogbound Glade",
   "environment": "fog",
+  "properties": { "fog": true },
   "grid": [
     "GWFGFGFGGGGGFGGGGGGG",
     "GGtFGFGFGGGGGFGGGGGG",

--- a/data/maps/map10.json
+++ b/data/maps/map10.json
@@ -1,6 +1,7 @@
 {
   "name": "Shrouded Labyrinth",
   "environment": "fog",
+  "properties": { "fog": true },
   "grid": [
     [
       "N",

--- a/scripts/fog_system.js
+++ b/scripts/fog_system.js
@@ -1,5 +1,6 @@
 let cols = 0;
 let container = null;
+let active = false;
 const revealed = new Set();
 
 document.addEventListener('playerMoved', (e) => {
@@ -9,18 +10,23 @@ document.addEventListener('playerMoved', (e) => {
   }
 });
 
-export function initFog(gridContainer, colsCount) {
+export function initFog(gridContainer, colsCount, enable = false) {
   container = gridContainer;
   cols = colsCount;
+  active = enable;
   revealed.clear();
   if (!container) return;
   container.querySelectorAll('.tile').forEach((tile) => {
-    tile.classList.add('fog-hidden');
+    if (active) {
+      tile.classList.add('fog-hidden');
+    } else {
+      tile.classList.remove('fog-hidden');
+    }
   });
 }
 
 export function revealAll() {
-  if (!container) return;
+  if (!container || !active) return;
   container.querySelectorAll('.tile').forEach((tile) => {
     tile.classList.remove('fog-hidden');
     const x = Number(tile.dataset.x);
@@ -32,7 +38,7 @@ export function revealAll() {
 }
 
 export function reveal(x, y) {
-  if (!container) return;
+  if (!container || !active) return;
   const key = `${x},${y}`;
   if (revealed.has(key)) return;
   revealed.add(key);
@@ -44,6 +50,11 @@ export function reveal(x, y) {
 }
 
 export function isRevealed(x, y) {
+  if (!active) return true;
   const key = `${x},${y}`;
   return revealed.has(key);
+}
+
+export function isFogActive() {
+  return active;
 }

--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -1,7 +1,7 @@
 import { getForkChoice } from './player_memory.js';
 import { player } from './player.js';
 
-export function renderGrid(grid, container, environment = 'clear') {
+export function renderGrid(grid, container, environment = 'clear', fog = false) {
   container.innerHTML = '';
   const cols = grid[0].length;
   container.style.display = 'grid';
@@ -71,7 +71,7 @@ export function renderGrid(grid, container, environment = 'clear') {
       if (cell.glow) div.classList.add('glowing');
       if (typeof cell.opacity === 'number') div.style.opacity = cell.opacity;
 
-      div.classList.add('fog-hidden');
+      if (fog) div.classList.add('fog-hidden');
 
       container.appendChild(div);
     });

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,4 @@
-import { getCurrentGrid } from './mapLoader.js';
+import { getCurrentGrid, isFogEnabled } from './mapLoader.js';
 import { handleTileEffects } from './gameEngine.js';
 import { toggleInventoryView } from './inventory_state.js';
 import { toggleQuestLog } from './quest_log.js';
@@ -310,11 +310,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     try {
       const { cols: newCols } = await router.loadMap(mapName);
       cols = newCols;
-      initFog(container, cols);
-      if (router.getCurrentMapName() === 'map01') {
-        revealAll();
-      } else {
-        reveal(player.x, player.y);
+      initFog(container, cols, isFogEnabled());
+      if (isFogEnabled()) {
+        if (router.getCurrentMapName() === 'map01') {
+          revealAll();
+        } else {
+          reveal(player.x, player.y);
+        }
       }
       player.maxHp = 100 + (gameState.maxHpBonus || 0);
       player.hp = Math.min(player.hp, player.maxHp);
@@ -329,11 +331,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   try {
     const { cols: newCols } = await router.loadMap('map01');
     cols = newCols;
-    initFog(container, cols);
-    if (router.getCurrentMapName() === 'map01') {
-      revealAll();
-    } else {
-      reveal(player.x, player.y);
+    initFog(container, cols, isFogEnabled());
+    if (isFogEnabled()) {
+      if (router.getCurrentMapName() === 'map01') {
+        revealAll();
+      } else {
+        reveal(player.x, player.y);
+      }
     }
     updateHpDisplay();
     updateXpDisplay();
@@ -352,11 +356,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       );
       if (newCols) {
         cols = newCols;
-        initFog(container, cols);
-        if (router.getCurrentMapName() === 'map01') {
-          revealAll();
-        } else {
-          reveal(player.x, player.y);
+        initFog(container, cols, isFogEnabled());
+        if (isFogEnabled()) {
+          if (router.getCurrentMapName() === 'map01') {
+            revealAll();
+          } else {
+            reveal(player.x, player.y);
+          }
         }
         updateHpDisplay();
       }
@@ -395,8 +401,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     document.addEventListener('playerRespawned', (e) => {
       cols = e.detail.cols;
-      initFog(container, cols);
-      revealAll();
+      initFog(container, cols, isFogEnabled());
+      if (isFogEnabled()) {
+        revealAll();
+      }
       updateHpDisplay();
       updateDefenseDisplay();
       updateXpDisplay();

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -1,7 +1,7 @@
 import * as router from './router.js';
 import { renderGrid } from './grid.js';
 import { player } from './player.js';
-import { getCurrentGrid, getCurrentEnvironment } from './mapLoader.js';
+import { getCurrentGrid, getCurrentEnvironment, isFogEnabled } from './mapLoader.js';
 
 /**
  * Move the player to a given map and coordinates.
@@ -21,7 +21,7 @@ export function spawnNpc(x, y, id) {
   if (!grid || !container) return;
   if (!grid[y] || !grid[y][x]) return;
   grid[y][x] = { type: 'N', npc: id };
-  renderGrid(grid, container, getCurrentEnvironment());
+  renderGrid(grid, container, getCurrentEnvironment(), isFogEnabled());
   router.drawPlayer(player, container, router.getCols());
 }
 
@@ -31,6 +31,6 @@ export function spawnEnemy(x, y, id) {
   if (!grid || !container) return;
   if (!grid[y] || !grid[y][x]) return;
   grid[y][x] = { type: 'E', enemyId: id };
-  renderGrid(grid, container, getCurrentEnvironment());
+  renderGrid(grid, container, getCurrentEnvironment(), isFogEnabled());
   router.drawPlayer(player, container, router.getCols());
 }

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -21,6 +21,7 @@ import { gameState } from './game_state.js';
 
 let currentGrid = null;
 let currentEnvironment = 'clear';
+let currentProperties = {};
 
 export function normalizeGrid(grid, size = 20) {
   const normalized = [];
@@ -180,6 +181,7 @@ export async function loadMap(name) {
     throw err;
   }
   currentEnvironment = data.environment || 'clear';
+  currentProperties = data.properties || {};
   currentGrid = data.grid.map((row) => {
     if (typeof row === 'string') {
       return row.split('').map((ch) => ({ type: ch }));
@@ -192,7 +194,11 @@ export async function loadMap(name) {
     });
   });
   currentGrid = normalizeGrid(currentGrid);
-  return { grid: currentGrid, environment: currentEnvironment };
+  return {
+    grid: currentGrid,
+    environment: currentEnvironment,
+    properties: currentProperties,
+  };
 }
 
 export function getCurrentGrid() {
@@ -201,6 +207,10 @@ export function getCurrentGrid() {
 
 export function getCurrentEnvironment() {
   return currentEnvironment;
+}
+
+export function isFogEnabled() {
+  return !!currentProperties.fog;
 }
 
 // After a class is chosen, send the player to that class's trial map

--- a/scripts/router.js
+++ b/scripts/router.js
@@ -41,13 +41,13 @@ export async function loadMap(filename, spawnPoint) {
   if (!result) {
     return { grid: getCurrentGrid(), cols };
   }
-  const { grid, environment } = result;
+  const { grid, environment, properties } = result;
   currentMap = name;
   gameState.currentMap = name;
   gameState.environment = environment;
   discoverMap(name);
   cols = grid[0].length;
-  renderGrid(grid, container, environment);
+  renderGrid(grid, container, environment, properties?.fog);
 
   // Mark chests that were previously opened
   for (const id of gameState.openedChests) {
@@ -72,7 +72,7 @@ export async function loadMap(filename, spawnPoint) {
   }
 
   drawPlayer(player, container, cols);
-  return { grid, cols };
+  return { grid, cols, properties };
 }
 
 export function getCols() {


### PR DESCRIPTION
## Summary
- make fog-of-war toggleable with new `properties.fog` field
- apply fog rules in map loader, grid renderer, router and gameplay logic
- update fog system to respect enabled state
- enable fog on maps that use the fog environment

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684838315dfc83319842806c029003ec