### PR TITLE
Add Darius NPC with dialogue tree

### DIFF
--- a/data/maps/map07_maze02.json
+++ b/data/maps/map07_maze02.json
@@ -242,7 +242,10 @@
         "type": "W"
       },
       "G",
-      "G",
+      {
+        "type": "N",
+        "npc": "darius_the_conversationalist"
+      },
       "F",
       "G",
       "G",

--- a/info/items.js
+++ b/info/items.js
@@ -50,7 +50,11 @@ export const itemDescriptions = {
   maze_key_1: 'Maze Key 1 \u2013 opens the western maze in the Gatepoint Room.',
   maze_key_2:
     'Maze Key 2 \u2013 unlocks the northern gate of the Gatepoint Room.',
-  forgotten_ring: 'Forgotten Ring \u2013 when worn, grants +1 attack.'
+  forgotten_ring: 'Forgotten Ring \u2013 when worn, grants +1 attack.',
+  clarity_shard:
+    'Clarity Shard \u2013 clears debuffs and grants Focus when used in combat.',
+  gentle_flask: 'Gentle Flask \u2013 restores a little health outside combat.',
+  dreamleaf: 'Dreamleaf \u2013 useful for brewing potions later.'
 };
 
 export function markItemUsed(id) {

--- a/info/npc.js
+++ b/info/npc.js
@@ -30,5 +30,13 @@ export const npcs = [
     name: 'Caelen',
     map: 'Map06',
     description: 'World-weary trader offering a key for magical exchange.'
+  },
+  {
+    id: 'darius_the_conversationalist',
+    name: 'Darius',
+    map: 'Map07 Maze',
+    location: '4,10',
+    items: 'Clarity Shard, Gentle Flask, Dreamleaf',
+    description: 'Affable wanderer who loves long conversations.'
   }
 ];

