### PR TITLE
Fix door requiring commander badge

### DIFF
--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -113,13 +113,6 @@ export async function loadMap(name) {
       }
     }
     if (name === 'map03' && isEnemyDefeated('scout_commander')) {
-      for (const row of data.grid) {
-        for (const cell of row) {
-          if (cell && cell.type === 'D' && cell.target === 'map04.json') {
-            cell.locked = false;
-          }
-        }
-      }
       if (!gameState.openedChests.has('map03:10,12')) {
         if (data.grid[12] && data.grid[12][10]) {
           data.grid[12][10] = { type: 'C', glow: true };


### PR DESCRIPTION
## Summary
- ensure the map03→map04 door only checks for the Commander Badge
- keep Scout Commander chest reward spawning without unlocking the door

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6849776f9e8483319c26a11e1e566764