### PR TITLE
Standardize skill data and add tooltips

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -331,7 +331,8 @@ export async function startCombat(enemy, player) {
       log('Silenced! You cannot use skills.');
       return;
     }
-    log(`Player uses ${skill.name}`);
+    const icon = skill.icon ? `${skill.icon} ` : '';
+    log(`Player uses ${icon}${skill.name}`);
     discoverSkill(skill.id);
     const result = skill.effect({
       damageEnemy,
@@ -531,7 +532,8 @@ export async function startCombat(enemy, player) {
     }
 
     if (skill) {
-      log(`${enemy.name} uses ${skill.name}`);
+      const icon = skill.icon ? `${skill.icon} ` : '';
+      log(`${enemy.name} uses ${icon}${skill.name}`);
       discoverSkill(skill.id);
       skill.effect({
         player,

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -1,5 +1,6 @@
 import { getStatusEffect } from './status_effects.js';
 import { getStatusList } from './statusManager.js';
+import { attachTooltip } from '../ui/skillsPanel.js';
 
 export function setupTabs(overlay) {
   const skillContainer = overlay.querySelector('.skill-buttons');
@@ -73,9 +74,17 @@ export function renderSkillList(container, skills, onClick) {
         .join(', ');
       effects.push(`Removes ${names}`);
     }
-    const descParts = [skill.description, ...effects].filter(Boolean).join(' ');
-    btn.innerHTML = `<strong>${skill.name}</strong><div class="desc">${descParts}</div>`;
+    const meta = [];
+    if (typeof skill.cost === 'number' && skill.cost > 0) meta.push(`Cost: ${skill.cost}`);
+    if (typeof skill.cooldown === 'number' && skill.cooldown > 0)
+      meta.push(`Cooldown: ${skill.cooldown}`);
+    const descParts = [skill.description, ...effects, ...meta]
+      .filter(Boolean)
+      .join(' ');
+    const icon = skill.icon ? `${skill.icon} ` : '';
+    btn.innerHTML = `<strong>${icon}${skill.name}</strong><div class="desc">${descParts}</div>`;
     btn.addEventListener('click', () => onClick(skill));
+    attachTooltip(btn, skill);
     container.appendChild(btn);
   });
 }

--- a/scripts/enemy_skills.js
+++ b/scripts/enemy_skills.js
@@ -5,7 +5,10 @@ export const enemySkills = {
   strike: {
     id: 'strike',
     name: 'Strike',
+    icon: '⚔️',
     description: 'A basic attack dealing 8 damage.',
+    cost: 0,
+    cooldown: 0,
     aiType: 'damage',
     effect({ enemy, damagePlayer, log }) {
       const atk = enemy.stats?.attack || 0;
@@ -17,7 +20,10 @@ export const enemySkills = {
   poisonSting: {
     id: 'poisonSting',
     name: 'Poison Sting',
+    icon: '☠️',
     description: 'Deal 5 damage and inflict Poisoned.',
+    cost: 0,
+    cooldown: 0,
     aiType: 'status',
     applies: ['poisoned'],
     statuses: [{ target: 'player', id: 'poisoned', duration: 2 }],
@@ -32,7 +38,10 @@ export const enemySkills = {
   weaken: {
     id: 'weaken',
     name: 'Weaken',
+    icon: '🤕',
     description: 'Inflict Weakened for 2 turns.',
+    cost: 0,
+    cooldown: 0,
     aiType: 'status',
     applies: ['weakened'],
     statuses: [{ target: 'player', id: 'weakened', duration: 2 }],
@@ -44,7 +53,10 @@ export const enemySkills = {
   memorySurge: {
     id: 'memorySurge',
     name: 'Memory Surge',
+    icon: '💥',
     description: 'Damage increases with every echo remembered.',
+    cost: 0,
+    cooldown: 0,
     aiType: 'damage',
     effect({ enemy, damagePlayer, log }) {
       const count = getEchoConversationCount();
@@ -57,7 +69,10 @@ export const enemySkills = {
   relicGuard: {
     id: 'relicGuard',
     name: 'Relic Guard',
+    icon: '🛡️',
     description: 'Raises defense based on relics owned.',
+    cost: 0,
+    cooldown: 0,
     aiType: 'buff',
     effect({ enemy, log }) {
       const relics = getOwnedRelics().length;
@@ -69,7 +84,10 @@ export const enemySkills = {
   shadowBolt: {
     id: 'shadowBolt',
     name: 'Shadow Bolt',
+    icon: '🌑',
     description: '6 damage and inflicts Haunted.',
+    cost: 0,
+    cooldown: 0,
     aiType: 'status',
     applies: ['haunted'],
     statuses: [{ target: 'player', id: 'haunted', duration: 2 }],
@@ -84,7 +102,10 @@ export const enemySkills = {
   emberBite: {
     id: 'emberBite',
     name: 'Ember Bite',
+    icon: '🔥',
     description: 'Chomp for 6 damage and burn the target.',
+    cost: 0,
+    cooldown: 0,
     aiType: 'status',
     applies: ['burned'],
     statuses: [{ target: 'player', id: 'burned', duration: 2 }],

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -5,7 +5,10 @@ const skillDefs = {
   strike: {
     id: 'strike',
     name: 'Strike',
+    icon: '⚔️',
     description: 'Deal 15 damage.',
+    cost: 0,
+    cooldown: 0,
     // Basic attack
     effect({ damageEnemy, log }) {
       const dmg = 15;
@@ -16,7 +19,10 @@ const skillDefs = {
   guard: {
     id: 'guard',
     name: 'Guard',
+    icon: '🛡️',
     description: 'Reduce damage from the next attack.',
+    cost: 0,
+    cooldown: 0,
     effect({ activateGuard, log }) {
       activateGuard();
       log('Player braces for impact.');
@@ -25,7 +31,10 @@ const skillDefs = {
   heal: {
     id: 'heal',
     name: 'Heal',
+    icon: '✨',
     description: 'Restore 20 HP. Can be used once per battle.',
+    cost: 0,
+    cooldown: 0,
     effect({ healPlayer, log, isHealUsed, setHealUsed }) {
       if (isHealUsed()) {
         log('Heal can only be used once!');
@@ -39,7 +48,10 @@ const skillDefs = {
   shieldWall: {
     id: 'shieldWall',
     name: 'Shield Wall',
+    icon: '🛡️',
     description: 'Completely block the next attack.',
+    cost: 0,
+    cooldown: 0,
     unlockCondition: { chest: 'map01:11,3' },
     effect({ activateShieldBlock, log }) {
       activateShieldBlock();
@@ -49,7 +61,10 @@ const skillDefs = {
   flameBurst: {
     id: 'flameBurst',
     name: 'Flame Burst',
+    icon: '🔥',
     description: 'Engulf the foe in flames for 10 damage.',
+    cost: 0,
+    cooldown: 0,
     unlockCondition: { enemy: 'E' },
     effect({ damageEnemy, log }) {
       const dmg = 10;
@@ -60,7 +75,10 @@ const skillDefs = {
   shadowStab: {
     id: 'shadowStab',
     name: 'Shadow Stab',
+    icon: '🌑',
     description: 'Strike from the shadows for 20 damage.',
+    cost: 0,
+    cooldown: 0,
     unlockCondition: { enemy: 'B' },
     effect({ damageEnemy, log }) {
       const dmg = 20;
@@ -71,7 +89,10 @@ const skillDefs = {
   boneSpike: {
     id: 'boneSpike',
     name: 'Bone Spike',
+    icon: '🦴',
     description: 'Hurl bone shards for 18 damage.',
+    cost: 0,
+    cooldown: 0,
     unlockCondition: { enemy: 'S' },
     effect({ damageEnemy, log }) {
       const dmg = 18;
@@ -82,7 +103,10 @@ const skillDefs = {
   arcaneBlast: {
     id: 'arcaneBlast',
     name: 'Arcane Blast',
+    icon: '✨',
     description: 'Unleash arcane energy for 12 damage.',
+    cost: 0,
+    cooldown: 0,
     unlockCondition: { item: 'ancient_scroll' },
     effect({ damageEnemy, log }) {
       const dmg = 12;
@@ -93,7 +117,10 @@ const skillDefs = {
   poisonDart: {
     id: 'poisonDart',
     name: 'Poison Dart',
+    icon: '☠️',
     description: 'Inflict Poisoned for 3 turns.',
+    cost: 0,
+    cooldown: 0,
     statuses: [{ target: 'enemy', id: 'poisoned', duration: 3 }],
     effect({ applyStatus, enemy, log }) {
       applyStatus(enemy, 'poisoned', 3);
@@ -103,7 +130,10 @@ const skillDefs = {
   rally: {
     id: 'rally',
     name: 'Rally',
+    icon: '📣',
     description: 'Gain Fortify for 3 turns.',
+    cost: 0,
+    cooldown: 0,
     statuses: [{ target: 'self', id: 'fortify', duration: 3 }],
     effect({ applyStatus, player, log }) {
       applyStatus(player, 'fortify', 3);
@@ -113,7 +143,10 @@ const skillDefs = {
   focusMind: {
     id: 'focusMind',
     name: 'Focus',
+    icon: '🎯',
     description: 'Gain Focus for your next attack.',
+    cost: 0,
+    cooldown: 0,
     statuses: [{ target: 'self', id: 'focus', duration: 1 }],
     effect({ applyStatus, player, log }) {
       applyStatus(player, 'focus', 1);
@@ -123,7 +156,10 @@ const skillDefs = {
   purify: {
     id: 'purify',
     name: 'Purify',
+    icon: '💫',
     description: 'Remove certain negative effects from yourself.',
+    cost: 0,
+    cooldown: 0,
     cleanse: ['poisoned', 'cursed', 'blinded'],
     effect({ player, removeNegativeStatus, log }) {
       const removed = removeNegativeStatus(player, [

--- a/scripts/status_effect.js
+++ b/scripts/status_effect.js
@@ -22,6 +22,10 @@ export function tickStatusEffects(target, log) {
     if (st.remaining <= 0) {
       if (def.remove) def.remove(target);
       target.statuses.splice(i, 1);
+      if (typeof log === 'function') {
+        const who = target.isPlayer ? 'You' : target.name || 'Enemy';
+        log(`${def.name || st.id} fades from ${who}.`);
+      }
     }
   }
 }

--- a/ui/skillsPanel.js
+++ b/ui/skillsPanel.js
@@ -1,0 +1,21 @@
+import { showItemTooltip, hideItemTooltip } from '../scripts/utils.js';
+
+export function attachTooltip(button, skill) {
+  if (!button || !skill) return;
+  const parts = [skill.description];
+  if (typeof skill.cost === 'number' && skill.cost > 0) {
+    parts.push(`Cost: ${skill.cost}`);
+  }
+  if (typeof skill.cooldown === 'number' && skill.cooldown > 0) {
+    parts.push(`Cooldown: ${skill.cooldown}`);
+  }
+  if (Array.isArray(skill.statuses)) {
+    skill.statuses.forEach((s) => {
+      parts.push(`${s.id} (${s.duration})`);
+    });
+  }
+  button.addEventListener('mouseenter', () => {
+    showItemTooltip(button, parts.join(' '));
+  });
+  button.addEventListener('mouseleave', hideItemTooltip);
+}


### PR DESCRIPTION
## Summary
- expand player skill definitions with icon, cost and cooldown metadata
- add matching metadata to enemy skills
- log skill icons in combat
- add tooltip helper for skills and update skill rendering
- show status expiration messages

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68483e5da93c83319bbe723e5cc9a3c3