### PR TITLE
Add Silari the analyst NPC

### DIFF
--- a/data/maps/map07_maze02.json
+++ b/data/maps/map07_maze02.json
@@ -113,7 +113,7 @@
       "G",
       {
         "type": "N",
-        "npc": "npc_02"
+        "npc": "silari_the_analyst"
       },
       "G",
       "G",

--- a/info/npc.js
+++ b/info/npc.js
@@ -38,5 +38,12 @@ export const npcs = [
     location: '4,10',
     items: 'Clarity Shard, Gentle Flask, Dreamleaf',
     description: 'Affable wanderer who loves long conversations.'
+  },
+  {
+    id: 'silari_the_analyst',
+    name: 'Silari',
+    map: 'Map07 Maze',
+    location: '4,15',
+    description: 'Calm informant who answers lore questions, not a trader.'
   }
 ];

--- a/info/npcs.js
+++ b/info/npcs.js
@@ -45,4 +45,12 @@ export const npcs = [
     items: 'Clarity Shard, Gentle Flask, Dreamleaf',
     description: 'Affable wanderer who loves long conversations.'
   }
+  ,
+  {
+    id: 'silari_the_analyst',
+    name: 'Silari',
+    map: 'Map07 Maze',
+    location: '4,15',
+    description: 'Calm informant who answers lore questions, not a trader.'
+  }
 ];

--- a/scripts/npc/index.js
+++ b/scripts/npc/index.js
@@ -46,6 +46,7 @@ import * as veil from './veil.js';
 import * as watcher from './watcher.js';
 import * as caelen from './caelen.js';
 import * as darius_the_conversationalist from './darius_the_conversationalist.js';
+import * as silari_the_analyst from './silari_the_analyst.js';
 import * as kaelor_the_weaver from './kaelor_the_weaver.js';
 import * as npc01 from './npc_01.js';
 import * as npc02 from './npc_02.js';
@@ -101,6 +102,7 @@ export const npcModules = {
   watcher,
   caelen,
   darius_the_conversationalist,
+  silari_the_analyst,
   kaelor_the_weaver,
   npc_01: npc01,
   npc_02: npc02,

--- a/scripts/npc/silari_the_analyst.js
+++ b/scripts/npc/silari_the_analyst.js
@@ -1,0 +1,7 @@
+import { startDialogueTree } from '../dialogueSystem.js';
+import { createSilariDialogue } from '../npc_dialogues/silari_the_analyst.js';
+
+export async function interact() {
+  const dialogue = await createSilariDialogue();
+  startDialogueTree(dialogue);
+}

--- a/scripts/npc_dialogues/silari_the_analyst.js
+++ b/scripts/npc_dialogues/silari_the_analyst.js
@@ -1,0 +1,55 @@
+export async function createSilariDialogue() {
+  return [
+    {
+      text: 'Silari traces symbols in the dust, waiting for your question.',
+      options: [
+        { label: 'What are Echoes?', goto: 1 },
+        { label: 'What do people do with an old coin?', goto: 3 },
+        { label: 'Why do doors lock in this world?', goto: 5 },
+        { label: 'What\u2019s the difference between a trap and a test?', goto: 7 },
+        { label: 'What happens if you lose too many memories?', goto: 9 },
+        { label: 'Maybe later.', goto: null }
+      ]
+    },
+    {
+      text: 'Echoes are the maze remembering itself.',
+      options: [ { label: 'And us?', goto: 2 } ]
+    },
+    {
+      text: 'We add new notes to its endless song.',
+      options: [ { label: 'I see.', goto: null, memoryFlag: 'asked_echoes' } ]
+    },
+    {
+      text: 'Old coins buy stories. Some trade them for guidance, some for luck.',
+      options: [ { label: 'Does it work?', goto: 4 } ]
+    },
+    {
+      text: 'Only if belief is strong; otherwise they remain metal.',
+      options: [ { label: 'Thank you.', goto: null, memoryFlag: 'asked_coin' } ]
+    },
+    {
+      text: 'Doors lock to give shape to our wanderings.',
+      options: [ { label: 'Who locks them?', goto: 6 } ]
+    },
+    {
+      text: 'Perhaps the architects, perhaps our fears.',
+      options: [ { label: 'Makes sense.', goto: null, memoryFlag: 'asked_doors' } ]
+    },
+    {
+      text: 'A trap condemns, a test prepares.',
+      options: [ { label: 'So this maze is?', goto: 8 } ]
+    },
+    {
+      text: 'Both, if we listen to the lessons.',
+      options: [ { label: 'Understood.', goto: null, memoryFlag: 'asked_trap' } ]
+    },
+    {
+      text: 'Lose too many memories and you fade into an Echo.',
+      options: [ { label: 'Can they return?', goto: 10 } ]
+    },
+    {
+      text: 'Sometimes. Echoes hold what we misplace.',
+      options: [ { label: 'Farewell.', goto: null, memoryFlag: 'asked_memories' } ]
+    }
+  ];
+}


### PR DESCRIPTION
## Summary
- add `silari_the_analyst` NPC with lore-based dialogue
- load new NPC in the index
- place Silari in `map07_maze02.json`
- document Silari in `info/npc.js`
- update `info/npcs.js` for completeness

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684925f05a2c8331bd8673a3c212f787