### PR TITLE
Remove deprecated relics from inventory

### DIFF
--- a/scripts/relic_state.js
+++ b/scripts/relic_state.js
@@ -23,7 +23,23 @@ function saveOwned(list) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
 }
 
+const DEPRECATED_RELICS = ['warrior', 'guardian', 'mirror'];
+
+function purgeDeprecatedRelics() {
+  let changed = false;
+  DEPRECATED_RELICS.forEach((id) => {
+    if (relicState.owned.has(id)) {
+      relicState.owned.delete(id);
+      changed = true;
+    }
+  });
+  if (changed) {
+    saveOwned(Array.from(relicState.owned));
+  }
+}
+
 relicState.owned = new Set(loadOwned());
+purgeDeprecatedRelics();
 
 document.dispatchEvent(new CustomEvent('relicsLoaded'));
 


### PR DESCRIPTION
## Summary
- clean relic save data on load
- drop warrior, guardian, and mirror relics

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849741c10a883319a2dfe9d0895b5e0