### PR TITLE
Implement item categories and consumption logic

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -11,7 +11,7 @@ import { getPassive } from './passive_skills.js';
 import { applyDamage } from './logic.js';
 import {
   addItem,
-  getItemsByTag,
+  getItemsByCategory,
   addItemToInventory,
   removeHealthBonusItem
 } from './inventory.js';
@@ -314,7 +314,7 @@ export async function startCombat(enemy, player) {
 
   function updateItemsUI() {
     itemContainer.innerHTML = '';
-    const items = getItemsByTag('combat');
+    const items = getItemsByCategory('combat');
     if (items.length === 0) {
       const msg = document.createElement('div');
       msg.textContent = 'No usable items';

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -53,7 +53,7 @@ export async function handleTileInteraction(
       showDialogue(tile.message || 'The insignia is missing.');
       return;
     }
-    removeItem('commander_badge');
+    useKey('commander_badge');
     markItemUsed('commander_badge');
     updateInventoryUI();
     const newCols = await enterDoor(tile.target, tile.spawn);
@@ -65,7 +65,7 @@ export async function handleTileInteraction(
       showDialogue(tile.message || 'A rift barrier blocks the way.');
       return;
     }
-    removeItem('rift_stone');
+    useKey('rift_stone');
     markItemUsed('rift_stone');
     updateInventoryUI();
     tile.locked = false;
@@ -81,7 +81,7 @@ export async function handleTileInteraction(
       );
       return;
     }
-    removeItem('rift_eye');
+    useKey('rift_eye');
     markItemUsed('rift_eye');
     updateInventoryUI();
     tile.locked = false;

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -127,18 +127,18 @@ export function hasItem(nameOrId) {
 
 export function useForkedKey() {
   if (hasItem('forked_key')) {
-    removeItem('forked_key');
+    const data = getItemData('forked_key');
+    if (data?.consumable !== false) removeItem('forked_key');
     return true;
   }
   return false;
 }
 
 export function useKey(id) {
-  if (hasItem(id)) {
-    removeItem(id);
-    return true;
-  }
-  return false;
+  if (!hasItem(id)) return false;
+  const data = getItemData(id);
+  if (data?.consumable !== false) removeItem(id);
+  return true;
 }
 
 export function hasCodeFile() {
@@ -164,6 +164,8 @@ export function removeItem(nameOrId, qty = 1) {
 }
 
 export function consumeItem(id, qty = 1) {
+  const data = getItemData(id);
+  if (data?.consumable === false) return false;
   const removed = removeItem(id, qty);
   if (removed) recordItemUse(id, qty);
   return removed;
@@ -173,6 +175,13 @@ export function getItemsByTag(tag) {
   return inventory.filter((it) => {
     const data = getItemData(it.id);
     return data && Array.isArray(data.tags) && data.tags.includes(tag);
+  });
+}
+
+export function getItemsByCategory(category) {
+  return inventory.filter((it) => {
+    const data = getItemData(it.id);
+    return data && data.category === category;
   });
 }
 

--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -4,7 +4,7 @@ import {
   getEquippedItem,
   getItemDisplayName,
   getItemLevel,
-  getItemsByTag
+  getItemsByCategory
 } from './inventory.js';
 import { player, getTotalStats } from './player.js';
 import {
@@ -62,7 +62,9 @@ export async function updateInventoryUI() {
     const stats = getTotalStats();
     statsEl.textContent = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}  Attack: ${stats.attack || 0}  Defense: ${stats.defense || 0}`;
   }
-  const filtered = getItemsByTag(currentCategory);
+  let cat = currentCategory;
+  if (cat === 'items') cat = 'general';
+  const filtered = getItemsByCategory(cat);
   if (filtered.length === 0) {
     const msg = document.createElement('div');
     msg.classList.add('info-empty');
@@ -125,7 +127,7 @@ export async function updateInventoryUI() {
     }
 
     const baseData = getItemData(item.id);
-    if (baseData && Array.isArray(baseData.tags) && baseData.tags.includes('combat')) {
+    if (baseData && baseData.category === 'combat') {
       const ubtn = document.createElement('button');
       ubtn.classList.add('equip-btn');
       ubtn.textContent = 'Use';

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -5,6 +5,8 @@ export const itemData = {
     description: 'Required to unlock the path to the next map.',
     type: 'key',
     tags: ['lore'],
+    category: 'key',
+    consumable: false,
     stackLimit: 1,
     icon: '🗝️'
   },
@@ -14,6 +16,8 @@ export const itemData = {
     description: 'Recovers 20 HP when used in combat.',
     type: 'combat',
     tags: ['combat'],
+    category: 'combat',
+    consumable: true,
     stackLimit: 5,
     icon: '🧪',
     useInCombat: true
@@ -24,6 +28,8 @@ export const itemData = {
     description: 'Permanently increases max HP when found.',
     type: 'passive',
     tags: ['equipable'],
+    category: 'equipable',
+    consumable: false,
     stackLimit: 99,
     icon: '🩸'
   },
@@ -33,6 +39,8 @@ export const itemData = {
     description: 'This chest was empty.',
     type: 'quest',
     tags: ['lore'],
+    category: 'lore',
+    consumable: false,
     stackLimit: 1,
     icon: '📝'
   },
@@ -42,6 +50,8 @@ export const itemData = {
     description: 'Slightly improves the accuracy of all skills.',
     type: 'gear',
     tags: ['equipable'],
+    category: 'equipable',
+    consumable: false,
     stackLimit: 1,
     icon: '🎯',
     passiveModifier: { accuracy: 0.1 }
@@ -52,6 +62,8 @@ export const itemData = {
     description: 'A crude bow taken from a goblin archer.',
     type: 'gear',
     tags: ['equipable'],
+    category: 'equipable',
+    consumable: false,
     stackLimit: 1,
     icon: '🏹'
   },
@@ -61,6 +73,8 @@ export const itemData = {
     description: 'Proof of defeating the scout commander.',
     type: 'gear',
     tags: ['equipable'],
+    category: 'equipable',
+    consumable: false,
     stackLimit: 1,
     icon: '🎖️'
   },
@@ -71,6 +85,8 @@ export const itemData = {
       'A worn weapon once carried by Vaelin. Use in battle to strike harder.',
     type: 'combat',
     tags: ['combat'],
+    category: 'combat',
+    consumable: true,
     stackLimit: 1,
     icon: '🗡️',
     useInCombat: true
@@ -81,6 +97,8 @@ export const itemData = {
     description: 'A light blade once wielded by a goblin scout.',
     type: 'material',
     tags: ['items'],
+    category: 'general',
+    consumable: true,
     stackLimit: 1,
     icon: '🔪'
   },
@@ -90,6 +108,8 @@ export const itemData = {
     description: 'Fragment used in defense-crafting rituals.',
     type: 'material',
     tags: ['items'],
+    category: 'general',
+    consumable: true,
     stackLimit: 99,
     icon: '🦴'
   },
@@ -99,6 +119,8 @@ export const itemData = {
     description: 'Still oozing with foul ichor.',
     type: 'quest',
     tags: ['lore'],
+    category: 'general',
+    consumable: true,
     stackLimit: 99,
     icon: '❤️'
   },
@@ -108,6 +130,8 @@ export const itemData = {
     description: 'Offers minimal protection despite the damage.',
     type: 'gear',
     tags: ['equipable'],
+    category: 'equipable',
+    consumable: false,
     stackLimit: 1,
     icon: '🪖'
   },
@@ -117,6 +141,8 @@ export const itemData = {
     description: 'Refreshes all skill cooldowns once.',
     type: 'combat',
     tags: ['combat'],
+    category: 'combat',
+    consumable: true,
     stackLimit: 99,
     icon: '🔮',
     useInCombat: true
@@ -127,6 +153,8 @@ export const itemData = {
     description: 'Used later for crafting defense-enhancing items.',
     type: 'material',
     tags: ['items'],
+    category: 'general',
+    consumable: true,
     stackLimit: 99,
     icon: '🍃'
   },
@@ -136,6 +164,8 @@ export const itemData = {
     description: 'Triggers hidden dialogue with a future ally.',
     type: 'quest',
     tags: ['lore'],
+    category: 'lore',
+    consumable: false,
     stackLimit: 1,
     icon: '📜'
   },
@@ -145,6 +175,8 @@ export const itemData = {
     description: 'Unleashes a burst damaging all foes once per battle.',
     type: 'combat',
     tags: ['combat'],
+    category: 'combat',
+    consumable: true,
     stackLimit: 3,
     icon: '✨',
     useInCombat: true
@@ -155,6 +187,8 @@ export const itemData = {
     description: 'Metal scrap useful for future armor crafting.',
     type: 'material',
     tags: ['items'],
+    category: 'general',
+    consumable: true,
     stackLimit: 99,
     icon: '🛡️'
   },
@@ -164,6 +198,8 @@ export const itemData = {
     description: 'Rare organ from rift creatures used in potent fusions.',
     type: 'material',
     tags: ['items'],
+    category: 'general',
+    consumable: true,
     stackLimit: 99,
     icon: '🧬'
   },
@@ -173,6 +209,8 @@ export const itemData = {
     description: 'Traded among scholars for high-level crafting.',
     type: 'material',
     tags: ['items'],
+    category: 'general',
+    consumable: true,
     stackLimit: 99,
     icon: '🕳️'
   },
@@ -182,6 +220,8 @@ export const itemData = {
     description: 'A faintly glowing fragment used for skill upgrades.',
     type: 'material',
     tags: ['items'],
+    category: 'general',
+    consumable: true,
     stackLimit: 99,
     icon: '🔷'
   },
@@ -191,6 +231,8 @@ export const itemData = {
     description: 'Increases defense by 2 for this fight.',
     type: 'combat',
     tags: ['combat'],
+    category: 'combat',
+    consumable: true,
     stackLimit: 10,
     icon: '🧴',
     useInCombat: true
@@ -201,6 +243,8 @@ export const itemData = {
     description: 'Used to enhance life-based skills (future).',
     type: 'material',
     tags: ['items'],
+    category: 'general',
+    consumable: true,
     stackLimit: 99,
     icon: '🧬'
   },
@@ -210,6 +254,8 @@ export const itemData = {
     description: 'Required for crafting crystalline armor later.',
     type: 'material',
     tags: ['items'],
+    category: 'general',
+    consumable: true,
     stackLimit: 99,
     icon: '✨'
   },
@@ -219,6 +265,8 @@ export const itemData = {
     description: 'Component in neural implants or debuff skills.',
     type: 'material',
     tags: ['items'],
+    category: 'general',
+    consumable: true,
     stackLimit: 99,
     icon: '🧠'
   },
@@ -228,6 +276,8 @@ export const itemData = {
     description: 'May open a sealed psychic gate elsewhere.',
     type: 'key',
     tags: ['lore'],
+    category: 'key',
+    consumable: false,
     stackLimit: 1,
     icon: '👁️'
   },
@@ -237,6 +287,8 @@ export const itemData = {
     description: 'Can be socketed or traded for a skill token.',
     type: 'material',
     tags: ['lore'],
+    category: 'lore',
+    consumable: false,
     stackLimit: 99,
     icon: '🔮'
   },
@@ -246,6 +298,8 @@ export const itemData = {
     description: 'A fragment pulsing with dimensional energy.',
     type: 'quest',
     tags: ['lore'],
+    category: 'lore',
+    consumable: false,
     stackLimit: 1,
     icon: '💠'
   }

--- a/scripts/npc_trade.js
+++ b/scripts/npc_trade.js
@@ -1,0 +1,6 @@
+import { removeItem } from './inventory.js';
+
+export function giveNpcItem(id, qty = 1) {
+  return removeItem(id, qty);
+}
+


### PR DESCRIPTION
## Summary
- categorize all items with new `category` and `consumable` fields
- adjust inventory logic to respect `consumable` and expose `getItemsByCategory`
- use new category system in combat, UI, and interactions
- add helper for NPC trades

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848fa0b52348331aa8acf639aed7262