### PR TITLE
Add save slots menu

### DIFF
--- a/__tests__/chestPersistence.test.js
+++ b/__tests__/chestPersistence.test.js
@@ -35,7 +35,9 @@ let openChest,
 
 beforeEach(async () => {
   jest.resetModules();
-  ({ openChest, isChestOpened, setOpenedChests } = await import('../scripts/chest.js'));
+  ({ openChest, isChestOpened, setOpenedChests } = await import(
+    '../scripts/chest.js'
+  ));
   ({ saveGame, loadGame } = await import('../scripts/save_load.js'));
   ({ getItemCount, inventory } = await import('../scripts/inventory.js'));
   inventory.length = 0;
@@ -49,13 +51,13 @@ test('opened chests remain opened after saving and loading', async () => {
   expect(isChestOpened(chestId)).toBe(true);
   expect(getItemCount('rusty_key')).toBe(1);
 
-  saveGame();
+  saveGame(1);
 
   setOpenedChests([]);
   inventory.length = 0;
   expect(isChestOpened(chestId)).toBe(false);
 
-  const loaded = loadGame();
+  const loaded = loadGame(1);
   expect(loaded).toBe(true);
   expect(isChestOpened(chestId)).toBe(true);
   expect(getItemCount('rusty_key')).toBe(1);

--- a/index.html
+++ b/index.html
@@ -158,6 +158,13 @@
         <button class="error-ok">OK</button>
       </div>
     </div>
+    <div id="save-load-overlay" class="save-load-overlay">
+      <div class="save-load-content">
+        <button class="close-btn">&times;</button>
+        <h2 id="save-load-title">Save Game</h2>
+        <div id="slots-container"></div>
+      </div>
+    </div>
     <script type="module" src="scripts/main.js"></script>
   </body>
 </html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -35,6 +35,11 @@ import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
 import { toggleInfoMenu, initInfoMenu } from '../ui/info_menu.js';
 import { refreshInventoryDisplay } from '../ui/inventory_menu.js';
+import {
+  initSaveSlotsMenu,
+  openSaveMenu,
+  openLoadMenu
+} from '../ui/save_slots_menu.js';
 import { saveState, loadState, gameState } from './game_state.js';
 import { saveGame, loadGame } from './save_load.js';
 import { initMenuBar } from '../ui/menu_bar.js';
@@ -122,14 +127,16 @@ document.addEventListener('DOMContentLoaded', async () => {
   const resetBtn = document.getElementById('reset-settings');
 
   function handleSave() {
-    saveState();
-    saveGame();
-    showDialogue('Game Saved.');
+    openSaveMenu();
   }
 
-  async function handleLoad() {
+  function handleLoad() {
+    openLoadMenu();
+  }
+
+  async function performLoad(slot) {
     loadState();
-    if (!loadGame()) {
+    if (!loadGame(slot)) {
       showDialogue('No save found.');
       return;
     }
@@ -155,6 +162,16 @@ document.addEventListener('DOMContentLoaded', async () => {
       console.error(err);
     }
   }
+
+  document.addEventListener('saveSlot', (e) => {
+    saveState();
+    saveGame(e.detail.slot);
+    showDialogue('Game Saved.');
+  });
+
+  document.addEventListener('loadSlot', (e) => {
+    performLoad(e.detail.slot);
+  });
 
   initMenuBar(handleSave, handleLoad);
   initInventoryUI();
@@ -182,6 +199,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   initPassiveSystem(player);
   initInfoMenu();
   initNullSummary();
+  initSaveSlotsMenu();
 
   try {
     await loadEnemyData();

--- a/scripts/save_load.js
+++ b/scripts/save_load.js
@@ -1,30 +1,35 @@
-const STORAGE_KEY = 'gridquest.saveData';
+const STORAGE_PREFIX = 'game_save_slot_';
 
 import {
   serializeGameState,
   deserializeGameState,
   validateLoadedInventory
 } from './game_state.js';
-import {
-  serializeInventory,
-  inventoryState
-} from './inventory_state.js';
+import { serializeInventory, inventoryState } from './inventory_state.js';
 import { serializeQuestState, deserializeQuestState } from './quest_state.js';
 import { serializePlayer, deserializePlayer } from './player.js';
 import { refreshInventoryDisplay } from '../ui/inventory_menu.js';
 
-export function saveGame() {
+import { gameState } from './game_state.js';
+
+export function saveGame(slot = 1) {
   const data = {
+    timestamp: Date.now(),
     game: serializeGameState(),
     inventory: serializeInventory(),
     quests: serializeQuestState(),
     player: serializePlayer()
   };
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  const key = `${STORAGE_PREFIX}${slot}`;
+  localStorage.setItem(key, JSON.stringify(data));
+  if (slot === 2) {
+    console.log('Saved to Slot 2:', gameState);
+  }
 }
 
-export function loadGame() {
-  const json = localStorage.getItem(STORAGE_KEY);
+export function loadGame(slot = 1) {
+  const key = `${STORAGE_PREFIX}${slot}`;
+  const json = localStorage.getItem(key);
   if (!json) return false;
   try {
     const data = JSON.parse(json);

--- a/style/main.css
+++ b/style/main.css
@@ -1457,3 +1457,69 @@ body {
   display: block;
   margin: 12px auto 0;
 }
+
+.save-load-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 900;
+}
+
+.save-load-overlay.active {
+  visibility: visible;
+  opacity: 1;
+}
+
+.save-load-content {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 280px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  position: relative;
+}
+
+.save-load-content .close-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.slot-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  margin: 8px 0;
+}
+
+.slot-info {
+  font-size: 12px;
+  color: #555;
+  margin-left: 8px;
+}
+
+@media (max-width: 500px) {
+  .slot-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .slot-info {
+    margin-left: 0;
+    margin-top: 4px;
+  }
+}

--- a/ui/save_slots_menu.js
+++ b/ui/save_slots_menu.js
@@ -1,0 +1,82 @@
+let mode = 'save';
+
+export function initSaveSlotsMenu() {
+  const overlay = document.getElementById('save-load-overlay');
+  if (!overlay) return;
+  const close = overlay.querySelector('.close-btn');
+  if (close) close.addEventListener('click', hideMenu);
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) hideMenu();
+  });
+}
+
+function hideMenu() {
+  const overlay = document.getElementById('save-load-overlay');
+  overlay?.classList.remove('active');
+}
+
+function buildMenu() {
+  const overlay = document.getElementById('save-load-overlay');
+  if (!overlay) return;
+  const title = overlay.querySelector('#save-load-title');
+  const container = overlay.querySelector('#slots-container');
+  title.textContent = mode === 'save' ? 'Save Game' : 'Load Game';
+  container.innerHTML = '';
+
+  for (let i = 1; i <= 3; i++) {
+    const row = document.createElement('div');
+    row.classList.add('slot-row');
+
+    const btn = document.createElement('button');
+    btn.textContent =
+      mode === 'save' ? `Slot ${i} \u2014 Save` : `Slot ${i} \u2014 Load`;
+    const json = localStorage.getItem(`game_save_slot_${i}`);
+    const hasData = !!json;
+    btn.disabled = mode === 'load' && !hasData;
+    btn.addEventListener('click', () => {
+      document.dispatchEvent(
+        new CustomEvent(mode === 'save' ? 'saveSlot' : 'loadSlot', {
+          detail: { slot: i }
+        })
+      );
+      hideMenu();
+    });
+    row.appendChild(btn);
+
+    let info = '';
+    if (hasData) {
+      try {
+        const data = JSON.parse(json);
+        const date = new Date(data.timestamp || Date.now()).toLocaleString();
+        const map = data.game?.currentMap || '';
+        const items = Array.isArray(data.inventory?.items)
+          ? data.inventory.items.length
+          : 0;
+        info = `${date} — Map: ${map || 'N/A'}, Items: ${items}`;
+      } catch {
+        info = '';
+      }
+    } else if (mode === 'load') {
+      info = 'Empty';
+    }
+
+    const infoEl = document.createElement('div');
+    infoEl.classList.add('slot-info');
+    infoEl.textContent = info;
+    row.appendChild(infoEl);
+
+    container.appendChild(row);
+  }
+}
+
+export function openSaveMenu() {
+  mode = 'save';
+  buildMenu();
+  document.getElementById('save-load-overlay')?.classList.add('active');
+}
+
+export function openLoadMenu() {
+  mode = 'load';
+  buildMenu();
+  document.getElementById('save-load-overlay')?.classList.add('active');
+}


### PR DESCRIPTION
## Summary
- add 3-slot save system with timestamp info
- create modal Save/Load UI
- hook up menu bar buttons to open new modal
- adjust tests for new save API

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849a87bc8448331b5cbcff4ca56bf23