### PR TITLE
Add Caelen NPC with prism key trade

### DIFF
--- a/data/maps/map06.json
+++ b/data/maps/map06.json
@@ -248,7 +248,7 @@
       "G",
       "G",
       "G",
-      "G",
+      { "type": "N", "npc": "caelen" },
       "G",
       "G",
       "G",
@@ -447,7 +447,9 @@
           "x": 1,
           "y": 1
         },
-        "locked": true
+        "locked": true,
+        "requiresItem": "prism_key",
+        "consumeItem": false
       },
       "F"
     ],

--- a/info/items.js
+++ b/info/items.js
@@ -47,6 +47,8 @@ export const itemDescriptions = {
     'Crystal Seed \u2013 essential for future item upgrades.',
   mana_scroll:
     'Mana Scroll \u2013 completely refreshes all skill cooldowns.',
+  prism_key:
+    'Prism Key \u2013 obtained from Caelen in map06, unlocks the path to the next area.',
   forgotten_ring:
     'Forgotten Ring \u2013 when worn, grants +1 attack.'
 };

--- a/info/npc.js
+++ b/info/npc.js
@@ -24,4 +24,11 @@ export const npcs = [
     map: 'Map05',
     description: 'Watcher of the rift who mutters about echoes.'
   }
+  ,
+  {
+    id: 'caelen',
+    name: 'Caelen',
+    map: 'Map06',
+    description: 'World-weary trader offering a key for magical exchange.'
+  }
 ];

--- a/info/npcs.js
+++ b/info/npcs.js
@@ -30,4 +30,11 @@ export const npcs = [
     map: 'Map05',
     description: 'Watcher of the rift who mutters about echoes.'
   }
+  ,
+  {
+    id: 'caelen',
+    name: 'Caelen',
+    map: 'Map06',
+    description: 'World-weary trader offering a key for magical exchange.'
+  }
 ];

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -754,3 +754,7 @@ export function flagObtainedArcaneSpark() {
 export function flagRiftLurkerDefeated() {
   setMemory('rift_lurker_defeated');
 }
+
+export function flagTradedForPrismKey() {
+  setMemory('traded_for_prism_key');
+}

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -383,6 +383,17 @@ export const itemData = {
     icon: '📜',
     useInCombat: true
   },
+  prism_key: {
+    id: 'prism_key',
+    name: 'Prism Key',
+    description: 'Unlocks the door to the final mirror.',
+    type: 'key',
+    tags: ['lore'],
+    category: 'key',
+    consumable: false,
+    stackLimit: 1,
+    icon: '🗝️'
+  },
   forgotten_ring: {
     id: 'forgotten_ring',
     name: 'Forgotten Ring',

--- a/scripts/npc/caelen.js
+++ b/scripts/npc/caelen.js
@@ -1,0 +1,6 @@
+import { startDialogueTree } from '../dialogueSystem.js';
+import { caelenDialogue } from '../npc_dialogues/caelen_dialogue.js';
+
+export function interact() {
+  startDialogueTree(caelenDialogue);
+}

--- a/scripts/npc/index.js
+++ b/scripts/npc/index.js
@@ -44,6 +44,7 @@ import * as vaelin from './vaelin.js';
 import * as vaultkeeper from './vaultkeeper.js';
 import * as veil from './veil.js';
 import * as watcher from './watcher.js';
+import * as caelen from './caelen.js';
 
 // Export a single map of NPC ids to modules
 export const npcModules = {
@@ -91,5 +92,6 @@ export const npcModules = {
   vaelin,
   vaultkeeper,
   veil,
-  watcher
+  watcher,
+  caelen
 };

--- a/scripts/npcInfo.js
+++ b/scripts/npcInfo.js
@@ -80,6 +80,11 @@ export const npcInfoList = [
     description: 'Hermit-technician who unlocks Fusion Crafting.'
   },
   {
+    id: 'caelen',
+    name: 'Caelen',
+    description: 'World-weary trader intrigued by magic artifacts.'
+  },
+  {
     id: 'krealer',
     name: 'Krealer',
     description: 'A cryptic entity guarding forbidden knowledge.'

--- a/scripts/npc_dialogues/caelen_dialogue.js
+++ b/scripts/npc_dialogues/caelen_dialogue.js
@@ -1,0 +1,34 @@
+import { removeItem, addItem } from '../inventory.js';
+import { loadItems, getItemData } from '../item_loader.js';
+
+export const caelenDialogue = [
+  {
+    text: 'Traveler, the mirrored gate needs a special key. Do you seek it?',
+    options: [
+      { label: 'What key?', goto: 1 },
+      { label: 'Just passing by.', goto: null }
+    ]
+  },
+  {
+    text: 'I can part with the prism key, but magic calls for magic. Bring me a mana scroll.',
+    options: [
+      {
+        label: 'Trade mana scroll.',
+        goto: 2,
+        condition: state => (state.inventory['mana_scroll'] || 0) >= 1,
+        onChoose: async () => {
+          await loadItems();
+          const data = getItemData('prism_key') || { name: 'Prism Key', description: '' };
+          removeItem('mana_scroll', 1);
+          addItem({ ...data, id: 'prism_key', quantity: 1 });
+        },
+        memoryFlag: 'traded_for_prism_key'
+      },
+      { label: 'Not right now.', goto: null }
+    ]
+  },
+  {
+    text: 'Use it wisely. The door ahead will open with this prism key.',
+    options: [ { label: 'Thank you.', goto: null } ]
+  }
+];


### PR DESCRIPTION
## Summary
- place Caelen on map06 and require prism_key to open map07
- add prism_key item data and info entry
- implement Caelen dialogue for trading mana_scroll for prism_key
- register Caelen in NPC lists and module index
- expose flagTradedForPrismKey in dialogue state

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490fbf52048331ab337f2e7d55371a