--- a/info/npcs.js
+++ b/info/npcs.js
@@ -36,5 +36,13 @@ export const npcs = [
     name: 'Caelen',
     map: 'Map06',
     description: 'World-weary trader offering a key for magical exchange.'
+  },
+  {
+    id: 'darius_the_conversationalist',
+    name: 'Darius',
+    map: 'Map07 Maze',
+    location: '4,10',
+    items: 'Clarity Shard, Gentle Flask, Dreamleaf',
+    description: 'Affable wanderer who loves long conversations.'
   }
 ];

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -139,7 +139,7 @@ export async function openChest(id, player) {
     for (const itm of config.items) {
       const data = getItemData(itm);
       if (data) {
-        giveItem(itm, 1);
+        await giveItem(itm, 1);
         items.push(data);
         unlockedSkills.push(...unlockSkillsFromItem(itm));
         if (player && itm === 'health_potion') {
@@ -153,7 +153,7 @@ export async function openChest(id, player) {
     item = getItemData(config.item);
     if (item) {
       const qty = config.quantity || 1;
-      giveItem(config.item, qty);
+      await giveItem(config.item, qty);
       if (player && config.item === 'health_potion') {
         increaseMaxHp(1);
         gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -115,10 +115,14 @@ export function addItemToInventory(item) {
   return addItem(item);
 }
 
-export function giveItem(id, quantity = 1) {
+export async function giveItem(id, quantity = 1) {
+  const { loadItems } = await import('./item_loader.js');
+  await loadItems();
   const data = getItemData(id);
   if (!data) return false;
-  return addItem({ ...data, id, quantity });
+  const added = addItem({ ...data, id, quantity });
+  document.dispatchEvent(new CustomEvent('inventoryUpdated'));
+  return added;
 }
 
 export function hasItem(nameOrId) {

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -427,6 +427,40 @@ export const itemData = {
     stackLimit: 1,
     icon: '🗝️'
   },
+  clarity_shard: {
+    id: 'clarity_shard',
+    name: 'Clarity Shard',
+    description: 'Use in combat to clear debuffs and gain "Focus".',
+    type: 'combat',
+    tags: ['combat'],
+    category: 'combat',
+    consumable: true,
+    stackLimit: 3,
+    icon: '🔷',
+    useInCombat: true
+  },
+  gentle_flask: {
+    id: 'gentle_flask',
+    name: 'Gentle Flask',
+    description: 'Restores 2 HP outside combat.',
+    type: 'usable',
+    tags: ['usable'],
+    category: 'general',
+    consumable: true,
+    stackLimit: 5,
+    icon: '🥤'
+  },
+  dreamleaf: {
+    id: 'dreamleaf',
+    name: 'Dreamleaf',
+    description: 'Can be used later to mix with herbs for potions.',
+    type: 'material',
+    tags: ['items'],
+    category: 'crafting',
+    consumable: true,
+    stackLimit: 99,
+    icon: '🌿'
+  },
   forgotten_ring: {
     id: 'forgotten_ring',
     name: 'Forgotten Ring',

--- a/scripts/npc/darius_the_conversationalist.js
+++ b/scripts/npc/darius_the_conversationalist.js
@@ -1,0 +1,7 @@
+import { startDialogueTree } from '../dialogueSystem.js';
+import { createDariusDialogue } from '../npc_dialogues/darius_the_conversationalist.js';
+
+export async function interact() {
+  const dialogue = await createDariusDialogue();
+  startDialogueTree(dialogue);
+}

--- a/scripts/npc/index.js
+++ b/scripts/npc/index.js
@@ -45,6 +45,7 @@ import * as vaultkeeper from './vaultkeeper.js';
 import * as veil from './veil.js';
 import * as watcher from './watcher.js';
 import * as caelen from './caelen.js';
+import * as darius_the_conversationalist from './darius_the_conversationalist.js';
 import * as npc01 from './npc_01.js';
 import * as npc02 from './npc_02.js';
 import * as npc03 from './npc_03.js';
@@ -98,6 +99,7 @@ export const npcModules = {
   veil,
   watcher,
   caelen,
+  darius_the_conversationalist,
   npc_01: npc01,
   npc_02: npc02,
   npc_03: npc03,

--- a/scripts/npc_dialogues/darius_the_conversationalist.js
+++ b/scripts/npc_dialogues/darius_the_conversationalist.js
@@ -1,0 +1,119 @@
+import { loadItems } from '../item_loader.js';
+
+export async function createDariusDialogue() {
+  await loadItems();
+  return [
+    {
+      text: 'Greetings, traveler! Care to spare a moment for conversation?',
+      options: [
+        { label: 'Who are you?', goto: 1 },
+        { label: 'How do I leave this maze?', goto: 4 },
+        { label: 'Share some wisdom.', goto: 6 },
+        { label: 'Do you have supplies?', goto: 8 },
+        { label: 'Tell me a story.', goto: 10 },
+        { label: 'I need help in battle.', goto: 12 },
+        { label: 'Maybe another time.', goto: null }
+      ]
+    },
+    {
+      text: "I'm Darius, once a wanderer, now a listener to echoes.",
+      options: [
+        { label: 'Sounds interesting.', goto: 2 },
+        { label: 'Good to meet you.', goto: null }
+      ]
+    },
+    {
+      text: 'In traveling these halls I found a shard that sharpens focus.',
+      options: [
+        { label: 'Any chance I could use it?', goto: 3 },
+        { label: 'Keep it safe.', goto: null }
+      ]
+    },
+    {
+      text: 'Certainly. May it clear your mind when danger strikes.',
+      options: [
+        {
+          label: 'Accept the shard',
+          goto: null,
+          give: 'clarity_shard',
+          condition: state => !state.memory.has('darius_clarity_given'),
+          memoryFlag: 'darius_clarity_given'
+        },
+        { label: 'No thank you.', goto: null }
+      ]
+    },
+    {
+      text: 'Paths twist upon themselves. Keep your left hand to the wall and you will circle back here.',
+      options: [
+        { label: 'Appreciate it.', goto: 5 },
+        { label: 'Why stay here?', goto: 5 }
+      ]
+    },
+    {
+      text: 'I stay because new faces bring new thoughts. That is enough for now.',
+      options: [ { label: 'I see.', goto: null } ]
+    },
+    {
+      text: 'Wisdom? Hmm. Listening is the first step to understanding.',
+      options: [
+        { label: 'Go on.', goto: 7 },
+        { label: 'I will remember that.', goto: null }
+      ]
+    },
+    {
+      text: 'And understanding is but a doorway to more questions.',
+      options: [ { label: 'Thought provoking.', goto: null } ]
+    },
+    {
+      text: 'Supplies are scarce, but I do have something gentle for weary bones.',
+      options: [
+        { label: 'A small drink would help.', goto: 9 },
+        { label: 'Save it for later.', goto: null }
+      ]
+    },
+    {
+      text: 'Here, this flask should ease your travels.',
+      options: [
+        {
+          label: 'Thank you.',
+          goto: null,
+          give: 'gentle_flask',
+          condition: state => !state.memory.has('darius_flask_given'),
+          memoryFlag: 'darius_flask_given'
+        },
+        { label: 'I actually do not need it.', goto: null }
+      ]
+    },
+    {
+      text: 'Very well. Let me recount a brief tale of dreams within dreams.',
+      options: [
+        { label: 'Listen closely.', goto: 11 },
+        { label: 'Another time.', goto: null }
+      ]
+    },
+    {
+      text: 'The story ends without an answer, leaving only reflection.',
+      options: [ { label: 'Interesting.', goto: null } ]
+    },
+    {
+      text: 'For battle, natural remedies often serve best.',
+      options: [
+        { label: 'Do you have one to spare?', goto: 13 },
+        { label: 'I will manage.', goto: null }
+      ]
+    },
+    {
+      text: 'Take this dreamleaf. Mix it later with herbs for potent brews.',
+      options: [
+        {
+          label: 'Accept the leaf',
+          goto: null,
+          give: 'dreamleaf',
+          condition: state => !state.memory.has('darius_leaf_given'),
+          memoryFlag: 'darius_leaf_given'
+        },
+        { label: 'Maybe later.', goto: null }
+      ]
+    }
+  ];
+}

--- a/scripts/npc_dialogues/lioran_dialogue.js
+++ b/scripts/npc_dialogues/lioran_dialogue.js
@@ -24,7 +24,7 @@ export const lioranDialogue = [
           const { loadItems } = await import('../item_loader.js');
           await loadItems();
           const inv = await import('../inventory.js');
-          inv.giveItem('focus_ring');
+          await inv.giveItem('focus_ring');
         }
       },
       {


### PR DESCRIPTION
## Summary
- add Darius the Conversationalist NPC to map07_maze02 at location 4,10
- create dialogue tree with multiple branches and item rewards
- register new items (clarity shard, gentle flask, dreamleaf)
- support async `giveItem` for combat items and update users
- document Darius and new items in info files

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684921bca3d0833185a1968e3bd1546c