### PR TITLE
Fix inventory UI refresh on load

### DIFF
--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -103,6 +103,9 @@ export async function updateInventoryUI() {
       }
     });
     const bonus = getItemBonuses(item.id);
+    if (bonus && bonus.slot && getEquippedItem(bonus.slot) === item.id) {
+      row.classList.add('equipped-item');
+    }
     if (bonus && bonus.slot) {
       const btn = document.createElement('button');
       btn.classList.add('equip-btn');

--- a/scripts/save_load.js
+++ b/scripts/save_load.js
@@ -11,6 +11,7 @@ import {
 } from './inventory_state.js';
 import { serializeQuestState, deserializeQuestState } from './quest_state.js';
 import { serializePlayer, deserializePlayer } from './player.js';
+import { refreshInventoryDisplay } from '../ui/inventory_menu.js';
 
 export function saveGame() {
   const data = {
@@ -29,6 +30,7 @@ export function loadGame() {
     const data = JSON.parse(json);
     deserializeGameState(data.game || {});
     inventoryState.loadFromObject(data.inventory || {});
+    refreshInventoryDisplay();
     validateLoadedInventory(data.inventory?.items || []);
     deserializeQuestState(data.quests || {});
     deserializePlayer(data.player || {});

--- a/style/main.css
+++ b/style/main.css
@@ -831,6 +831,11 @@ body {
   font-weight: bold;
 }
 
+/* Highlight for items that are currently equipped */
+.equipped-item {
+  background: #e0ffe0;
+}
+
 .enchanted {
   color: #b347ff;
   text-shadow: 0 0 4px rgba(179, 71, 255, 0.7);

--- a/ui/inventory_menu.js
+++ b/ui/inventory_menu.js
@@ -1,5 +1,10 @@
 import { updateInventoryUI } from '../scripts/inventory_ui.js';
 
+/**
+ * Refresh the inventory display after the internal state has changed or been
+ * loaded from a save. Re-renders the item list so quantities, equipped
+ * highlights and action handlers are accurate.
+ */
 export function refreshInventoryDisplay() {
   updateInventoryUI();
 }


### PR DESCRIPTION
## Summary
- refresh the inventory UI from menu helper
- highlight equipped items visually
- call refreshInventoryDisplay when loading saved games
- style for equipped items

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849986aecc88331abdf4310c9085470