### PR TITLE
Implement locked exit door logic

### DIFF
--- a/data/maps/map01.json
+++ b/data/maps/map01.json
@@ -74,7 +74,17 @@
       },
       "G",
       "G",
-      "G",
+      {
+        "type": "D",
+        "target": "map02.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        },
+        "locked": true,
+        "requiresItem": "rusty_key",
+        "consumeItem": true
+      },
       "F"
     ],
     [
@@ -180,16 +190,7 @@
       "G",
       "G",
       "G",
-      {
-        "type": "D",
-        "target": "map02.json",
-        "spawn": {
-          "x": 1,
-          "y": 1
-        },
-        "locked": true,
-        "requiresItem": "rusty_key"
-      },
+      "G",
       "G",
       "G",
       "G",

--- a/info/items.js
+++ b/info/items.js
@@ -1,0 +1,5 @@
+export const usedItems = [];
+
+export function markItemUsed(id) {
+  if (!usedItems.includes(id)) usedItems.push(id);
+}

--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -75,6 +75,7 @@ export function renderGrid(
           div.classList.add('ground');
       }
 
+      if (cell.locked) div.classList.add('locked');
       if (cell.flow) div.classList.add('flowing');
       if (cell.glow) div.classList.add('glowing');
       if (typeof cell.opacity === 'number') div.style.opacity = cell.opacity;

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -103,6 +103,10 @@ export function removeItem(nameOrId, qty = 1) {
   return false;
 }
 
+export function consumeItem(id, qty = 1) {
+  return removeItem(id, qty);
+}
+
 export function getItemsByType(type) {
   return inventory.filter((it) => {
     const data = getItemData(it.id);

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -8,6 +8,7 @@ import { getItemBonuses } from './item_stats.js';
 import { getRelicBonuses } from './relic_state.js';
 import { getClassBonuses, getChosenClass } from './class_state.js';
 import { unlockSkill, getAllSkills } from './skills.js';
+import { addItem, removeItem as removeInvItem } from './inventory.js';
 
 export const player = {
   x: 0,
@@ -211,4 +212,12 @@ export function grantSkill(id) {
       showDialogue(`You've learned a new skill: ${skill.name}!`);
     }
   }
+}
+
+export function obtainItem(id, qty = 1) {
+  addItem({ id, quantity: qty });
+}
+
+export function loseItem(id, qty = 1) {
+  removeInvItem(id, qty);
 }

--- a/scripts/transition.js
+++ b/scripts/transition.js
@@ -1,0 +1,21 @@
+import * as router from './router.js';
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function transitionToMap(target, spawn) {
+  const overlay = document.createElement('div');
+  overlay.id = 'map-overlay';
+  overlay.classList.add('map-transition');
+  document.body.appendChild(overlay);
+  // force reflow
+  overlay.offsetWidth;
+  overlay.classList.add('active');
+  await delay(500);
+  const { cols } = await router.loadMap(target.replace(/\.json$/, ''), spawn);
+  overlay.classList.remove('active');
+  await delay(500);
+  overlay.remove();
+  return cols;
+}

--- a/style/main.css
+++ b/style/main.css
@@ -130,6 +130,10 @@ body {
   background: #2ecc71;
 }
 
+.door.locked {
+  background: #1abc9c;
+}
+
 .tile.trap-light {
   background-color: #999;
 }
@@ -1218,4 +1222,21 @@ body {
   font-size: 13px;
   color: #555;
   margin-top: 2px;
+}
+
+#map-overlay.map-transition {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.5s ease;
+  z-index: 1000;
+}
+
+#map-overlay.map-transition.active {
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary
- add locked door on outer edge of map01
- add `map-transition` overlay for scene changes
- implement door unlocking with key consumption and map transition
- expose helper functions for managing inventory
- track used items
- show locked doors visually

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485efe089083318c6c5564f9918ccd