### PR TITLE
Add rotating skills to Arcane Wretch

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -575,7 +575,8 @@
     "description": "A warped mage that disrupts magic.",
     "intro": "Arcane whispers herald the wretch's arrival!",
     "portrait": "🧟‍♂️",
-    "skills": ["silence_wave"],
+    "skills": ["silence_wave", "arcane_bolt", "weakening_hex"],
+    "cycleSkills": true,
     "behavior": "aggressive",
     "drops": [
       {

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -137,6 +137,7 @@ export async function startCombat(enemy, player) {
   player.tempAttack = 0;
   enemy.tempDefense = 0;
   enemy.tempAttack = 0;
+  enemy.skillIndex = 0;
 
   updateHpBar(playerBar, playerHp, playerMax);
   updateHpBar(enemyBar, enemyHp, enemyMax);
@@ -594,6 +595,12 @@ export async function startCombat(enemy, player) {
     const behavior = enemy.behavior || 'balanced';
     const special = isElite(enemy) || isBoss(enemy);
 
+    if (enemy.cycleSkills && list.length) {
+      const idx = enemy.skillIndex || 0;
+      skill = list[idx % list.length];
+      enemy.skillIndex = (idx + 1) % list.length;
+    } else {
+
     if (special && list.length >= 2) {
       skill = list[Math.floor(Math.random() * list.length)];
     } else if (playerVulnerable && statusSkills.length) {
@@ -619,6 +626,7 @@ export async function startCombat(enemy, player) {
         playerTurn = true;
         return;
       }
+    }
     }
 
     if (skill) {

--- a/scripts/enemy_skills.js
+++ b/scripts/enemy_skills.js
@@ -284,6 +284,38 @@ export const enemySkills = {
       log(`${enemy.name} touches you for ${applied} damage. Reality wavers!`);
     }
   },
+  arcane_bolt: {
+    id: 'arcane_bolt',
+    name: 'Arcane Bolt',
+    icon: '✨',
+    description: 'A burst of arcane energy dealing 7 damage.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 0,
+    aiType: 'damage',
+    effect({ enemy, damagePlayer, log }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = 7 + atk + (enemy.tempAttack || 0);
+      const applied = damagePlayer(dmg);
+      log(`${enemy.name} hurls an arcane bolt for ${applied} damage!`);
+    }
+  },
+  weakening_hex: {
+    id: 'weakening_hex',
+    name: 'Weakening Hex',
+    icon: '🌀',
+    description: 'Applies Weakened for 3 turns.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 0,
+    aiType: 'status',
+    applies: ['weakened'],
+    statuses: [{ target: 'player', id: 'weakened', duration: 3 }],
+    effect({ enemy, player, applyStatus, log }) {
+      applyStatus(player, 'weakened', 3);
+      log(`${enemy.name} hexes you with weakening magic!`);
+    }
+  },
   silence_wave: {
     id: 'silence_wave',
     name: 'Silencing Wave',


### PR DESCRIPTION
## Summary
- add new enemy skills `arcane_bolt` and `weakening_hex`
- give Arcane Wretch three skills and enable skill rotation
- track skill index and cycle enemy skills during combat

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848d3dfa87c8331a344e695c5a5c3c8