### PR TITLE
Revamp Info menu into collapsible compendium

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,42 +62,38 @@
       </div>
     </div>
     <div id="info-overlay" class="info-overlay">
-      <div id="info-panel">
+      <div id="info-menu">
         <button class="close-btn">&times;</button>
-        <div class="info-tabs">
-          <div class="info-tab-btn active" data-target="npcs">NPCs</div>
-          <div class="info-tab-btn" data-target="enemies">Enemies</div>
-          <div class="info-tab-btn" data-target="items">Items</div>
-          <div class="info-tab-btn" data-target="skills">Skills</div>
-          <div class="info-tab-btn" data-target="status">Status</div>
-          <div class="info-tab-btn" data-target="lore">Lore</div>
+        <nav class="info-nav">
+          <div class="info-nav-btn active" data-target="enemies">Enemies</div>
+          <div class="info-nav-btn" data-target="items">Items</div>
+          <div class="info-nav-btn" data-target="skills">Skills</div>
+          <div class="info-nav-btn" data-target="status">Status</div>
+          <div class="info-nav-btn" data-target="lore">Lore</div>
+        </nav>
+        <div class="info-content">
+          <div id="content-enemies" class="info-section"></div>
+          <div
+            id="content-items"
+            class="info-section"
+            style="display: none"
+          ></div>
+          <div
+            id="content-skills"
+            class="info-section"
+            style="display: none"
+          ></div>
+          <div
+            id="content-status"
+            class="info-section"
+            style="display: none"
+          ></div>
+          <div
+            id="content-lore"
+            class="info-section"
+            style="display: none"
+          ></div>
         </div>
-        <div id="info-npcs" class="info-tab-content"></div>
-        <div
-          id="info-enemies"
-          class="info-tab-content"
-          style="display: none"
-        ></div>
-        <div
-          id="info-items"
-          class="info-tab-content"
-          style="display: none"
-        ></div>
-        <div
-          id="info-skills"
-          class="info-tab-content"
-          style="display: none"
-        ></div>
-        <div
-          id="info-status"
-          class="info-tab-content"
-          style="display: none"
-        ></div>
-        <div
-          id="info-lore"
-          class="info-tab-content"
-          style="display: none"
-        ></div>
       </div>
     </div>
     <div id="null-summary-overlay" class="null-summary-overlay">
@@ -151,7 +147,9 @@
         <label class="setting-row">
           <input type="checkbox" id="center-toggle" /> Center Mode (Portrait)
         </label>
-        <button id="reset-settings" class="reset-btn">Reset All Settings</button>
+        <button id="reset-settings" class="reset-btn">
+          Reset All Settings
+        </button>
       </div>
     </div>
     <div id="error-overlay" class="error-overlay">

--- a/info_data/enemies.json
+++ b/info_data/enemies.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "goblin_scout",
+    "name": "Goblin Scout",
+    "locations": ["Map03"],
+    "drops": ["Scout Blade"],
+    "skills": ["strike"],
+    "weaknesses": ["fire"],
+    "resistances": ["poison"]
+  }
+]

--- a/info_data/items.json
+++ b/info_data/items.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "scout_blade",
+    "name": "Scout Blade",
+    "description": "A light blade used by goblin scouts.",
+    "type": "Equipable",
+    "obtained": "Dropped by Goblin Scout",
+    "functionality": "Basic slashing weapon"
+  }
+]

--- a/info_data/lore.json
+++ b/info_data/lore.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "lorebound",
+    "title": "The Lorebound",
+    "location": "Old Library",
+    "text": "An ancient order sworn to preserve knowledge.",
+    "source": "Scroll"
+  }
+]

--- a/info_data/skills.json
+++ b/info_data/skills.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "strike",
+    "name": "Strike",
+    "type": "Offensive",
+    "effect": "Deal physical damage to a target.",
+    "cooldown": 0,
+    "origin": "Goblin"
+  }
+]

--- a/info_data/status.json
+++ b/info_data/status.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "poisoned",
+    "name": "Poisoned",
+    "type": "negative",
+    "description": "Loses HP each turn.",
+    "duration": "3 turns",
+    "inflicted_by": "Poison Dagger",
+    "cured_by": "Antidote"
+  }
+]

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -33,7 +33,7 @@ import { initNullSummary } from '../ui/null_summary.js';
 import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
-import { toggleInfoPanel, initInfoPanel } from './info_panel.js';
+import { toggleInfoMenu, initInfoMenu } from '../ui/info_menu.js';
 import { saveState, loadState, gameState } from './game_state.js';
 import { saveGame, loadGame } from './save_system.js';
 import {
@@ -141,7 +141,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   initMobileCenter(container);
   initSkillSystem(player);
   initPassiveSystem(player);
-  initInfoPanel();
+  initInfoMenu();
   initNullSummary();
 
   try {
@@ -174,11 +174,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (e.target === statusOverlay) toggleStatusPanel();
     });
   }
-  if (infoTab) infoTab.addEventListener('click', toggleInfoPanel);
-  if (infoClose) infoClose.addEventListener('click', toggleInfoPanel);
+  if (infoTab) infoTab.addEventListener('click', toggleInfoMenu);
+  if (infoClose) infoClose.addEventListener('click', toggleInfoMenu);
   if (infoOverlay) {
     infoOverlay.addEventListener('click', (e) => {
-      if (e.target === infoOverlay) toggleInfoPanel();
+      if (e.target === infoOverlay) toggleInfoMenu();
     });
   }
 

