### PR TITLE
Fix settings reference error

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -47,6 +47,8 @@ import { loadLanguage } from './language_loader.js';
 
 // Inventory contents are managed in inventory.js
 
+let settings = loadSettings();
+
 let isInBattle = false;
 
 let isMoving = false;
@@ -160,7 +162,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   updateXpDisplay();
   let cols = 0;
 
-  let settings = loadSettings();
+  settings = loadSettings();
   applySettings(settings);
   coordsToggle.checked = settings.gridCoordinates;
   moveSelect.value = settings.movementSpeed;
@@ -319,7 +321,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       loadLanguage(settings.language);
     }
   });
-
 
   try {
     const { cols: newCols } = await router.loadMap('map01');


### PR DESCRIPTION
## Summary
- keep settings in global scope so movement functions can access it

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498b2c1d9c8331adc0db6c65d5be77