### PR TITLE
Fix inventory restoration on load

### DIFF
--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -1,6 +1,5 @@
-import { inventory, recalcPassiveModifiers } from './inventory.js';
-import { player } from './player.js';
-import { checkTempleSet } from './equipment.js';
+import { inventory } from './inventory.js';
+import { player, reapplyEquipmentBonuses } from './player.js';
 
 export function serializeInventory() {
   return {
@@ -24,12 +23,18 @@ export function deserializeInventory(data) {
     player.equipment.armor = data.equipment.armor || null;
     player.equipment.accessory = data.equipment.accessory || null;
   }
-  recalcPassiveModifiers();
-  checkTempleSet();
-  document.dispatchEvent(new CustomEvent('equipmentChanged'));
-  document.dispatchEvent(new CustomEvent('inventoryUpdated'));
 }
 
 export function loadInventoryFromObject(savedInventory) {
   deserializeInventory(savedInventory);
+  reapplyEquipmentBonuses();
+  document.dispatchEvent(new CustomEvent('inventoryUpdated'));
 }
+
+export const inventoryState = {
+  loadFromObject(savedInventory) {
+    deserializeInventory(savedInventory);
+    reapplyEquipmentBonuses();
+    document.dispatchEvent(new CustomEvent('inventoryUpdated'));
+  }
+};

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -309,3 +309,9 @@ export async function enterDoor(target, spawn) {
   const { cols } = await transitionToMap(target, spawn);
   return cols;
 }
+
+export function reapplyEquipmentBonuses() {
+  recalcPassiveModifiers();
+  checkTempleSet();
+  document.dispatchEvent(new CustomEvent('equipmentChanged'));
+}

--- a/scripts/save_load.js
+++ b/scripts/save_load.js
@@ -7,7 +7,7 @@ import {
 } from './game_state.js';
 import {
   serializeInventory,
-  loadInventoryFromObject
+  inventoryState
 } from './inventory_state.js';
 import { serializeQuestState, deserializeQuestState } from './quest_state.js';
 import { serializePlayer, deserializePlayer } from './player.js';
@@ -28,7 +28,7 @@ export function loadGame() {
   try {
     const data = JSON.parse(json);
     deserializeGameState(data.game || {});
-    loadInventoryFromObject(data.inventory || {});
+    inventoryState.loadFromObject(data.inventory || {});
     validateLoadedInventory(data.inventory?.items || []);
     deserializeQuestState(data.quests || {});
     deserializePlayer(data.player || {});


### PR DESCRIPTION
## Summary
- ensure `inventoryState.loadFromObject` reconstructs items and equipment
- use new loader in `loadGame`
- expose `reapplyEquipmentBonuses` in player logic

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684995b4788c833182272983b91d840b