--- a/style/main.css
+++ b/style/main.css
@@ -995,6 +995,66 @@ body {
   padding: 6px 0;
 }
 
+/* Info Menu (new compendium) */
+#info-menu {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 320px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  position: relative;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+#info-menu .close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+#info-menu .info-nav {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+#info-menu .info-nav-btn {
+  background: #333;
+  color: #fff;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 6px 10px;
+  margin: 2px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+#info-menu .info-nav-btn.active {
+  background: #555;
+}
+
+#info-menu details {
+  margin-bottom: 6px;
+}
+
+#info-menu summary {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+#info-menu .info-row {
+  font-size: 12px;
+  padding-left: 10px;
+}
+
 /* Settings UI */
 .settings-overlay {
   position: fixed;

--- a/ui/info_menu.js
+++ b/ui/info_menu.js
@@ -1,0 +1,100 @@
+export async function loadJson(name) {
+  try {
+    const res = await fetch(`info_data/${name}`);
+    if (!res.ok) return [];
+    return await res.json();
+  } catch {
+    return [];
+  }
+}
+
+function createEntry(obj, fields) {
+  const details = document.createElement('details');
+  const summary = document.createElement('summary');
+  summary.textContent = obj.name || obj.title;
+  details.appendChild(summary);
+  const body = document.createElement('div');
+  body.classList.add('info-details');
+  fields.forEach((f) => {
+    if (obj[f]) {
+      const div = document.createElement('div');
+      div.classList.add('info-row');
+      div.innerHTML = `<strong>${f.replace(/_/g, ' ')}:</strong> ${Array.isArray(obj[f]) ? obj[f].join(', ') : obj[f]}`;
+      body.appendChild(div);
+    }
+  });
+  details.appendChild(body);
+  return details;
+}
+
+async function populate(section, file, fields) {
+  const container = document.getElementById(section);
+  if (!container) return;
+  const data = await loadJson(file);
+  container.innerHTML = '';
+  data.forEach((e) => container.appendChild(createEntry(e, fields)));
+}
+
+export async function updateInfoMenu() {
+  await populate('content-enemies', 'enemies.json', [
+    'locations',
+    'drops',
+    'skills',
+    'weaknesses',
+    'resistances'
+  ]);
+  await populate('content-items', 'items.json', [
+    'description',
+    'type',
+    'obtained',
+    'functionality'
+  ]);
+  await populate('content-skills', 'skills.json', [
+    'type',
+    'effect',
+    'cooldown',
+    'origin'
+  ]);
+  await populate('content-status', 'status.json', [
+    'type',
+    'description',
+    'duration',
+    'inflicted_by',
+    'cured_by'
+  ]);
+  await populate('content-lore', 'lore.json', ['location', 'text', 'source']);
+}
+
+function showSection(target) {
+  document.querySelectorAll('#info-menu .info-nav-btn').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.target === target);
+  });
+  document.querySelectorAll('#info-menu .info-section').forEach((sec) => {
+    sec.style.display = sec.id === `content-${target}` ? 'block' : 'none';
+  });
+}
+
+export function initInfoMenu() {
+  document.querySelectorAll('#info-menu .info-nav-btn').forEach((btn) => {
+    btn.addEventListener('click', () => showSection(btn.dataset.target));
+  });
+  const close = document.querySelector('#info-menu .close-btn');
+  if (close) close.addEventListener('click', toggleInfoMenu);
+  const overlay = document.getElementById('info-overlay');
+  if (overlay)
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) toggleInfoMenu();
+    });
+}
+
+export async function toggleInfoMenu() {
+  const overlay = document.getElementById('info-overlay');
+  if (!overlay) return;
+  if (overlay.classList.contains('active')) {
+    overlay.classList.remove('active');
+  } else {
+    await updateInfoMenu();
+    overlay.classList.add('active');
+    showSection('enemies');
+  }
+}

--- a/ui/menu_renderer.js
+++ b/ui/menu_renderer.js
@@ -1,0 +1,21 @@
+export function switchSection(menuId, target) {
+  const menu = document.getElementById(menuId);
+  if (!menu) return;
+  menu.querySelectorAll('.info-nav-btn').forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.target === target);
+  });
+  menu.querySelectorAll('.info-section').forEach((sec) => {
+    sec.style.display = sec.id === `content-${target}` ? 'block' : 'none';
+  });
+}
+
+export function initMenuNav(menuId, callback) {
+  const menu = document.getElementById(menuId);
+  if (!menu) return;
+  menu.querySelectorAll('.info-nav-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      switchSection(menuId, btn.dataset.target);
+      if (callback) callback(btn.dataset.target);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add new collapsible info menu UI
- load entries from new `info_data` JSON files
- switch to `initInfoMenu` in `main.js`
- style new menu layout

## Testing
- `npx prettier --write index.html style/main.css ui/info_menu.js ui/menu_renderer.js scripts/main.js info_data/enemies.json info_data/items.json info_data/skills.json info_data/status.json info_data/lore.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684982c375148331abf42f02f4f8c09c