### PR TITLE
Add new key, passive health amulet and lore note

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -20,6 +20,13 @@
     "stackLimit": 1,
     "icon": "🗝️"
   },
+  "map02_key": {
+    "name": "Map02 Key",
+    "description": "Opens the way forward.",
+    "type": "key",
+    "stackLimit": 1,
+    "icon": "🗝️"
+  },
   "ruin_key": {
     "name": "Ruin Key",
     "description": "Opens the path to deeper ruins.",
@@ -85,8 +92,8 @@
   },
   "health_amulet": {
     "name": "Health Amulet",
-    "description": "An amulet that bolsters vitality",
-    "type": "gear",
+    "description": "Permanently increases max HP when found",
+    "type": "passive",
     "stackLimit": 1,
     "icon": "🩸"
   },
@@ -160,6 +167,13 @@
     "type": "quest",
     "stackLimit": 1,
     "icon": "✉️"
+  },
+  "empty_note": {
+    "name": "Empty Note",
+    "description": "A faded note… it's unreadable.",
+    "type": "quest",
+    "stackLimit": 1,
+    "icon": "📝"
   },
   "old_coin": {
     "name": "Old Coin",

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -78,14 +78,6 @@ export async function openChest(id, player) {
           increaseMaxHp(1);
           gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
         }
-        if (player && itm === 'health_amulet') {
-          if (!player.bonusHpGiven?.health_amulet) {
-            increaseMaxHp(2);
-            gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 2;
-            if (!player.bonusHpGiven) player.bonusHpGiven = {};
-            player.bonusHpGiven.health_amulet = true;
-          }
-        }
       }
     }
     updateInventoryUI();
@@ -94,18 +86,9 @@ export async function openChest(id, player) {
     if (item) {
       const qty = config.quantity || 1;
       addItem({ ...item, id: config.item, quantity: qty });
-      if (player) {
-        if (config.item === 'potion_of_health') {
-          increaseMaxHp(1);
-          gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
-        } else if (config.item === 'health_amulet') {
-          if (!player.bonusHpGiven?.health_amulet) {
-            increaseMaxHp(2);
-            gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 2;
-            if (!player.bonusHpGiven) player.bonusHpGiven = {};
-            player.bonusHpGiven.health_amulet = true;
-          }
-        }
+      if (player && config.item === 'potion_of_health') {
+        increaseMaxHp(1);
+        gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
       }
       updateInventoryUI();
       unlockedSkills = unlockSkillsFromItem(config.item);

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -1,5 +1,6 @@
 import { getItemData } from './item_loader.js';
-import { player } from './player.js';
+import { player, increaseMaxHp } from './player.js';
+import { gameState } from './game_state.js';
 import { getItemBonuses } from './item_stats.js';
 import { unlockBlueprint } from './craft_state.js';
 import { discover } from './player_memory.js';
@@ -44,6 +45,12 @@ export function addItem(item) {
     if ((existing.quantity || 0) >= limit) return false;
     existing.quantity = Math.min(limit, (existing.quantity || 0) + qty);
     discover('items', parseItemId(item.id).baseId);
+    if (baseId === 'health_amulet' && !player.bonusHpGiven?.health_amulet) {
+      increaseMaxHp(1);
+      gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
+      if (!player.bonusHpGiven) player.bonusHpGiven = {};
+      player.bonusHpGiven.health_amulet = true;
+    }
     document.dispatchEvent(new CustomEvent('inventoryUpdated'));
     return true;
   }
@@ -62,6 +69,12 @@ export function addItem(item) {
     unlockBlueprint(item.id.replace('blueprint_', ''));
   }
   discover('items', parseItemId(item.id).baseId);
+  if (baseId === 'health_amulet' && !player.bonusHpGiven?.health_amulet) {
+    increaseMaxHp(1);
+    gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
+    if (!player.bonusHpGiven) player.bonusHpGiven = {};
+    player.bonusHpGiven.health_amulet = true;
+  }
   document.dispatchEvent(new CustomEvent('inventoryUpdated'));
   return true;
 }

--- a/scripts/item_stats.js
+++ b/scripts/item_stats.js
@@ -7,10 +7,6 @@ export const itemBonuses = {
   'cracked_helmet+2': { slot: 'armor', defense: 3 },
   'cracked_helmet+3': { slot: 'armor', defense: 4 },
   commander_badge: { slot: 'weapon', attack: 2 },
-  health_amulet: { slot: 'accessory', maxHp: 5 },
-  'health_amulet+1': { slot: 'accessory', maxHp: 6 },
-  'health_amulet+2': { slot: 'accessory', maxHp: 7 },
-  'health_amulet+3': { slot: 'accessory', maxHp: 8 },
 };
 
 export function getItemBonuses(id) {


### PR DESCRIPTION
## Summary
- add `map02_key` and `empty_note` to item data
- change `health_amulet` to a passive item and implement its HP bonus in inventory logic
- remove health amulet equip bonuses
- remove chest-specific health amulet handling

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486cb77b108331ab72e11164137e83