### PR TITLE
Add Kaelor the Weaver NPC

### DIFF
--- a/data/maps/map07_maze02.json
+++ b/data/maps/map07_maze02.json
@@ -180,7 +180,10 @@
       "G",
       "G",
       "F",
-      "G",
+      {
+        "type": "N",
+        "npc": "kaelor_the_weaver"
+      },
       "G",
       "G",
       "G",

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -770,3 +770,7 @@ export function flagRiftLurkerDefeated() {
 export function flagTradedForPrismKey() {
   setMemory('traded_for_prism_key');
 }
+
+export function flagTradedWithKaelor() {
+  setMemory('traded_with_kaelor');
+}

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -211,6 +211,10 @@ export function removeHealthBonusItem() {
   return false;
 }
 
+export function removePrismFragments(qty = 10) {
+  return removeItem('prism_fragment', qty);
+}
+
 export function equipItem(itemId) {
   const bonus = getItemBonuses(itemId);
   if (!bonus || !bonus.slot) return false;

--- a/scripts/npc/index.js
+++ b/scripts/npc/index.js
@@ -46,6 +46,7 @@ import * as veil from './veil.js';
 import * as watcher from './watcher.js';
 import * as caelen from './caelen.js';
 import * as darius_the_conversationalist from './darius_the_conversationalist.js';
+import * as kaelor_the_weaver from './kaelor_the_weaver.js';
 import * as npc01 from './npc_01.js';
 import * as npc02 from './npc_02.js';
 import * as npc03 from './npc_03.js';
@@ -100,6 +101,7 @@ export const npcModules = {
   watcher,
   caelen,
   darius_the_conversationalist,
+  kaelor_the_weaver,
   npc_01: npc01,
   npc_02: npc02,
   npc_03: npc03,

--- a/scripts/npc/kaelor_the_weaver.js
+++ b/scripts/npc/kaelor_the_weaver.js
@@ -1,0 +1,7 @@
+import { startDialogueTree } from '../dialogueSystem.js';
+import { createKaelorDialogue } from '../npc_dialogues/kaelor_the_weaver.js';
+
+export async function interact() {
+  const dialogue = await createKaelorDialogue();
+  startDialogueTree(dialogue);
+}

--- a/scripts/npcInfo.js
+++ b/scripts/npcInfo.js
@@ -88,6 +88,11 @@ export const npcInfoList = [
     id: 'krealer',
     name: 'Krealer',
     description: 'A cryptic entity guarding forbidden knowledge.'
+  },
+  {
+    id: 'kaelor_the_weaver',
+    name: 'Kaelor the Weaver',
+    description: 'Pragmatic trader who exchanges fragments for a key.'
   }
 ];
 

--- a/scripts/npc_dialogues/kaelor_the_weaver.js
+++ b/scripts/npc_dialogues/kaelor_the_weaver.js
@@ -1,0 +1,34 @@
+import { removePrismFragments, addItem } from '../inventory.js';
+import { loadItems, getItemData } from '../item_loader.js';
+
+export async function createKaelorDialogue() {
+  await loadItems();
+  return [
+    {
+      text: 'Need the last key? Ten prism fragments. No haggling.',
+      options: [
+        {
+          label: 'Trade fragments.',
+          goto: 1,
+          condition: state =>
+            (state.inventory['prism_fragment'] || 0) >= 10 &&
+            !state.memory.has('traded_with_kaelor'),
+          onChoose: () => {
+            const data = getItemData('maze_key_2') || {
+              name: 'Maze Key 2',
+              description: ''
+            };
+            removePrismFragments(10);
+            addItem({ ...data, id: 'maze_key_2', quantity: 1 });
+          },
+          memoryFlag: 'traded_with_kaelor'
+        },
+        { label: 'Maybe later.', goto: null }
+      ]
+    },
+    {
+      text: 'Deal done. That key opens the north gate.',
+      options: [{ label: 'Understood.', goto: null }]
+    }
+  ];
+}


### PR DESCRIPTION
## Summary
- add Kaelor the Weaver NPC and dialogue
- allow removing prism fragments via inventory helper
- expose Kaelor in NPC index and info list
- track `traded_with_kaelor` memory flag
- place Kaelor in map07_maze02

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684923fa10c0833194d7dd78d45eb651