### PR TITLE
Enhance save slot info

### DIFF
--- a/scripts/save_load.js
+++ b/scripts/save_load.js
@@ -11,10 +11,13 @@ import { serializePlayer, deserializePlayer } from './player.js';
 import { refreshInventoryDisplay } from '../ui/inventory_menu.js';
 
 import { gameState } from './game_state.js';
+import { inventory } from './inventory.js';
 
 export function saveGame(slot = 1) {
   const data = {
     timestamp: Date.now(),
+    mapName: gameState.currentMap,
+    itemCount: inventory.length,
     game: serializeGameState(),
     inventory: serializeInventory(),
     quests: serializeQuestState(),

--- a/style/main.css
+++ b/style/main.css
@@ -1511,6 +1511,12 @@ body {
   font-size: 12px;
   color: #555;
   margin-left: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 8px;
+}
+.slot-info > div {
+  margin-right: 8px;
 }
 
 @media (max-width: 500px) {
@@ -1521,5 +1527,6 @@ body {
   .slot-info {
     margin-left: 0;
     margin-top: 4px;
+    flex-direction: column;
   }
 }

--- a/ui/save_slots_menu.js
+++ b/ui/save_slots_menu.js
@@ -43,26 +43,39 @@ function buildMenu() {
     });
     row.appendChild(btn);
 
-    let info = '';
+    let infoData = null;
     if (hasData) {
       try {
         const data = JSON.parse(json);
+        const map = data.mapName || data.game?.currentMap || '';
+        const items =
+          typeof data.itemCount === 'number'
+            ? data.itemCount
+            : Array.isArray(data.inventory?.items)
+            ? data.inventory.items.length
+            : 0;
         const date = new Date(data.timestamp || Date.now()).toLocaleString();
-        const map = data.game?.currentMap || '';
-        const items = Array.isArray(data.inventory?.items)
-          ? data.inventory.items.length
-          : 0;
-        info = `${date} — Map: ${map || 'N/A'}, Items: ${items}`;
+        infoData = { map, items, date };
       } catch {
-        info = '';
+        infoData = null;
       }
-    } else if (mode === 'load') {
-      info = 'Empty';
     }
 
     const infoEl = document.createElement('div');
     infoEl.classList.add('slot-info');
-    infoEl.textContent = info;
+    if (infoData) {
+      const mapEl = document.createElement('div');
+      mapEl.textContent = `Map: ${infoData.map || 'N/A'}`;
+      const itemsEl = document.createElement('div');
+      itemsEl.textContent = `Items: ${infoData.items}`;
+      const timeEl = document.createElement('div');
+      timeEl.textContent = `Saved: ${infoData.date}`;
+      infoEl.appendChild(mapEl);
+      infoEl.appendChild(itemsEl);
+      infoEl.appendChild(timeEl);
+    } else {
+      infoEl.textContent = 'Slot empty';
+    }
     row.appendChild(infoEl);
 
     container.appendChild(row);


### PR DESCRIPTION
## Summary
- store summary info (map name, item count) with each save
- render save slot details with separate labels
- style slot info for horizontal and mobile layouts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ab1e9468833199196665e0172e3d