### PR TITLE
Fix inventory persistence when loading

### DIFF
--- a/scripts/game_state.js
+++ b/scripts/game_state.js
@@ -1,4 +1,5 @@
 import { loadSettings } from './settingsManager.js';
+import { inventory } from './inventory.js';
 
 export const gameState = {
   currentMap: '',
@@ -43,5 +44,12 @@ export function loadState() {
     deserializeGameState(data);
   } catch {
     // ignore malformed data
+  }
+}
+
+export function validateLoadedInventory(savedItems) {
+  const expected = Array.isArray(savedItems) ? savedItems.length : 0;
+  if (expected !== inventory.length) {
+    console.warn('Inventory size mismatch after load');
   }
 }

--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -1,5 +1,6 @@
-import { inventory } from './inventory.js';
+import { inventory, recalcPassiveModifiers } from './inventory.js';
 import { player } from './player.js';
+import { checkTempleSet } from './equipment.js';
 
 export function serializeInventory() {
   return {
@@ -23,5 +24,12 @@ export function deserializeInventory(data) {
     player.equipment.armor = data.equipment.armor || null;
     player.equipment.accessory = data.equipment.accessory || null;
   }
+  recalcPassiveModifiers();
+  checkTempleSet();
+  document.dispatchEvent(new CustomEvent('equipmentChanged'));
   document.dispatchEvent(new CustomEvent('inventoryUpdated'));
+}
+
+export function loadInventoryFromObject(savedInventory) {
+  deserializeInventory(savedInventory);
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -34,6 +34,7 @@ import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
 import { toggleInfoMenu, initInfoMenu } from '../ui/info_menu.js';
+import { refreshInventoryDisplay } from '../ui/inventory_menu.js';
 import { saveState, loadState, gameState } from './game_state.js';
 import { saveGame, loadGame } from './save_load.js';
 import { initMenuBar } from '../ui/menu_bar.js';
@@ -132,6 +133,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       showDialogue('No save found.');
       return;
     }
+    refreshInventoryDisplay();
     const mapName = gameState.currentMap || 'map01';
     try {
       const { cols: newCols } = await router.loadMap(mapName);

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -12,8 +12,10 @@ import { unlockSkill, getAllSkills } from './skills.js';
 import {
   addItem,
   removeItem as removeInvItem,
-  getPassiveModifiers
+  getPassiveModifiers,
+  recalcPassiveModifiers
 } from './inventory.js';
+import { checkTempleSet } from './equipment.js';
 
 export const player = {
   x: 0,
@@ -244,6 +246,9 @@ export function deserializePlayer(data) {
     player.equipment.weapon = data.equipment.weapon || null;
     player.equipment.armor = data.equipment.armor || null;
     player.equipment.accessory = data.equipment.accessory || null;
+    recalcPassiveModifiers();
+    checkTempleSet();
+    document.dispatchEvent(new CustomEvent('equipmentChanged'));
   }
 }
 

--- a/scripts/save_load.js
+++ b/scripts/save_load.js
@@ -1,7 +1,14 @@
 const STORAGE_KEY = 'gridquest.saveData';
 
-import { serializeGameState, deserializeGameState } from './game_state.js';
-import { serializeInventory, deserializeInventory } from './inventory_state.js';
+import {
+  serializeGameState,
+  deserializeGameState,
+  validateLoadedInventory
+} from './game_state.js';
+import {
+  serializeInventory,
+  loadInventoryFromObject
+} from './inventory_state.js';
 import { serializeQuestState, deserializeQuestState } from './quest_state.js';
 import { serializePlayer, deserializePlayer } from './player.js';
 
@@ -21,7 +28,8 @@ export function loadGame() {
   try {
     const data = JSON.parse(json);
     deserializeGameState(data.game || {});
-    deserializeInventory(data.inventory || {});
+    loadInventoryFromObject(data.inventory || {});
+    validateLoadedInventory(data.inventory?.items || []);
     deserializeQuestState(data.quests || {});
     deserializePlayer(data.player || {});
     return true;

--- a/ui/inventory_menu.js
+++ b/ui/inventory_menu.js
@@ -1,0 +1,5 @@
+import { updateInventoryUI } from '../scripts/inventory_ui.js';
+
+export function refreshInventoryDisplay() {
+  updateInventoryUI();
+}


### PR DESCRIPTION
## Summary
- keep inventory state consistent when loading
- expose helper to restore inventory state
- recalc passive bonuses and set effects on deserialize
- refresh UI inventory after loading
- validate loaded inventory size

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684990ad0488833194910fa12bda6a28