### PR TITLE
Add map01 NPC implementations

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -167,5 +167,12 @@
     "type": "quest",
     "stackLimit": 1,
     "icon": "💾"
+  },
+  "recall_shard": {
+    "name": "Recall Shard",
+    "description": "A fragment pulsing with lost memory.",
+    "type": "quest",
+    "stackLimit": 1,
+    "icon": "💠"
   }
 }

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -734,3 +734,11 @@ export function echoAbsoluteDefeat() {
     recordEnding('defeat', 'Consumed by the Absolute');
   });
 }
+
+export function flagMetFirstMemory() {
+  setMemory('met_first_memory');
+}
+
+export function flagEryndorSkillGiven() {
+  setMemory('eryndor_skill_given');
+}

--- a/scripts/npc/eryndor.js
+++ b/scripts/npc/eryndor.js
@@ -1,6 +1,8 @@
-import { startDialogueTree } from '../dialogueSystem.js';
+import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
 import { eryndorDialogue } from '../npc_dialogues/eryndor_dialogue.js';
+import { npcAppearance } from '../npc_data.js';
 
 export function interact() {
-  startDialogueTree(eryndorDialogue);
+  const title = npcAppearance.eryndor.displayTitle || 'Eryndor';
+  showDialogue(title, () => startDialogueTree(eryndorDialogue));
 }

--- a/scripts/npc/first_memory.js
+++ b/scripts/npc/first_memory.js
@@ -1,6 +1,8 @@
 import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
 import { firstMemoryDialogue } from '../npc_dialogues/first_memory_dialogue.js';
+import { npcAppearance } from '../npc_data.js';
 
 export function interact() {
-  showDialogue('Memory Echo', () => startDialogueTree(firstMemoryDialogue));
+  const title = npcAppearance.first_memory.displayTitle || 'Memory';
+  showDialogue(title, () => startDialogueTree(firstMemoryDialogue));
 }

--- a/scripts/npc_data.js
+++ b/scripts/npc_data.js
@@ -3,14 +3,14 @@ export const npcAppearance = {
     nameColor: '#ccccff',
     font: 'sans-serif',
     border: '#ccccff',
-    displayTitle: 'Memory Echo',
+    displayTitle: 'Echo of a Name',
     dialogueScale: 1
   },
   eryndor: {
     nameColor: '#99ff99',
     font: 'serif',
     border: '#99ff99',
-    displayTitle: 'Eryndor',
+    displayTitle: 'Eryndor, the Withheld',
     dialogueScale: 1
   },
   krealer1: {
@@ -68,5 +68,18 @@ export const npcAppearance = {
     border: '#ff99cc',
     displayTitle: 'Persona Architecture',
     dialogueScale: 0.9
+  }
+};
+
+export const npcData = {
+  first_memory: {
+    name: 'Echo of a Name',
+    map: 'map01',
+    description: 'A fragmented memory that speaks in whispers.'
+  },
+  eryndor: {
+    name: 'Eryndor, the Withheld',
+    map: 'map01',
+    description: 'A guarded mentor who knows forgotten techniques.'
   }
 };

