### PR TITLE
Refactor main.js into smaller modules

### DIFF
--- a/scripts/npc/index.js
+++ b/scripts/npc/index.js
@@ -1,0 +1,91 @@
+// Consolidated NPC module exports for easier imports
+import * as arbiter from './arbiter.js';
+import * as arvalin from './arvalin.js';
+import * as breathlessNight from './breathless_night.js';
+import * as coren from './coren.js';
+import * as corruptionShrine from './corruption_shrine.js';
+import * as dreamEcho1 from './dream_echo1.js';
+import * as dreamEcho2 from './dream_echo2.js';
+import * as echoMemory from './echo_memory.js';
+import * as echoSelfFlame from './echo_self_flame.js';
+import * as echoSelfPeace from './echo_self_peace.js';
+import * as echoSelfShadow from './echo_self_shadow.js';
+import * as ember from './ember.js';
+import * as eryndor from './eryndor.js';
+import * as fieldNoteDisintegration from './field_note_disintegration.js';
+import * as firstMemory from './first_memory.js';
+import * as flamebound from './flamebound.js';
+import * as forgeNpc from './forge_npc.js';
+import * as forkGuide from './fork_guide.js';
+import * as goblinQuestGiver from './goblin_quest_giver.js';
+import * as grindle from './grindle.js';
+import * as korell from './korell.js';
+import * as krealer from './krealer.js';
+import * as krealer1 from './krealer1.js';
+import * as krealer2 from './krealer2.js';
+import * as krealer3 from './krealer3.js';
+import * as krealer4 from './krealer4.js';
+import * as krealer5 from './krealer5.js';
+import * as krealer6 from './krealer6.js';
+import * as krealer7 from './krealer7.js';
+import * as krealer8 from './krealer8.js';
+import * as lioran from './lioran.js';
+import * as loreObelisk from './lore_obelisk.js';
+import * as loreStatue from './lore_statue.js';
+import * as myralen from './myralen.js';
+import * as relicChamber from './relic_chamber.js';
+import * as ruinsScholar from './ruins_scholar.js';
+import * as secondVoice from './second_voice.js';
+import * as shadeSage from './shade_sage.js';
+import * as silentMonument from './silent_monument.js';
+import * as vaelin from './vaelin.js';
+import * as vaultkeeper from './vaultkeeper.js';
+import * as veil from './veil.js';
+import * as watcher from './watcher.js';
+
+// Export a single map of NPC ids to modules
+export const npcModules = {
+  arbiter,
+  arvalin,
+  breathless_night: breathlessNight,
+  coren,
+  corruption_shrine: corruptionShrine,
+  dream_echo1: dreamEcho1,
+  dream_echo2: dreamEcho2,
+  echo_memory: echoMemory,
+  echo_self_flame: echoSelfFlame,
+  echo_self_peace: echoSelfPeace,
+  echo_self_shadow: echoSelfShadow,
+  ember,
+  eryndor,
+  field_note_disintegration: fieldNoteDisintegration,
+  first_memory: firstMemory,
+  flamebound,
+  forge_npc: forgeNpc,
+  fork_guide: forkGuide,
+  goblin_quest_giver: goblinQuestGiver,
+  grindle,
+  korell,
+  krealer,
+  krealer1,
+  krealer2,
+  krealer3,
+  krealer4,
+  krealer5,
+  krealer6,
+  krealer7,
+  krealer8,
+  lioran,
+  lore_obelisk: loreObelisk,
+  lore_statue: loreStatue,
+  myralen,
+  relic_chamber: relicChamber,
+  ruins_scholar: ruinsScholar,
+  second_voice: secondVoice,
+  shade_sage: shadeSage,
+  silent_monument: silentMonument,
+  vaelin,
+  vaultkeeper,
+  veil,
+  watcher
+};

--- a/scripts/ui/playerDisplay.js
+++ b/scripts/ui/playerDisplay.js
@@ -1,0 +1,33 @@
+// Handles player stats display elements
+import { player, getTotalStats } from '../player.js';
+import { getRelicBonuses } from '../relic_state.js';
+
+let hpDisplay;
+let defenseDisplay;
+let xpDisplay;
+
+export function initPlayerDisplay() {
+  hpDisplay = document.getElementById('hp-display');
+  defenseDisplay = document.getElementById('defense-display');
+  xpDisplay = document.getElementById('xp-display');
+}
+
+export function updateHpDisplay() {
+  if (hpDisplay) {
+    const bonus = getRelicBonuses().maxHp || 0;
+    hpDisplay.textContent = `HP: ${player.hp}/${player.maxHp + bonus}`;
+  }
+}
+
+export function updateDefenseDisplay() {
+  if (defenseDisplay) {
+    const stats = getTotalStats();
+    defenseDisplay.textContent = `Defense: ${stats.defense || 0}`;
+  }
+}
+
+export function updateXpDisplay() {
+  if (xpDisplay) {
+    xpDisplay.textContent = `Level: ${player.level} XP: ${player.xp}/${player.xpToNextLevel}`;
+  }
+}


### PR DESCRIPTION
## Summary
- create `npc/index.js` to consolidate all NPC modules
- move player stat display code to `ui/playerDisplay.js`
- simplify `scripts/main.js` by importing these modules and initializing displays

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848c0489420833195ad930956eec9ac