### PR TITLE
Add Fogbound Fragment memory echo

### DIFF
--- a/data/maps/map01.json
+++ b/data/maps/map01.json
@@ -68,7 +68,10 @@
       "G",
       "G",
       "G",
-      "G",
+      {
+        "type": "echo",
+        "id": "fogbound_fragment"
+      },
       "G",
       "G",
       "G",

--- a/info/echoes.js
+++ b/info/echoes.js
@@ -1,0 +1,3 @@
+export const echoes = [
+  { id: 'fogbound_fragment', name: 'Fogbound Fragment', location: 'Map01' }
+];

--- a/scripts/echoInfo.js
+++ b/scripts/echoInfo.js
@@ -6,6 +6,11 @@ export const echoInfoList = [
       'Fog remembers what we forget. But not all of it returns whole.'
   },
   {
+    id: 'fogbound_fragment',
+    name: 'Fogbound Fragment',
+    description: 'Echo of a self unsure it ever existed.'
+  },
+  {
     id: 'shadow',
     name: 'Shadow Self',
     description: 'A reflection of the path you did not take.'

--- a/scripts/echo_data.js
+++ b/scripts/echo_data.js
@@ -1,0 +1,15 @@
+export const echoData = {
+  fogbound_fragment: {
+    id: 'fogbound_fragment',
+    flag: 'echo_fogbound_intro',
+    text: [
+      'Fog remembers what we forget.',
+      'But not all of it returns whole.',
+      'Your shape is still being drawn.'
+    ]
+  }
+};
+
+export function getEchoData(id) {
+  return echoData[id];
+}

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -13,6 +13,8 @@ import * as router from './router.js';
 import { gameState } from './game_state.js';
 import { triggerRotation } from './rotation_puzzle.js';
 import { recordEchoConversation } from './player_memory.js';
+import { getEchoData } from './echo_data.js';
+import { setLoreFlag } from './lore_state.js';
 
 /**
  * Handles double click interactions on tiles.
@@ -146,13 +148,23 @@ export async function handleTileInteraction(
       break;
     }
     case 'echo': {
-      showDialogue(
-        'Fog remembers what we forget. But not all of it returns whole.',
-        () => {
-          recordEchoConversation('fogbound_intro');
-          setMemory('echo_fogbound_intro');
+      const echo = getEchoData(tile.id);
+      if (echo) {
+        for (const line of echo.text) {
+          // eslint-disable-next-line no-await-in-loop
+          await new Promise((resolve) => showDialogue(line, resolve));
         }
-      );
+        recordEchoConversation(tile.id);
+        setLoreFlag(echo.flag);
+        setMemory(echo.flag);
+      }
+      const index = y * cols + x;
+      const tileEl = container.children[index];
+      if (tileEl) {
+        tileEl.classList.remove('echo', 'blocked');
+        tileEl.classList.add('ground');
+      }
+      tile.type = 'G';
       break;
     }
     case 'N': {

--- a/scripts/lore_state.js
+++ b/scripts/lore_state.js
@@ -1,0 +1,38 @@
+const STORAGE_KEY = 'gridquest.lore_flags';
+
+const flags = new Set();
+
+function load() {
+  const json = localStorage.getItem(STORAGE_KEY);
+  if (!json) return;
+  try {
+    const arr = JSON.parse(json);
+    if (Array.isArray(arr)) {
+      arr.forEach((f) => flags.add(f));
+    }
+  } catch {
+    // ignore malformed data
+  }
+}
+
+function save() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(flags)));
+}
+
+load();
+
+export function setLoreFlag(flag) {
+  if (!flag) return;
+  if (!flags.has(flag)) {
+    flags.add(flag);
+    save();
+  }
+}
+
+export function hasLoreFlag(flag) {
+  return flags.has(flag);
+}
+
+export function getLoreFlags() {
+  return Array.from(flags);
+}


### PR DESCRIPTION
## Summary
- introduce Fogbound Fragment echo tile on map01
- add echo info entry
- implement echo data and simple lore flag state
- handle echo interaction via new data-driven system
- list Fogbound Fragment in info/echoes.js

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68485ce83c448331877f67b4c45aa316