### PR TITLE
Fix Syranel dialogue

### DIFF
--- a/scripts/npc_dialogues/syranel_dialogue.js
+++ b/scripts/npc_dialogues/syranel_dialogue.js
@@ -11,6 +11,19 @@ export const syranelDialogue = [
         goto: null,
         memoryFlag: 'syranel_request',
         onChoose: () => startQuest('crimson_request')
+      },
+      {
+        label: 'Offer the rotting heart.',
+        goto: 2,
+        condition: state => state.inventory['rotting_heart'] >= 1,
+        onChoose: async () => {
+          await loadItems();
+          removeItem('rotting_heart', 1);
+          const m = await import('../player.js');
+          m.grantSkill('leech');
+        },
+        completeQuest: 'crimson_request',
+        memoryFlag: 'learned_leech'
       }
     ]
   },


### PR DESCRIPTION
## Summary
- add an extra option to deliver the rotting heart directly in Syranel's dialogue

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a5a4d38c83319f284501a5cf16c5