### PR TITLE
Add temple harmony set and floor 03

### DIFF
--- a/data/maps/map09_floor03.json
+++ b/data/maps/map09_floor03.json
@@ -1,0 +1,29 @@
+{
+  "name": "Temple of Depths — Floor III",
+  "environment": "ruins",
+  "grid": [
+    "FFFFFFFFFFFFFFFFFFFF",
+    [
+      "F","G","G","G","G","G","G","G","G",
+      {"type":"D","target":"map09_floor02.json","spawn":{"x":10,"y":18}},
+      "G","G","G","G","G","G","G","G","G","F"
+    ],
+    "FGGGGGGGGGGGGGGGGGGF",
+    ["F","G","G","T","C","G","G","G","G","G","G","G","G","G","G","G","G","G","G","F"],
+    "FGGGGGGGGGGGGGGGGGGF",
+    ["F","G","t","G","G","G","G","G","G","C","G","G","G","G","G","G","G","t","G","F"],
+    "FGGGGGGGGGGGGGGGGGGF",
+    ["F","G","G","G","G","G","T","G","G","G","G","G","G","G","G","G","G","G","G","F"],
+    ["F","G","G","G","G","G","G","G","G","G","G","F","F","t","G","C","G","G","G","F"],
+    "FGGGGGtGGGGGGGGGGGGF",
+    ["F","G","G","G","G","G","T","G","G","G","G","G","G","G","G","G","G","G","G","F"],
+    ["F","G","G","G","G","G","G","G","G","T","G","G","G","G","G","G","G","G","G","F"],
+    ["F","G","G","G","t","G","G","G","G","G","G","G","G","G","G","G","G","G","G","F"],
+    "FGGGGGGGGGGGGGGGGGGF",
+    "FGGGGGGGGGGGGGGGGGGF",
+    ["F","G","G","T","G","G","G","G","G","G","G","G","G","G","G","G","G","G","G","F"],
+    "FGGGGGGGGGGGGGGGGGGF",
+    "FGGGGGGGGGGGGGGGGGGF",
+    "FFFFFFFFFFFFFFFFFFFF"
+  ]
+}

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -3,7 +3,7 @@ import { addItem, giveItem } from './inventory.js';
 import { updateInventoryUI } from './inventory_ui.js';
 import { giveRelic, setMemory } from './dialogue_state.js';
 import { getItemData, loadItems } from './item_loader.js';
-import { increaseMaxHp } from './player.js';
+import { increaseMaxHp, loseHpNonLethal } from './player.js';
 import { unlockSkillsFromItem, unlockSkillsFromRelic } from './skills.js';
 
 const chestContents = {
@@ -131,6 +131,21 @@ const chestContents = {
     item: 'ember_prayer_scroll',
     message: 'Inside rests a sealed scroll etched in ember.'
   },
+  'map09_floor03:4,3': {
+    item: 'temple_sword',
+    hpLoss: 10,
+    message: 'A guardian trap drains your strength as you claim the sword.'
+  },
+  'map09_floor03:9,5': {
+    item: 'temple_shell',
+    hpLoss: 10,
+    message: 'Ancient energies lash out when the shell is taken.'
+  },
+  'map09_floor03:15,8': {
+    item: 'temple_ring',
+    hpLoss: 10,
+    message: 'Cursed fumes seep out as you grasp the ring.'
+  },
   'map_warrior:18,18': {
     relic: 'warrior_sigil',
     message: 'You obtained the Warrior Sigil!'
@@ -195,6 +210,9 @@ export async function openChest(id, player) {
   if (config.relic) {
     giveRelic(config.relic);
     unlockedSkills.push(...unlockSkillsFromRelic(config.relic));
+  }
+  if (config.hpLoss && player) {
+    loseHpNonLethal(config.hpLoss);
   }
   return { item, items, message: config.message || null, unlockedSkills };
 }

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -203,6 +203,10 @@ export async function startCombat(enemy, player) {
       log('Reflected the damage back!');
       reflectActive = false;
     }
+    if (player.templeSetActive && applied > 0) {
+      damageEnemy(2);
+      healPlayer(1);
+    }
     return applied;
   }
 

--- a/scripts/equipment.js
+++ b/scripts/equipment.js
@@ -1,0 +1,13 @@
+import { player } from './player.js';
+
+const SET_PASSIVE_ID = 'temple_harmony';
+
+export function checkTempleSet() {
+  const eq = player.equipment || {};
+  const hasSet =
+    eq.weapon?.startsWith('temple_sword') &&
+    eq.armor?.startsWith('temple_shell') &&
+    eq.accessory?.startsWith('temple_ring');
+  player.templeSetActive = !!hasSet;
+  document.dispatchEvent(new CustomEvent('equipmentSetChecked'));
+}

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -2,6 +2,7 @@ import { getItemData } from './item_loader.js';
 import { player, applyItemReward } from './player.js';
 import { gameState } from './game_state.js';
 import { getItemBonuses } from './item_stats.js';
+import { checkTempleSet } from './equipment.js';
 import { unlockBlueprint } from './craft_state.js';
 import { discover } from './player_memory.js';
 import { isRelic } from './relic_state.js';
@@ -243,6 +244,7 @@ export function equipItem(itemId) {
   }
   player.equipment[bonus.slot] = itemId;
   recalcPassiveModifiers();
+  checkTempleSet();
   document.dispatchEvent(new CustomEvent('equipmentChanged'));
   return true;
 }

