### PR TITLE
Fix key use and commander badge

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -138,10 +138,10 @@
   "commander_badge": {
     "name": "Commander Badge",
     "description": "Proof of defeating the scout commander.",
-    "type": "gear",
+    "type": "key",
     "stackLimit": 1,
     "icon": "🎖️",
-    "category": "equipable"
+    "category": "key"
   },
   "scout_blade": {
     "name": "Scout Blade",

--- a/scripts/door_logic.js
+++ b/scripts/door_logic.js
@@ -24,6 +24,6 @@ export async function tryVicarDoor(tile) {
     updateInventoryUI();
     tile.locked = false;
   }
-  const { cols } = await enterDoor(tile.target, tile.spawn);
-  return cols;
+  const newCols = await enterDoor(tile.target, tile.spawn);
+  return newCols;
 }

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -3,7 +3,7 @@ import { getCurrentGrid } from './mapLoader.js';
 import { isAdjacent } from './logic.js';
 import { gameState } from './game_state.js';
 import { isInteractable, onInteractEffect } from './tile_type.js';
-import { hasItem, removeItem } from './inventory.js';
+import { hasItem, removeItem, useKey } from './inventory.js';
 import { updateInventoryUI } from './inventory_ui.js';
 import { showDialogue } from './dialogueSystem.js';
 import { markItemUsed } from '../info/items.js';

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -93,9 +93,9 @@ export const itemData = {
     id: 'commander_badge',
     name: 'Commander Badge',
     description: 'Proof of defeating the scout commander.',
-    type: 'gear',
-    tags: ['equipable'],
-    category: 'equipable',
+    type: 'key',
+    tags: ['lore'],
+    category: 'key',
     consumable: false,
     stackLimit: 1,
     icon: '🎖️'

--- a/scripts/item_stats.js
+++ b/scripts/item_stats.js
@@ -6,7 +6,6 @@ export const itemBonuses = {
   'cracked_helmet+1': { slot: 'armor', defense: 2 },
   'cracked_helmet+2': { slot: 'armor', defense: 3 },
   'cracked_helmet+3': { slot: 'armor', defense: 4 },
-  commander_badge: { slot: 'weapon', attack: 2 },
   focus_ring: { slot: 'accessory' },
   forgotten_ring: { slot: 'accessory', attack: 1 },
   temple_sword: { slot: 'weapon', attack: 3 },

--- a/scripts/tile_type.js
+++ b/scripts/tile_type.js
@@ -118,7 +118,7 @@ export async function onInteractEffect(
               updateInventoryUI();
             }
             tile.locked = false;
-            const { cols: newCols } = await enterDoor(targetMap, tile.spawn);
+            const newCols = await enterDoor(targetMap, tile.spawn);
             resolve(newCols);
           });
         });
@@ -129,7 +129,7 @@ export async function onInteractEffect(
         updateInventoryUI();
       }
       {
-        const { cols: newCols } = await enterDoor(targetMap, tile.spawn);
+        const newCols = await enterDoor(targetMap, tile.spawn);
         return newCols;
       }
     }

--- a/scripts/transition.js
+++ b/scripts/transition.js
@@ -17,5 +17,5 @@ export async function transitionToMap(target, spawn) {
   overlay.classList.remove('active');
   await delay(500);
   overlay.remove();
-  return cols;
+  return { cols };
 }


### PR DESCRIPTION
## Summary
- import `useKey` in `interaction.js`
- return an object from `transitionToMap`
- fix destructuring in `tile_type.js` and `door_logic.js`
- change Commander Badge item to a key item
- remove Commander Badge stats

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6849732828788331b26aabc9e00625e6