### PR TITLE
Add Memory Echo dialogue

### DIFF
--- a/scripts/npc/first_memory.js
+++ b/scripts/npc/first_memory.js
@@ -1,5 +1,6 @@
-import { firstMemory } from '../dialogue_state.js';
+import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
+import { firstMemoryDialogue } from '../npc_dialogues/first_memory_dialogue.js';
 
 export function interact() {
-  firstMemory();
+  showDialogue('Memory Echo', () => startDialogueTree(firstMemoryDialogue));
 }

--- a/scripts/npcInfo.js
+++ b/scripts/npcInfo.js
@@ -5,6 +5,11 @@ export const npcInfoList = [
     description: 'Last of the Lorebound, keeper of forgotten tales.'
   },
   {
+    id: 'first_memory',
+    name: 'Memory Echo',
+    description: 'A lingering vision of your earliest recollections.'
+  },
+  {
     id: 'lioran',
     name: 'Lioran',
     description: 'A fugitive scholar hiding among the ruins.'

--- a/scripts/npc_data.js
+++ b/scripts/npc_data.js
@@ -1,4 +1,18 @@
 export const npcAppearance = {
+  first_memory: {
+    nameColor: '#ccccff',
+    font: 'sans-serif',
+    border: '#ccccff',
+    displayTitle: 'Memory Echo',
+    dialogueScale: 1
+  },
+  eryndor: {
+    nameColor: '#99ff99',
+    font: 'serif',
+    border: '#99ff99',
+    displayTitle: 'Eryndor',
+    dialogueScale: 1
+  },
   krealer1: {
     nameColor: '#ff9999',
     font: 'monospace',

--- a/scripts/npc_dialogues/first_memory_dialogue.js
+++ b/scripts/npc_dialogues/first_memory_dialogue.js
@@ -1,0 +1,36 @@
+export const firstMemoryDialogue = [
+  {
+    text: 'A faint echo of your past flickers before you.',
+    options: [
+      {
+        label: 'Reach toward the memory.',
+        goto: 1,
+        onChoose: () =>
+          import('../dialogue_state.js').then((m) =>
+            m.discoverLore('first_memory')
+          ),
+        memoryFlag: 'first_memory_touched'
+      },
+      { label: 'Ignore it.', goto: null }
+    ]
+  },
+  {
+    text: 'Images swirl, revealing moments you thought lost.',
+    options: [
+      {
+        label: 'Embrace what you see.',
+        goto: 2,
+        memoryFlag: 'first_memory_embraced'
+      },
+      { label: 'Turn away.', goto: 3, memoryFlag: 'first_memory_rejected' }
+    ]
+  },
+  {
+    text: 'Warmth fills you as the vision settles.',
+    options: [{ label: 'Let it fade.', goto: null }]
+  },
+  {
+    text: 'Doubt lingers as the vision dims.',
+    options: [{ label: 'Leave it be.', goto: null }]
+  }
+];


### PR DESCRIPTION
## Summary
- add dialogue tree for first_memory NPC
- hook NPC into interaction system via new script
- register Memory Echo in npc info and appearance data

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npx prettier --write scripts/npc/first_memory.js scripts/npc_dialogues/first_memory_dialogue.js scripts/npcInfo.js scripts/npc_data.js`

------
https://chatgpt.com/codex/tasks/task_e_684843d02fcc833187cb7829fc0ee357