--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -152,6 +152,12 @@ export async function updateInventoryUI() {
       });
       tooltipText = effects.join(', ');
     }
+    const baseId = splitItemId(item.id).baseId;
+    if (baseId === 'temple_sword' || baseId === 'temple_shell' || baseId === 'temple_ring') {
+      if (tooltipText) tooltipText += '\n';
+      tooltipText += 'Temple Set piece';
+      if (player.templeSetActive) tooltipText += ' (Set active)';
+    }
     if (tooltipText) {
       row.addEventListener('mouseenter', () =>
         showItemTooltip(row, tooltipText)

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -706,6 +706,39 @@ export const itemData = {
     stackLimit: 99,
     icon: '🌫️'
   },
+  temple_sword: {
+    id: 'temple_sword',
+    name: 'Temple Sword',
+    description: 'A blade resonating with ancient power.',
+    type: 'gear',
+    tags: ['equipable'],
+    category: 'equipable',
+    consumable: false,
+    stackLimit: 1,
+    icon: '🗡️'
+  },
+  temple_shell: {
+    id: 'temple_shell',
+    name: 'Temple Shell',
+    description: 'Hardened armor bearing sacred sigils.',
+    type: 'gear',
+    tags: ['equipable'],
+    category: 'equipable',
+    consumable: false,
+    stackLimit: 1,
+    icon: '🛡️'
+  },
+  temple_ring: {
+    id: 'temple_ring',
+    name: 'Temple Ring',
+    description: 'An ornate band linked to temple rites.',
+    type: 'gear',
+    tags: ['equipable'],
+    category: 'equipable',
+    consumable: false,
+    stackLimit: 1,
+    icon: '💍'
+  },
   echo_crystal: {
     id: 'echo_crystal',
     name: 'Echo Crystal',

--- a/scripts/item_stats.js
+++ b/scripts/item_stats.js
@@ -8,7 +8,10 @@ export const itemBonuses = {
   'cracked_helmet+3': { slot: 'armor', defense: 4 },
   commander_badge: { slot: 'weapon', attack: 2 },
   focus_ring: { slot: 'accessory' },
-  forgotten_ring: { slot: 'accessory', attack: 1 }
+  forgotten_ring: { slot: 'accessory', attack: 1 },
+  temple_sword: { slot: 'weapon', attack: 3 },
+  temple_shell: { slot: 'armor', defense: 2, maxHp: 5 },
+  temple_ring: { slot: 'accessory', attack: 1, defense: 1, maxHp: 2 }
 };
 
 export function getItemBonuses(id) {

--- a/scripts/menu/status.js
+++ b/scripts/menu/status.js
@@ -54,6 +54,16 @@ export function updateStatusPanel() {
     }
     equipList.appendChild(row);
   });
+  if (player.templeSetActive) {
+    const row = document.createElement('div');
+    row.classList.add('status-equip');
+    row.innerHTML = '<strong>Set Bonus:</strong> Temple Harmony';
+    row.addEventListener('mouseenter', () =>
+      showItemTooltip(row, 'Counter 2 dmg and heal 1 HP when hit')
+    );
+    row.addEventListener('mouseleave', hideItemTooltip);
+    equipList.appendChild(row);
+  }
   info.textContent = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}`;
   (player.passives || []).forEach(id => {
     const p = defs[id];

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -59,6 +59,14 @@ export function takeDamage(amount) {
   if (player.hp === 0) triggerDeath();
 }
 
+export function loseHpNonLethal(amount) {
+  if (typeof amount !== 'number' || amount <= 0) return;
+  player.hp = Math.max(1, player.hp - amount);
+  document.dispatchEvent(
+    new CustomEvent('playerHpChanged', { detail: { hp: player.hp, maxHp: player.maxHp } })
+  );
+}
+
 export function isAlive() {
   return player.hp > 0;
 }


### PR DESCRIPTION
## Summary
- build final temple floor with cursed chests
- add Temple Sword, Shell and Ring items
- grant stats for temple gear
- apply Temple Harmony bonus in combat when full set equipped
- drop HP on cursed chests without killing
- show set info in inventory and status panels

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68493bc7ed108331904472094ea6b473