### PR TITLE
Handle uncategorized items and show key items

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
           <button data-cat="items" class="selected">Items</button>
           <button data-cat="equipable">Equipable Items</button>
           <button data-cat="combat">Combat Items</button>
+          <button data-cat="key">Key Items</button>
           <button data-cat="lore">Lore Items</button>
         </div>
         <div id="inventory-list"></div>

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -181,7 +181,9 @@ export function getItemsByTag(tag) {
 export function getItemsByCategory(category) {
   return inventory.filter((it) => {
     const data = getItemData(it.id);
-    return data && data.category === category;
+    if (!data) return false;
+    const cat = data.category || 'general';
+    return cat === category;
   });
 }
 


### PR DESCRIPTION
## Summary
- default `getItemsByCategory` to treat missing categories as `general`
- add a new UI tab to view **Key Items** separately

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848ff5b00e88331aea1b7b6cf68ecae