### PR TITLE
Add rift eye door logic

### DIFF
--- a/data/maps/map05.json
+++ b/data/maps/map05.json
@@ -268,7 +268,10 @@
           "x": 1,
           "y": 1
         },
-        "locked": true
+        "locked": true,
+        "requiresItem": "rift_eye",
+        "consumeItem": true,
+        "message": "A singular socket awaits a gaze… but you hold no eye."
       }
     ],
     [

--- a/info/items.js
+++ b/info/items.js
@@ -26,7 +26,7 @@ export const itemDescriptions = {
   psy_fiber:
     'Psy Fiber \u2013 material for neural implants or debuff recipes.',
   rift_eye:
-    'Rift Eye \u2013 rumored to open a psychic gate somewhere.',
+    'Rift Eye \u2013 rumored to open a psychic gate somewhere; unlocks rift gate.',
   memory_gem:
     'Memory Gem \u2013 trade or socket this to improve your skills.',
   crystal_shard: 'Crystal Shard \u2013 can be used later to upgrade skills.',

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -7,6 +7,7 @@ import { hasItem, removeItem } from './inventory.js';
 import { updateInventoryUI } from './inventory_state.js';
 import { showDialogue } from './dialogueSystem.js';
 import { markItemUsed } from '../info/items.js';
+import { setMemory } from './dialogue_state.js';
 import { enterDoor } from './player.js';
 
 /**
@@ -68,6 +69,23 @@ export async function handleTileInteraction(
     markItemUsed('rift_stone');
     updateInventoryUI();
     tile.locked = false;
+    const newCols = await enterDoor(tile.target, tile.spawn);
+    return newCols;
+  }
+
+  if (tile.type === 'D' && tile.requiresItem === 'rift_eye' && tile.locked) {
+    if (!hasItem('rift_eye')) {
+      showDialogue(
+        tile.message ||
+          'A singular socket awaits a gaze… but you hold no eye.'
+      );
+      return;
+    }
+    removeItem('rift_eye');
+    markItemUsed('rift_eye');
+    updateInventoryUI();
+    tile.locked = false;
+    setMemory('entered_map06');
     const newCols = await enterDoor(tile.target, tile.spawn);
     return newCols;
   }

--- a/scripts/tile_type.js
+++ b/scripts/tile_type.js
@@ -83,7 +83,7 @@ export async function onInteractEffect(
     case 'D': {
       const required = tile.key || tile.requiresItem;
       const targetMap = tile.target;
-      if (required && !hasItem(required)) {
+      if (required && !hasItem(required) && tile.locked) {
         showDialogue("It\u2019s locked.");
         break;
       }


### PR DESCRIPTION
## Summary
- lock the Convergence Rift exit behind the `rift_eye`
- describe `rift_eye` as unlocking the rift gate
- handle the `rift_eye` door in interaction logic and mark `entered_map06`
- allow doors to remain open once unlocked without needing key again

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6848eba14bc08331870c47eed03a3c54