### PR TITLE
Fix settings import issue

### DIFF
--- a/scripts/settingsManager.js
+++ b/scripts/settingsManager.js
@@ -1,4 +1,4 @@
-import data from '../settings_data.json' assert { type: 'json' };
+import data from '../settings_data.js';
 
 export const DEFAULT_SETTINGS = Object.fromEntries(
   Object.entries(data).map(([k, v]) => [k, v.default])
@@ -44,4 +44,3 @@ export function applySettings(settings) {
     }
   });
 }
-

--- a/settings_data.js
+++ b/settings_data.js
@@ -1,0 +1,34 @@
+export default {
+  gridCoordinates: {
+    default: false,
+    description: 'Show (x, y) when hovering over a tile'
+  },
+  movementSpeed: {
+    default: 'normal',
+    description: 'Player tile transition speed'
+  },
+  combatSpeed: {
+    default: 'normal',
+    description: 'Speed of combat animations'
+  },
+  colorblind: {
+    default: false,
+    description: 'High contrast grid visuals'
+  },
+  tileLabels: {
+    default: false,
+    description: 'Overlay names on tiles'
+  },
+  dialogueAnim: {
+    default: true,
+    description: 'Type out dialogue text'
+  },
+  language: {
+    default: 'en',
+    description: 'UI language code'
+  },
+  centerMode: {
+    default: false,
+    description: 'Re-center grid after movement in portrait'
+  }
+};


### PR DESCRIPTION
## Summary
- replace JSON module import with normal JS module for settings
- add `settings_data.js` to export settings data

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684984a0e92c83319cbce8e9d0992668