### PR TITLE
Add health amulet chest to map03

### DIFF
--- a/data/maps/map03.json
+++ b/data/maps/map03.json
@@ -146,7 +146,10 @@
       {
         "type": "D",
         "target": "map04.json",
-        "spawn": { "x": 1, "y": 1 },
+        "spawn": {
+          "x": 1,
+          "y": 1
+        },
         "locked": true,
         "requiresItem": "commander_badge",
         "consumeItem": true,
@@ -154,7 +157,30 @@
       }
     ],
     "FGGGGGGGtttttGGGGGGF",
-    "FGGGGGGGGtFtGGGGGGGF",
+    [
+      "F",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "t",
+      {
+        "type": "C"
+      },
+      "t",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "G",
+      "F"
+    ],
     "FGGGGGGGGGFGGGGGGGGF",
     "FGGGGGGGGGFGGGWWWWGF",
     [

--- a/info/items.js
+++ b/info/items.js
@@ -2,7 +2,7 @@ export const usedItems = [];
 
 export const itemDescriptions = {
   map02_key: 'Unlocks the door from Rainy Crossroads to Twilight Field.',
-  health_amulet: 'A relic that permanently boosts your vitality by 1.',
+  health_amulet: 'Health Amulet \u2013 increases max HP by 2',
   empty_note: 'The note is blank, leaving more questions than answers.',
   focus_ring: 'A ring that sharpens concentration, boosting accuracy by 10%',
   commander_badge: 'Grants access from Twilight Field to Central Hub.'

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -34,9 +34,9 @@ const chestContents = {
     message: 'This chest was empty.',
     memoryFlag: 'empty_chest_seen'
   },
-  'map03:10,10': {
+  'map03:10,12': {
     item: 'health_amulet',
-    message: 'A pedestal glows softly, revealing a radiant amulet.'
+    message: 'You feel stronger.'
   },
   'map05:10,9': {
     item: 'mysterious_key',

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -66,12 +66,12 @@ export function addItem(item) {
     if ((existing.quantity || 0) >= limit) return false;
     existing.quantity = Math.min(limit, (existing.quantity || 0) + qty);
     discover('items', parseItemId(item.id).baseId);
-    if (baseId === 'health_amulet') {
-      if (!player.bonusHpGiven?.health_amulet) {
-        gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
+      if (baseId === 'health_amulet') {
+        if (!player.bonusHpGiven?.health_amulet) {
+          gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 2;
+        }
+        applyItemReward(baseId);
       }
-      applyItemReward(baseId);
-    }
     document.dispatchEvent(new CustomEvent('inventoryUpdated'));
     return true;
   }
@@ -92,7 +92,7 @@ export function addItem(item) {
   discover('items', parseItemId(item.id).baseId);
   if (baseId === 'health_amulet') {
     if (!player.bonusHpGiven?.health_amulet) {
-      gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
+      gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 2;
     }
     applyItemReward(baseId);
   }

--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -128,6 +128,7 @@ export function toggleInventoryView() {
 // Keep UI in sync when inventory changes
 document.addEventListener('inventoryUpdated', updateInventoryUI);
 document.addEventListener('playerDefenseChanged', updateInventoryUI);
+document.addEventListener('playerHpChanged', updateInventoryUI);
 document.addEventListener('playerXpChanged', updateInventoryUI);
 document.addEventListener('playerLevelUp', updateInventoryUI);
 document.addEventListener('relicsUpdated', updateInventoryUI);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -412,6 +412,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       updateXpDisplay();
     });
     document.addEventListener('playerDefenseChanged', updateDefenseDisplay);
+    document.addEventListener('playerHpChanged', updateHpDisplay);
     document.addEventListener('playerXpChanged', updateXpDisplay);
     document.addEventListener('playerLevelUp', updateXpDisplay);
     document.addEventListener('passivesUpdated', () => {

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -119,9 +119,9 @@ export async function loadMap(name) {
           }
         }
       }
-      if (!gameState.openedChests.has('map03:10,10')) {
-        if (data.grid[10] && data.grid[10][10]) {
-          data.grid[10][10] = { type: 'C', glow: true };
+      if (!gameState.openedChests.has('map03:10,12')) {
+        if (data.grid[12] && data.grid[12][10]) {
+          data.grid[12][10] = { type: 'C', glow: true };
         }
       }
     }

--- a/scripts/menu/status.js
+++ b/scripts/menu/status.js
@@ -80,6 +80,7 @@ export function toggleStatusPanel() {
 }
 
 document.addEventListener('passivesUpdated', updateStatusPanel);
+document.addEventListener('playerHpChanged', updateStatusPanel);
 document.addEventListener('playerXpChanged', updateStatusPanel);
 document.addEventListener('playerLevelUp', updateStatusPanel);
 document.addEventListener('equipmentChanged', updateStatusPanel);

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -91,15 +91,22 @@ export function healFull() {
 }
 
 export function increaseMaxHp(amount) {
+  if (typeof amount !== 'number' || amount === 0) return;
   player.maxHp += amount;
   player.hp = Math.min(player.hp, player.maxHp);
+  document.dispatchEvent(
+    new CustomEvent('playerHpChanged', {
+      detail: { hp: player.hp, maxHp: player.maxHp }
+    })
+  );
 }
 
 export function applyItemReward(id) {
   if (id === 'health_amulet' && !player.bonusHpGiven?.health_amulet) {
-    increaseMaxHp(1);
+    increaseMaxHp(2);
     if (!player.bonusHpGiven) player.bonusHpGiven = {};
     player.bonusHpGiven.health_amulet = true;
+    showDialogue('You feel a warmth surge through you.');
   }
 }
 


### PR DESCRIPTION
## Summary
- add chest tile in map03 at (10,12) containing Health Amulet
- update chest contents and loader to spawn chest and glow when boss defeated
- Health Amulet now grants +2 max HP and shows feedback message
- refresh UI when HP changes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848910d10ec8331900e2d451f0b8027