### PR TITLE
Add basic crafting feature with health amulet recipe

### DIFF
--- a/data/blueprints.json
+++ b/data/blueprints.json
@@ -2,14 +2,14 @@
   "health_amulet": {
     "id": "health_amulet",
     "name": "Health Amulet",
-    "ingredients": {"potion_of_health": 2},
+    "ingredients": { "health_potion": 2 },
     "result": "health_amulet",
     "quantity": 1
   },
   "cracked_helmet": {
     "id": "cracked_helmet",
     "name": "Cracked Helmet",
-    "ingredients": {"armor_piece": 3},
+    "ingredients": { "armor_piece": 3 },
     "result": "cracked_helmet",
     "quantity": 1
   }

--- a/data/items.json
+++ b/data/items.json
@@ -41,8 +41,8 @@
     "stackLimit": 1,
     "icon": "🗝️"
   },
-  "potion_of_health": {
-    "name": "Potion of Health",
+  "health_potion": {
+    "name": "Health Potion",
     "description": "Increases maximum health permanently.",
     "type": "consumable",
     "stackLimit": 5,

--- a/data/recipes.json
+++ b/data/recipes.json
@@ -2,14 +2,14 @@
   "healing_salve": {
     "id": "healing_salve",
     "name": "Healing Salve",
-    "ingredients": {"goblin_ear": 1, "rotten_tooth": 1},
-    "result": "potion_of_health",
+    "ingredients": { "goblin_ear": 1, "rotten_tooth": 1 },
+    "result": "health_potion",
     "quantity": 1
   },
   "health_amulet": {
     "id": "health_amulet",
     "name": "Health Amulet",
-    "ingredients": {"potion_of_health": 2},
+    "ingredients": { "health_potion": 2 },
     "result": "health_amulet",
     "quantity": 1
   }

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
       <div id="xp-display"></div>
       <div class="tab settings-tab">Settings</div>
       <div class="tab inventory-tab">Inventory</div>
+      <div class="tab craft-tab" style="display: none">Craft</div>
       <div class="tab quests-tab">Quests</div>
       <div class="tab status-tab">Status</div>
       <div class="tab null-tab disabled">The Null Factor</div>
@@ -28,6 +29,13 @@
         <div id="player-stats"></div>
         <div id="inventory-list"></div>
         <div id="forge-log" class="forge-log"></div>
+      </div>
+    </div>
+    <div id="craft-overlay" class="craft-overlay">
+      <div class="craft-content">
+        <button class="close-btn">&times;</button>
+        <h2>Crafting</h2>
+        <div id="craft-list"></div>
       </div>
     </div>
     <div id="quest-log-overlay" class="quest-overlay">

--- a/info/items.js
+++ b/info/items.js
@@ -2,11 +2,13 @@ export const usedItems = [];
 
 export const itemDescriptions = {
   map02_key: 'Unlocks the door from Rainy Crossroads to Twilight Field.',
-  health_amulet: 'Health Amulet \u2013 increases max HP by 2',
+  health_potion: 'Health Potion \u2013 permanently increases max HP by 1',
+  health_amulet: 'Health Amulet \u2013 increases max HP by 2 when crafted',
   empty_note: 'The note is blank, leaving more questions than answers.',
   focus_ring: 'A ring that sharpens concentration, boosting accuracy by 10%',
   commander_badge: 'Grants access from Twilight Field to Central Hub.',
-  faded_blade: "Vaelin's old weapon. Using it in combat grants +2 attack for that battle."
+  faded_blade:
+    "Vaelin's old weapon. Using it in combat grants +2 attack for that battle."
 };
 
 export function markItemUsed(id) {

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -83,7 +83,7 @@ export async function openChest(id, player) {
         giveItem(itm, 1);
         items.push(data);
         unlockedSkills.push(...unlockSkillsFromItem(itm));
-        if (player && itm === 'potion_of_health') {
+        if (player && itm === 'health_potion') {
           increaseMaxHp(1);
           gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
         }
@@ -95,7 +95,7 @@ export async function openChest(id, player) {
     if (item) {
       const qty = config.quantity || 1;
       giveItem(config.item, qty);
-      if (player && config.item === 'potion_of_health') {
+      if (player && config.item === 'health_potion') {
         increaseMaxHp(1);
         gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
       }

--- a/scripts/craft.js
+++ b/scripts/craft.js
@@ -15,6 +15,7 @@ import { getItemBonuses } from './item_stats.js';
 import { isRecipeUnlocked } from './recipe_state.js';
 import { loadJson } from './dataService.js';
 import { showError } from './errorPrompt.js';
+import { showDialogue } from './dialogueSystem.js';
 
 let craftingAllowed = false;
 
@@ -82,7 +83,10 @@ export async function craft(id) {
   if (!recipe) return false;
   if (blueprints[id] && !isBlueprintUnlocked(id)) return false;
   if (recipes[id] && !isRecipeUnlocked(id)) return false;
-  if (!canCraft(id)) return false;
+  if (!canCraft(id)) {
+    showDialogue('Missing materials.');
+    return false;
+  }
   for (const [item, qty] of Object.entries(recipe.ingredients)) {
     removeItem(item, qty);
   }
@@ -99,6 +103,7 @@ export async function craft(id) {
         new CustomEvent('equipmentCrafted', { detail: recipe.result })
       );
     }
+    showDialogue(`You've crafted ${data.name}!`);
     return true;
   }
   return false;

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -10,7 +10,7 @@ export const inventory = [];
 export const passiveModifiers = {};
 
 export function recalcPassiveModifiers() {
-  Object.keys(passiveModifiers).forEach(k => delete passiveModifiers[k]);
+  Object.keys(passiveModifiers).forEach((k) => delete passiveModifiers[k]);
   const eq = player.equipment || {};
   Object.values(eq).forEach((id) => {
     if (!id) return;
@@ -66,12 +66,12 @@ export function addItem(item) {
     if ((existing.quantity || 0) >= limit) return false;
     existing.quantity = Math.min(limit, (existing.quantity || 0) + qty);
     discover('items', parseItemId(item.id).baseId);
-      if (baseId === 'health_amulet') {
-        if (!player.bonusHpGiven?.health_amulet) {
-          gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 2;
-        }
-        applyItemReward(baseId);
+    if (baseId === 'health_amulet') {
+      if (!player.bonusHpGiven?.health_amulet) {
+        gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 2;
       }
+      applyItemReward(baseId);
+    }
     document.dispatchEvent(new CustomEvent('inventoryUpdated'));
     return true;
   }
@@ -84,7 +84,7 @@ export function addItem(item) {
     ...item,
     name,
     description: desc,
-    quantity: Math.min(qty, limit),
+    quantity: Math.min(qty, limit)
   });
   if (item.id && item.id.startsWith('blueprint_')) {
     unlockBlueprint(item.id.replace('blueprint_', ''));
@@ -164,7 +164,7 @@ export function getItemsByType(type) {
 }
 
 export function removeHealthBonusItem() {
-  const idx = inventory.findIndex((it) => it.id === 'potion_of_health');
+  const idx = inventory.findIndex((it) => it.id === 'health_potion');
   if (idx !== -1) {
     inventory.splice(idx, 1);
     document.dispatchEvent(new CustomEvent('inventoryUpdated'));

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -12,7 +12,7 @@ export const itemData = {
     name: 'Health Amulet',
     description: 'Permanently increases max HP when found.',
     type: 'passive',
-    stackLimit: 1,
+    stackLimit: 99,
     icon: '🩸'
   },
   empty_note: {
@@ -51,7 +51,8 @@ export const itemData = {
   faded_blade: {
     id: 'faded_blade',
     name: 'Faded Blade',
-    description: 'A worn weapon once carried by Vaelin. Use in battle to strike harder.',
+    description:
+      'A worn weapon once carried by Vaelin. Use in battle to strike harder.',
     type: 'combat',
     stackLimit: 1,
     icon: '🗡️'

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2,6 +2,7 @@ import { getCurrentGrid, isFogEnabled } from './mapLoader.js';
 import { onStepEffect, isWalkable } from './tile_type.js';
 import { toggleInventoryView } from './inventory_state.js';
 import { toggleQuestLog } from './quest_log.js';
+import { toggleCraftView } from './craft_ui.js';
 import { player, getTotalStats, stepTo } from './player.js';
 import { initFog, reveal, revealAll } from './fog_system.js';
 import { getRelicBonuses } from './relic_state.js';
@@ -18,6 +19,7 @@ import { showDialogue } from './dialogueSystem.js';
 import { handleTileInteraction } from './interaction.js';
 import { isMovementDisabled } from './movement.js';
 import { hasCodeFile, hasItem } from './inventory.js';
+import { craftState } from './craft_state.js';
 import { movePlayerTo, spawnEnemy } from './map.js';
 import * as eryndor from './npc/eryndor.js';
 import * as coren from './npc/coren.js';
@@ -187,6 +189,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const questsTab = document.querySelector('.quests-tab');
   const questsOverlay = document.getElementById('quest-log-overlay');
   const questsClose = questsOverlay.querySelector('.close-btn');
+  const craftTab = document.querySelector('.craft-tab');
+  const craftOverlay = document.getElementById('craft-overlay');
+  const craftClose = craftOverlay?.querySelector('.close-btn');
   const statusTab = document.querySelector('.status-tab');
   const nullTab = document.querySelector('.null-tab');
   const statusOverlay = document.getElementById('status-overlay');
@@ -233,6 +238,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   inventoryOverlay.addEventListener('click', (e) => {
     if (e.target === inventoryOverlay) toggleInventoryView();
   });
+  if (craftTab) craftTab.addEventListener('click', toggleCraftView);
+  if (craftClose) craftClose.addEventListener('click', toggleCraftView);
+  if (craftOverlay) {
+    craftOverlay.addEventListener('click', (e) => {
+      if (e.target === craftOverlay) toggleCraftView();
+    });
+  }
   questsTab.addEventListener('click', toggleQuestLog);
   questsClose.addEventListener('click', toggleQuestLog);
   questsOverlay.addEventListener('click', (e) => {
@@ -267,6 +279,19 @@ document.addEventListener('DOMContentLoaded', async () => {
     updateNullTab();
   }
   document.addEventListener('inventoryUpdated', updateNullTab);
+
+  function updateCraftTab() {
+    if (!craftTab) return;
+    if (craftState.unlockedBlueprints.size > 0) {
+      craftTab.style.display = 'block';
+    } else {
+      craftTab.style.display = 'none';
+    }
+  }
+
+  updateCraftTab();
+  document.addEventListener('blueprintUnlocked', updateCraftTab);
+  document.addEventListener('blueprintsLoaded', updateCraftTab);
 
   function showSettings() {
     settingsOverlay.classList.add('active');

--- a/style/main.css
+++ b/style/main.css
@@ -603,6 +603,78 @@ body {
   color: #fff;
 }
 
+/* Crafting UI */
+.craft-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 900;
+}
+
+.craft-overlay.active {
+  visibility: visible;
+  opacity: 1;
+}
+
+.craft-content {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 300px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  position: relative;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.craft-content h2 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.craft-content .close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.craft-item {
+  border-bottom: 1px solid #ddd;
+  padding: 6px 0;
+}
+
+.craft-item:last-child {
+  border-bottom: none;
+}
+
+.craft-item .desc {
+  font-size: 12px;
+  color: #555;
+}
+
+.craft-item .req.missing {
+  color: #c0392b;
+}
+
+.craft-item .req.have {
+  color: #27ae60;
+}
+
 /* Quest Log UI */
 .quest-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- add Craft tab and overlay
- show unlocked blueprints and requirements
- implement crafting messages
- add health_potion item and health_amulet blueprint
- allow crafting health_amulet once blueprint is obtained
- update style for crafting UI

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6848a1d42b10833187ff604e4a0e1699