### PR TITLE
Fix duplicate variable declaration in inventory UI

### DIFF
--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -152,7 +152,7 @@ export async function updateInventoryUI() {
       });
       tooltipText = effects.join(', ');
     }
-    const baseId = splitItemId(item.id).baseId;
+    // baseId was already extracted above; reuse it here to check for set pieces
     if (baseId === 'temple_sword' || baseId === 'temple_shell' || baseId === 'temple_ring') {
       if (tooltipText) tooltipText += '\n';
       tooltipText += 'Temple Set piece';


### PR DESCRIPTION
## Summary
- avoid redeclaring `baseId` when building inventory UI

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68496a971ce083319acb3a2c5f36f900