### PR TITLE
Remove unused relics

### DIFF
--- a/data/relics.json
+++ b/data/relics.json
@@ -9,28 +9,11 @@
     "description": "An ancient badge that bolsters defense.",
     "bonuses": { "defense": 2 }
   },
-  "warrior_sigil": {
-    "name": "Warrior Sigil",
-    "description": "Awarded for proving your strength in combat.",
-    "class": "warrior",
-    "bonuses": { "attack": 2 }
-  },
-  "guardian_emblem": {
-    "name": "Guardian Emblem",
-    "description": "A token that reinforces protective instincts.",
-    "class": "guardian",
-    "bonuses": { "defense": 2 }
-  },
   "alchemist_catalyst": {
     "name": "Alchemist Catalyst",
     "description": "A mysterious powder that empowers concoctions.",
     "class": "alchemist",
     "bonuses": { "itemHealBonus": 1 }
-  },
-  "mirror_shard": {
-    "name": "Mirror Shard",
-    "description": "Reflects the trials of shadow and flame, empowering the bearer.",
-    "bonuses": { "attack": 1, "defense": 1 }
   },
   "compass_core": {
     "name": "Compass Core",

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -146,14 +146,6 @@ const chestContents = {
     hpLoss: 10,
     message: 'Cursed fumes seep out as you grasp the ring.'
   },
-  'map_warrior:18,18': {
-    relic: 'warrior_sigil',
-    message: 'You obtained the Warrior Sigil!'
-  },
-  'map_guardian:18,18': {
-    relic: 'guardian_emblem',
-    message: 'You obtained the Guardian Emblem!'
-  },
   'map_alchemist:18,18': {
     relic: 'alchemist_catalyst',
     message: 'You obtained the Alchemist Catalyst!'

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -115,10 +115,7 @@ export function chooseForkPath(path) {
 
 export function arbiterDialogue() {
   if (visitedBothForks()) {
-    showDialogue(
-      'You have proven mastery over both paths. Accept this shard of the mirror.'
-    );
-    giveRelic('mirror_shard');
+    showDialogue('You have proven mastery over both paths.');
     discoverLore('two_flames_crossed');
   } else {
     showDialogue(


### PR DESCRIPTION
## Summary
- delete Guardian Emblem, Warrior Sigil, and Mirror Shard relic definitions
- remove unreachable relic chests
- update Arbiter dialogue since the shard is gone

## Testing
- `npx prettier --write data/relics.json scripts/chest.js scripts/dialogue_state.js`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496e62ef6883318f1ea49034d1cc60