### PR TITLE
Improve JSON asset loading error messages

### DIFF
--- a/scripts/dataService.js
+++ b/scripts/dataService.js
@@ -2,9 +2,18 @@ export async function loadJson(path) {
   try {
     const res = await fetch(path);
     if (!res.ok) {
-      throw new Error(`${res.status} ${res.statusText}`);
+      const msg =
+        res.status === 404
+          ? `File not found: ${path}`
+          : `${res.status} ${res.statusText} (${path})`;
+      throw new Error(msg);
     }
-    return await res.json();
+    const text = await res.text();
+    try {
+      return JSON.parse(text);
+    } catch (err) {
+      throw new Error(`Malformed JSON in ${path}: ${err.message}`);
+    }
   } catch (err) {
     console.error(`Failed to load ${path}`, err);
     return null;

--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -5,23 +5,20 @@ import { unlockSkillsFromItem, getAllSkills } from './skills.js';
 import { dialogueMemory, setMemory, giveBlueprint, triggerUpgrade, triggerReroll } from './dialogue_state.js';
 import { getQuests, completeQuest } from './quest_state.js';
 import { showError } from './errorPrompt.js';
+import { loadJson } from './dataService.js';
 
 let dialogueLines = {};
 let dataLoaded = false;
 
 async function loadDialogData() {
   if (dataLoaded) return;
-  try {
-    const res = await fetch('data/dialog.json');
-    if (res.ok) {
-      dialogueLines = await res.json();
-    }
-  } catch (err) {
-    console.error('Failed to load dialog data', err);
+  const data = await loadJson('data/dialog.json');
+  if (data) {
+    dialogueLines = data;
+  } else {
     showError('Failed to load dialogue');
-  } finally {
-    dataLoaded = true;
   }
+  dataLoaded = true;
 }
 
 export async function showDialogue(keyOrText, callback = () => {}) {

--- a/scripts/enemy.js
+++ b/scripts/enemy.js
@@ -1,19 +1,15 @@
 import { gameState } from './game_state.js';
 import { showError } from './errorPrompt.js';
+import { loadJson } from './dataService.js';
 
 let enemyData = {};
 
 export async function loadEnemyData() {
   if (Object.keys(enemyData).length) return enemyData;
-  try {
-    const res = await fetch('data/enemies.json');
-    if (res.ok) {
-      enemyData = await res.json();
-    } else {
-      throw new Error('Failed to load enemies');
-    }
-  } catch (err) {
-    console.error(err);
+  const data = await loadJson('data/enemies.json');
+  if (data) {
+    enemyData = data;
+  } else {
     showError('Failed to load enemies');
   }
   return enemyData;

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -1,4 +1,5 @@
 import { showError } from './errorPrompt.js';
+import { loadJson } from './dataService.js';
 import {
   markForkVisited,
   visitedBothForks,
@@ -57,11 +58,11 @@ export async function loadMap(name) {
       showDialogue('Obtain code file to enter.');
       return null;
     }
-    const response = await fetch(`data/maps/${name}.json`);
-    if (!response.ok) {
-      throw new Error(`Failed to load map ${name}`);
+    data = await loadJson(`data/maps/${name}.json`);
+    if (!data) {
+      showError(`Failed to load map ${name}`);
+      return null;
     }
-    data = await response.json();
     if (name === 'map06_left') markForkVisited('left');
     if (name === 'map06_right') markForkVisited('right');
     if (name === 'map07' && visitedBothForks()) {
@@ -177,7 +178,7 @@ export async function loadMap(name) {
     }
   } catch (err) {
     console.error(err);
-    showError(`Failed to load map ${name}`);
+    showError(err.message || `Failed to load map ${name}`);
     throw err;
   }
   currentEnvironment = data.environment || 'clear';


### PR DESCRIPTION
## Summary
- enhance `loadJson` helper to detect missing or malformed files
- use `loadJson` when loading maps, enemies and dialogue
- surface file-specific errors when a map fails to load

## Testing
- `npm run lint` *(fails: cannot find ESLint config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c2e783b483319c2ab99c5c31aea3