### PR TITLE
Add traps and update trap logic

### DIFF
--- a/data/maps/map03.json
+++ b/data/maps/map03.json
@@ -112,7 +112,7 @@
     ],
     "FGGGGGGGGGFGGGGGGGGF",
     "FGGGGGGGGtFtGGGGGGGF",
-    "FGGGGGGGtttttGGGGGGF",
+    "FGGGGGGTtttttGGGGGTF",
     [
       {
         "type": "D",
@@ -166,13 +166,13 @@
       "G",
       "G",
       "G",
-      "G",
+      "t",
       "t",
       {
         "type": "C"
       },
       "t",
-      "G",
+      "t",
       "G",
       "G",
       "G",

--- a/info/tiles.js
+++ b/info/tiles.js
@@ -1,3 +1,17 @@
 export const tiles = [
-  { symbol: 'W', name: 'Water', description: 'Click to restore full health (non-walkable)' }
+  {
+    symbol: 'W',
+    name: 'Water',
+    description: 'Click to restore full health (non-walkable)'
+  },
+  {
+    symbol: 't',
+    name: 'Light Trap',
+    description: '-1 HP, apply weakened for 3 turns'
+  },
+  {
+    symbol: 'T',
+    name: 'Heavy Trap',
+    description: '-2 HP, apply burned for 3 turns'
+  }
 ];

--- a/scripts/status_effects.js
+++ b/scripts/status_effects.js
@@ -137,7 +137,7 @@ export const statusEffects = {
     icon: '🤕',
     description: 'Deal half damage.',
     type: 'negative',
-    duration: 2,
+    duration: 3,
     apply(target) {
       target.damageModifier = (target.damageModifier || 1) * 0.5;
     },

--- a/scripts/trap_logic.js
+++ b/scripts/trap_logic.js
@@ -2,15 +2,15 @@ import { reveal } from './fog_system.js';
 import { applyStatus } from './statusManager.js';
 
 export function triggerDarkTrap(player, applyDamage, showDialogue, x, y) {
-  applyDamage(player, 2);
-  applyStatus(player, 'weakened', 2);
+  applyDamage(player, 1);
+  applyStatus(player, 'weakened', 3);
   showDialogue('Shadows coil around you, draining your strength.');
   reveal(x, y);
 }
 
 export function triggerFireTrap(player, applyDamage, showDialogue, x, y) {
-  applyDamage(player, 3);
-  applyStatus(player, 'burned', 2);
+  applyDamage(player, 2);
+  applyStatus(player, 'burned', 3);
   showDialogue('Fire erupts beneath your feet!');
   reveal(x, y);
 }


### PR DESCRIPTION
## Summary
- place light/heavy traps in map03
- detail trap tiles in info panel
- adjust trap handlers for new damage values
- set weakened default duration to 3

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684896664a3483318adf6403414942f8