### PR TITLE
Add goblin raider and restless bones

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -403,6 +403,36 @@
       { "item": "code_file", "quantity": 1 }
     ]
   },
+  "goblin_raider": {
+    "name": "Goblin Raider",
+    "hp": 55,
+    "stats": { "attack": 3, "defense": 1 },
+    "xp": 7,
+    "description": "A goblin clad in mismatched gear from raids.",
+    "intro": "A goblin raider leaps from the shadows!",
+    "portrait": "🗡️",
+    "skills": [
+      "scratch"
+    ],
+    "drops": [
+      { "item": "goblin_gear", "quantity": 1 }
+    ]
+  },
+  "restless_bones": {
+    "name": "Restless Bones",
+    "hp": 45,
+    "stats": { "attack": 2, "defense": 0 },
+    "xp": 6,
+    "description": "Bones animated by lingering necrotic energy.",
+    "intro": "A pile of bones rattles to life!",
+    "portrait": "💀",
+    "skills": [
+      "decay_touch"
+    ],
+    "drops": [
+      { "item": "bone_fragment", "quantity": 1 }
+    ]
+  },
   "echo_absolute": {
     "name": "Echo Absolute",
     "hp": 300,

--- a/data/items.json
+++ b/data/items.json
@@ -62,6 +62,13 @@
     "stackLimit": 99,
     "icon": "👂"
   },
+  "goblin_gear": {
+    "name": "Goblin Gear",
+    "description": "Common drop; tradeable later",
+    "type": "material",
+    "stackLimit": 99,
+    "icon": "⚙️"
+  },
   "rotten_tooth": {
     "name": "Rotten Tooth",
     "description": "Crumbly but still has bite",
@@ -71,7 +78,7 @@
   },
   "bone_fragment": {
     "name": "Bone Fragment",
-    "description": "Sharp piece of bone from an undead",
+    "description": "Necrotic crafting material",
     "type": "material",
     "stackLimit": 99,
     "icon": "🦴"

--- a/data/maps/map01.json
+++ b/data/maps/map01.json
@@ -33,7 +33,10 @@
       "G",
       "G",
       "G",
-      "G",
+      {
+        "type": "E",
+        "enemyId": "goblin_raider"
+      },
       "G",
       "G",
       "G",
@@ -395,7 +398,10 @@
       "G",
       "G",
       "G",
-      "G",
+      {
+        "type": "E",
+        "enemyId": "restless_bones"
+      },
       "G",
       "G",
       "G",

--- a/scripts/enemy_skills.js
+++ b/scripts/enemy_skills.js
@@ -117,6 +117,39 @@ export const enemySkills = {
       log(`${enemy.name} bites for ${applied} damage and burns you!`);
     }
   },
+  scratch: {
+    id: 'scratch',
+    name: 'Scratch',
+    icon: '🗡️',
+    description: 'A quick swipe dealing 7 damage.',
+    cost: 0,
+    cooldown: 0,
+    aiType: 'damage',
+    effect({ enemy, damagePlayer, log }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = 7 + atk + (enemy.tempAttack || 0);
+      const applied = damagePlayer(dmg);
+      log(`${enemy.name} scratches for ${applied} damage!`);
+    }
+  },
+  decay_touch: {
+    id: 'decay_touch',
+    name: 'Decay Touch',
+    icon: '☠️',
+    description: 'Weak necrotic attack that curses the target.',
+    cost: 0,
+    cooldown: 0,
+    aiType: 'status',
+    applies: ['cursed'],
+    statuses: [{ target: 'player', id: 'cursed', duration: 2 }],
+    effect({ enemy, damagePlayer, applyStatus, log, player }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = 4 + atk + (enemy.tempAttack || 0);
+      const applied = damagePlayer(dmg);
+      applyStatus(player, 'cursed', 2);
+      log(`${enemy.name} spreads decay for ${applied} damage!`);
+    }
+  },
 };
 
 export function getEnemySkill(id) {

--- a/scripts/skill_data.js
+++ b/scripts/skill_data.js
@@ -5,5 +5,19 @@ export const skillData = {
     damage: 18,
     accuracy: 1.2,
     description: 'Deliver a precise blow with heightened accuracy.'
+  },
+  scratch: {
+    id: 'scratch',
+    name: 'Scratch',
+    damage: 7,
+    accuracy: 1,
+    description: 'A quick swipe from a claw or crude blade.'
+  },
+  decay_touch: {
+    id: 'decay_touch',
+    name: 'Decay Touch',
+    damage: 4,
+    accuracy: 1,
+    description: 'Necrotic hit that leaves a lingering curse.'
   }
 };


### PR DESCRIPTION
## Summary
- populate map01 with two new enemy positions
- create `goblin_raider` and `restless_bones` enemy entries
- define `scratch` and `decay_touch` skills for enemies
- update item data with `goblin_gear` and revised `bone_fragment`

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68485950bc908331b56f899a18231385