### PR TITLE
Add Verge Whispers echo tile

### DIFF
--- a/data/maps/map03.json
+++ b/data/maps/map03.json
@@ -202,7 +202,10 @@
       "G",
       "W",
       "W",
-      "G",
+      {
+        "type": "echo",
+        "id": "verge_whispers"
+      },
       "F"
     ],
     "FGGGGGGGGGFGGGWWWWGF",

--- a/info/echoes.js
+++ b/info/echoes.js
@@ -1,4 +1,5 @@
 export const echoes = [
   { id: 'fogbound_fragment', name: 'Fogbound Fragment', location: 'Map01' },
-  { id: 'verge_whispers', name: 'Verge Whispers', location: 'Map02' }
+  { id: 'verge_whispers', name: 'Verge Whispers', location: 'Map02' },
+  { id: 'verge_whispers', name: 'Verge Whispers', location: 'Map03' }
 ];

--- a/scripts/echo_data.js
+++ b/scripts/echo_data.js
@@ -12,8 +12,9 @@ export const echoData = {
     id: 'verge_whispers',
     flag: 'echo_verge_triggered',
     text: [
-      'A faint whisper rides the rain-soaked breeze.',
-      "Something ancient stirs beyond the water's edge."
+      'You stand at the edge of something unfinished.',
+      'Voices echo backwards in time… but remember nothing.',
+      'The verge remembers what you try to forget.'
     ]
   }
 };

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -33,9 +33,14 @@ export async function handleTileInteraction(
   const y = Number(target.dataset.y);
   const grid = getCurrentGrid();
   if (!grid || !grid[y] || !grid[y][x]) return;
-  if (!isAdjacent(player.x, player.y, x, y)) return;
 
   const tile = grid[y][x];
+  const sameTile = player.x === x && player.y === y;
+  if (tile.type === 'echo') {
+    if (!isAdjacent(player.x, player.y, x, y) && !sameTile) return;
+  } else if (!isAdjacent(player.x, player.y, x, y)) {
+    return;
+  }
   if (!isInteractable(tile.type)) return;
 
   if (tile.type === 'D' && tile.requiresItem === 'commander_badge') {

--- a/scripts/lore_state.js
+++ b/scripts/lore_state.js
@@ -36,3 +36,7 @@ export function hasLoreFlag(flag) {
 export function getLoreFlags() {
   return Array.from(flags);
 }
+
+export function isEchoVergeTriggered() {
+  return flags.has('echo_verge_triggered');
+}


### PR DESCRIPTION
## Summary
- add Verge Whispers echo tile on map03
- allow interacting with echo tiles from the same tile
- update Verge Whispers dialogue text
- list Verge Whispers echo under map03 in info panel
- expose `isEchoVergeTriggered` flag helper

## Testing
- `npx prettier --write data/maps/map03.json scripts/interaction.js scripts/echo_data.js info/echoes.js scripts/lore_state.js`
- `npx eslint data/maps/map03.json scripts/interaction.js scripts/echo_data.js info/echoes.js scripts/lore_state.js` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684898add494833195a3d207c25325a8