### PR TITLE
Add Verrel the Voice NPC

### DIFF
--- a/data/maps/map07_maze02.json
+++ b/data/maps/map07_maze02.json
@@ -379,6 +379,10 @@
         "type": "N",
         "npc": "npc_04"
       },
+      {
+        "type": "N",
+        "npc": "verrel_the_voice"
+      },
       "G",
       "G",
       "G",

--- a/info/npc.js
+++ b/info/npc.js
@@ -23,8 +23,7 @@ export const npcs = [
     name: 'Thalos',
     map: 'Map05',
     description: 'Watcher of the rift who mutters about echoes.'
-  }
-  ,
+  },
   {
     id: 'caelen',
     name: 'Caelen',
@@ -45,5 +44,12 @@ export const npcs = [
     map: 'Map07 Maze',
     location: '4,15',
     description: 'Calm informant who answers lore questions, not a trader.'
+  },
+  {
+    id: 'verrel_the_voice',
+    name: 'Verrel',
+    map: 'Map07 Maze',
+    location: '16,15',
+    description: 'Speaks of kindness, leaves you with less.'
   }
 ];

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -774,3 +774,7 @@ export function flagTradedForPrismKey() {
 export function flagTradedWithKaelor() {
   setMemory('traded_with_kaelor');
 }
+
+export function flagManipulatedByVerrel() {
+  setMemory('manipulated_by_verrel');
+}

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -215,6 +215,23 @@ export function removePrismFragments(qty = 10) {
   return removeItem('prism_fragment', qty);
 }
 
+export function removeEnemyDropItem() {
+  const enemyItems = [
+    'prism_fragment',
+    'goblin_ear',
+    'zombie_claw',
+    'cracked_signet',
+    'arcane_core'
+  ];
+  for (const id of enemyItems) {
+    if (getItemCount(id) > 0) {
+      removeItem(id, 1);
+      return id;
+    }
+  }
+  return null;
+}
+
 export function equipItem(itemId) {
   const bonus = getItemBonuses(itemId);
   if (!bonus || !bonus.slot) return false;

--- a/scripts/npc/index.js
+++ b/scripts/npc/index.js
@@ -52,6 +52,7 @@ import * as npc01 from './npc_01.js';
 import * as npc02 from './npc_02.js';
 import * as npc03 from './npc_03.js';
 import * as npc04 from './npc_04.js';
+import * as verrel_the_voice from './verrel_the_voice.js';
 
 // Export a single map of NPC ids to modules
 export const npcModules = {
@@ -107,5 +108,6 @@ export const npcModules = {
   npc_01: npc01,
   npc_02: npc02,
   npc_03: npc03,
-  npc_04: npc04
+  npc_04: npc04,
+  verrel_the_voice
 };

--- a/scripts/npc/verrel_the_voice.js
+++ b/scripts/npc/verrel_the_voice.js
@@ -1,0 +1,7 @@
+import { startDialogueTree } from '../dialogueSystem.js';
+import { createVerrelDialogue } from '../npc_dialogues/verrel_the_voice.js';
+
+export async function interact() {
+  const dialogue = await createVerrelDialogue();
+  startDialogueTree(dialogue);
+}

--- a/scripts/npc_dialogues/verrel_the_voice.js
+++ b/scripts/npc_dialogues/verrel_the_voice.js
@@ -1,0 +1,78 @@
+import { removeEnemyDropItem } from '../inventory.js';
+import { loadItems } from '../item_loader.js';
+
+const hasEnemyDrop = (state) =>
+  (state.inventory['prism_fragment'] || 0) > 0 ||
+  (state.inventory['goblin_ear'] || 0) > 0 ||
+  (state.inventory['zombie_claw'] || 0) > 0 ||
+  (state.inventory['cracked_signet'] || 0) > 0 ||
+  (state.inventory['arcane_core'] || 0) > 0;
+
+export async function createVerrelDialogue() {
+  await loadItems();
+  return [
+    {
+      text: 'A gentle voice resonates from the dim corridor. "Traveler, spare a moment?"',
+      options: [
+        { label: 'Who is speaking?', goto: 1 },
+        { label: 'Walk away.', goto: null }
+      ]
+    },
+    {
+      text: 'I am Verrel, merely a keeper of tokens forgotten.',
+      options: [
+        { label: 'Tokens?', goto: 2 },
+        { label: 'I have none.', goto: 3 }
+      ]
+    },
+    {
+      text: 'The shards and claws you take from foes cling to you. May I relieve you of one?',
+      options: [
+        { label: 'Perhaps.', goto: 4, condition: hasEnemyDrop },
+        { label: 'No, I need them.', goto: 3 }
+      ]
+    },
+    {
+      text: 'Then we have little more to discuss. Farewell.',
+      options: [{ label: 'Leave.', goto: null }]
+    },
+    {
+      text: 'A single piece is all I ask. Why hold tight to grim trophies?',
+      options: [
+        { label: 'Why do you want it?', goto: 5 },
+        {
+          label: 'Fine, take one.',
+          goto: 7,
+          condition: hasEnemyDrop,
+          onChoose: () => removeEnemyDropItem(),
+          memoryFlag: 'manipulated_by_verrel'
+        },
+        { label: 'I refuse.', goto: 6 }
+      ]
+    },
+    {
+      text: 'To keep you from carrying the echoes of violence. Guilt is a slow poison.',
+      options: [
+        { label: 'Maybe you are right.', goto: 6 },
+        { label: 'I doubt that.', goto: null }
+      ]
+    },
+    {
+      text: 'Consider how light you would feel, freed of just one burden.',
+      options: [
+        {
+          label: 'Take it then.',
+          goto: 7,
+          condition: hasEnemyDrop,
+          onChoose: () => removeEnemyDropItem(),
+          memoryFlag: 'manipulated_by_verrel'
+        },
+        { label: 'Still no.', goto: null }
+      ]
+    },
+    {
+      text: 'Verrel accepts the item with a whisper of thanks that chills the air.',
+      options: [{ label: 'Leave him behind.', goto: null }]
+    }
+  ];
+}


### PR DESCRIPTION
## Summary
- add Verrel the Voice NPC to map07_maze02
- implement manipulative dialogue removing enemy items
- support removing enemy drop items in inventory
- record 'manipulated_by_verrel' memory flag
- document Verrel in NPC info

## Testing
- `npx prettier --write scripts/npc/verrel_the_voice.js scripts/npc_dialogues/verrel_the_voice.js info/npc.js data/maps/map07_maze02.json scripts/inventory.js scripts/dialogue_state.js scripts/npc/index.js`
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684926ec12d8833191cd96238526d42f