--- a/scripts/npc_dialogues/eryndor_dialogue.js
+++ b/scripts/npc_dialogues/eryndor_dialogue.js
@@ -1,11 +1,37 @@
 export const eryndorDialogue = [
   {
-    text: 'You shouldn’t be here yet. But I’m glad you are.',
+    text: 'A hooded figure blocks your path, gaze unreadable.',
+    options: [
+      { label: 'Who are you?', goto: 1 },
+      { label: 'Step away', goto: null }
+    ]
+  },
+  {
+    text: "'Eryndor,' he says. 'I keep what others misuse.'",
+    options: [
+      { label: 'I seek your guidance.', goto: 2 },
+      { label: 'Then I will not intrude.', goto: null, memoryFlag: 'eryndor_intro' }
+    ]
+  },
+  {
+    text: 'Knowledge has a price. Focus is the first payment.',
     options: [
       {
-        label: 'Why do you say that?',
+        label: 'Teach me',
+        goto: 3
+      },
+      { label: 'Another time.', goto: null }
+    ]
+  },
+  {
+    text: 'He demonstrates a swift, precise strike.',
+    options: [
+      {
+        label: 'Commit it to memory',
         goto: null,
-        memoryFlag: 'eryndor_intro'
+        memoryFlag: 'eryndor_skill_given',
+        onChoose: () =>
+          import('../player.js').then((m) => m.grantSkill('focus_strike'))
       }
     ]
   }

--- a/scripts/npc_dialogues/first_memory_dialogue.js
+++ b/scripts/npc_dialogues/first_memory_dialogue.js
@@ -1,21 +1,47 @@
 export const firstMemoryDialogue = [
   {
-    text: 'The fog parts, revealing a vision from long ago.',
+    text: 'A whisper of your name echoes from the mist.',
     options: [
       {
-        label: 'Watch carefully.',
+        label: 'Listen',
         goto: 1,
-        memoryFlag: 'first_memory_seen',
-        onChoose: () =>
-          import('../dialogue_state.js').then((m) =>
-            m.discoverLore('first_memory')
-          )
+        memoryFlag: 'met_first_memory'
       },
-      { label: 'Let it fade.', goto: null }
+      { label: 'Ignore it', goto: null }
     ]
   },
   {
-    text: 'The memory shimmers before dissolving back into fog.',
-    options: [{ label: 'Continue on.', goto: null }]
+    text: 'Fragments swirl, forming words you almost remember.',
+    options: [
+      { label: 'Reach toward them', goto: 2 },
+      { label: 'Let them drift by', goto: 3 }
+    ]
+  },
+  {
+    text: 'The shards coalesce into a small crystal pulsing with recognition.',
+    options: [
+      {
+        label: 'Take the shard',
+        goto: 4,
+        give: 'recall_shard'
+      },
+      { label: 'Leave it be', goto: 3 }
+    ]
+  },
+  {
+    text: 'The memory fades, leaving only silence.',
+    options: [ { label: 'Continue on', goto: null } ]
+  },
+  {
+    text: 'Emotion floods you as forgotten images flare and dim.',
+    options: [
+      {
+        label: 'Hold the feeling',
+        goto: null,
+        memoryFlag: 'first_memory_seen',
+        onChoose: () =>
+          import('../dialogue_state.js').then((m) => m.discoverLore('first_memory'))
+      }
+    ]
   }
 ];

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -7,6 +7,7 @@ import { unlockPassivesForLevel, getPassive } from './passive_skills.js';
 import { getItemBonuses } from './item_stats.js';
 import { getRelicBonuses } from './relic_state.js';
 import { getClassBonuses, getChosenClass } from './class_state.js';
+import { unlockSkill, getAllSkills } from './skills.js';
 
 export const player = {
   x: 0,
@@ -201,4 +202,13 @@ export function getTotalStats() {
     }
   }
   return total;
+}
+
+export function grantSkill(id) {
+  if (unlockSkill(id)) {
+    const skill = getAllSkills()[id];
+    if (skill) {
+      showDialogue(`You've learned a new skill: ${skill.name}!`);
+    }
+  }
 }

--- a/scripts/skill_data.js
+++ b/scripts/skill_data.js
@@ -1,0 +1,9 @@
+export const skillData = {
+  focus_strike: {
+    id: 'focus_strike',
+    name: 'Focus Strike',
+    damage: 18,
+    accuracy: 1.2,
+    description: 'Deliver a precise blow with heightened accuracy.'
+  }
+};

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -153,6 +153,19 @@ const skillDefs = {
       log('You concentrate deeply, preparing your strike.');
     }
   },
+  focusStrike: {
+    id: 'focus_strike',
+    name: 'Focus Strike',
+    icon: '🎯',
+    description: 'A precise attack that rarely misses.',
+    cost: 0,
+    cooldown: 0,
+    effect({ damageEnemy, log }) {
+      const dmg = 18;
+      damageEnemy(dmg);
+      log(`Your focus strike deals ${dmg} damage!`);
+    }
+  },
   purify: {
     id: 'purify',
     name: 'Purify',


### PR DESCRIPTION
## Summary
- implement item `recall_shard`
- add `focus_strike` skill
- support granting skills to the player
- create new `npc_data` entries and update display names
- write dialogue for **Echo of a Name** and **Eryndor, the Withheld**
- connect NPC modules to their dialogue
- log memory flags for the new NPCs
- provide standalone skill data file

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848564c6eb483319da3b809d3446617