### PR TITLE
Add rift stone door progression

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -557,6 +557,10 @@
       {
         "item": "chaos_organ",
         "quantity": 1
+      },
+      {
+        "item": "rift_stone",
+        "quantity": 1
       }
     ]
   },

--- a/data/items.json
+++ b/data/items.json
@@ -245,5 +245,12 @@
     "type": "material",
     "stackLimit": 99,
     "icon": "🕳️"
+  },
+  "rift_stone": {
+    "name": "Rift Stone",
+    "description": "A shard humming with unstable dimensional energy.",
+    "type": "key",
+    "stackLimit": 1,
+    "icon": "💎"
   }
 }

--- a/data/maps/map04.json
+++ b/data/maps/map04.json
@@ -447,6 +447,22 @@
       "F"
     ],
     [
+      {
+        "type": "D",
+        "target": "map03.json",
+        "spawn": {
+          "x": 1,
+          "y": 1
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
       "F",
       "F",
       "F",
@@ -463,17 +479,11 @@
         "spawn": {
           "x": 1,
           "y": 1
-        }
-      },
-      "F",
-      "F",
-      "F",
-      "F",
-      "F",
-      "F",
-      "F",
-      "F",
-      "F"
+        },
+        "locked": true,
+        "requiresItem": "rift_stone",
+        "consumeItem": true
+      }
     ],
     [
       "F",

--- a/info/enemies.js
+++ b/info/enemies.js
@@ -44,7 +44,7 @@ export const enemies = [
     name: 'Rift Lurker',
     map: 'Map04',
     location: '10,5',
-    drops: 'Chaos Organ',
+    drops: 'Rift Stone',
     skills: 'rift_touch'
   },
   {

--- a/info/items.js
+++ b/info/items.js
@@ -16,7 +16,9 @@ export const itemDescriptions = {
   ward_leaf:
     'Ward Leaf \u2013 a crafting material discovered in Isolation Nexus, prized for defensive rituals.',
   old_scroll:
-    'Old Scroll \u2013 a weathered document from Isolation Nexus. Someone may want to read it later.'
+    'Old Scroll \u2013 a weathered document from Isolation Nexus. Someone may want to read it later.',
+  rift_stone:
+    'Rift Stone \u2013 unlocks the sealed gate in Isolation Nexus after defeating the Rift Lurker.'
 };
 
 export function markItemUsed(id) {

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -750,3 +750,7 @@ export function flagMetLioran() {
 export function flagObtainedArcaneSpark() {
   setMemory('obtained_arcane_spark');
 }
+
+export function flagRiftLurkerDefeated() {
+  setMemory('rift_lurker_defeated');
+}

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -59,5 +59,18 @@ export async function handleTileInteraction(
     return newCols;
   }
 
+  if (tile.type === 'D' && tile.requiresItem === 'rift_stone' && tile.locked) {
+    if (!hasItem('rift_stone')) {
+      showDialogue(tile.message || 'A rift barrier blocks the way.');
+      return;
+    }
+    removeItem('rift_stone');
+    markItemUsed('rift_stone');
+    updateInventoryUI();
+    tile.locked = false;
+    const newCols = await enterDoor(tile.target, tile.spawn);
+    return newCols;
+  }
+
   return onInteractEffect(tile, x, y, player, container, cols, npcModules);
 }


### PR DESCRIPTION
## Summary
- add a new `rift_stone` key item
- make the Rift Lurker drop the rift stone and update info listings
- place a backtracking door to map03 and a locked door to map05 in map04
- add logic for rift stone locked doors and a dialogue flag for defeating the Rift Lurker

## Testing
- `npm run lint` *(fails: ESLint config not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b57e8a1c83319167a41b3e310bfd