### PR TITLE
Unify inventory tab styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,11 +28,11 @@
         <h2>Inventory</h2>
         <div id="player-stats"></div>
         <div class="inventory-categories">
-          <button data-cat="items" class="selected">Items</button>
-          <button data-cat="equipable">Equipable Items</button>
-          <button data-cat="combat">Combat Items</button>
-          <button data-cat="key">Key Items</button>
-          <button data-cat="lore">Lore Items</button>
+          <button data-cat="items" class="tab selected">Items</button>
+          <button data-cat="equipable" class="tab">Equipable Items</button>
+          <button data-cat="combat" class="tab">Combat Items</button>
+          <button data-cat="key" class="tab">Key Items</button>
+          <button data-cat="lore" class="tab">Lore Items</button>
         </div>
         <div id="inventory-list"></div>
         <div id="forge-log" class="forge-log"></div>

--- a/style/main.css
+++ b/style/main.css
@@ -255,20 +255,25 @@ body {
 }
 
 #ui-bar .tab {
-  background: #333;
   margin: 0 5px;
+}
+
+.tab {
+  background: #333;
   padding: 8px 12px;
   cursor: pointer;
   border-radius: 4px;
   transition: background 0.2s;
   border: 1px solid #444;
+  color: #fff;
+  font-weight: 600;
 }
 
-#ui-bar .tab:hover {
+.tab:hover {
   background: #555;
 }
 
-#ui-bar .tab.disabled {
+.tab.disabled {
   opacity: 0.5;
   pointer-events: none;
 }
@@ -567,16 +572,16 @@ body {
   margin-bottom: 8px;
 }
 
-.inventory-categories button {
+.inventory-categories .tab {
   flex: 1;
-  padding: 4px;
-  font-size: 12px;
+  margin: 0;
+  padding: 6px 10px;
+  font-size: 14px;
 }
 
-.inventory-categories button.selected {
-  background: #666;
-  color: #fff;
-  border-color: #999;
+.inventory-categories .tab.selected {
+  background: #555;
+  border-color: #666;
 }
 
 .inventory-content .close-btn {


### PR DESCRIPTION
## Summary
- reuse `.tab` class for inventory categories
- tweak layout so Inventory buttons match the main menu

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849036ced5883319e67d63a08b1f465