### PR TITLE
Fix doors to not consume key items

### DIFF
--- a/data/maps/map01.json
+++ b/data/maps/map01.json
@@ -83,7 +83,7 @@
         },
         "locked": true,
         "requiresItem": "rusty_key",
-        "consumeItem": true
+        "consumeItem": false
       },
       "F"
     ],

--- a/data/maps/map02.json
+++ b/data/maps/map02.json
@@ -293,7 +293,7 @@
         "type": "D",
         "locked": true,
         "requiresItem": "map02_key",
-        "consumeItem": true,
+        "consumeItem": false,
         "target": "map03.json",
         "spawn": {
           "x": 1,

--- a/data/maps/map03.json
+++ b/data/maps/map03.json
@@ -155,7 +155,7 @@
         },
         "locked": true,
         "requiresItem": "commander_badge",
-        "consumeItem": true,
+        "consumeItem": false,
         "message": "The insignia is missing."
       }
     ],

--- a/data/maps/map04.json
+++ b/data/maps/map04.json
@@ -458,7 +458,7 @@
         },
         "locked": true,
         "requiresItem": "rift_stone",
-        "consumeItem": true
+        "consumeItem": false
       }
     ],
     [

--- a/data/maps/map05.json
+++ b/data/maps/map05.json
@@ -270,7 +270,7 @@
         },
         "locked": true,
         "requiresItem": "rift_eye",
-        "consumeItem": true,
+        "consumeItem": false,
         "message": "A singular socket awaits a gaze… but you hold no eye."
       }
     ],


### PR DESCRIPTION
## Summary
- retain keys upon unlocking doors on maps 1–5

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849053592e88331b9000df4cf755838