### PR TITLE
Add confirmation before overwriting save slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,15 @@
         <button class="error-ok">OK</button>
       </div>
     </div>
+    <div id="confirm-overlay" class="confirm-overlay">
+      <div class="confirm-content">
+        <div id="confirm-message"></div>
+        <div class="confirm-actions">
+          <button class="confirm-yes">Confirm</button>
+          <button class="confirm-cancel">Cancel</button>
+        </div>
+      </div>
+    </div>
     <div id="save-load-overlay" class="save-load-overlay">
       <div class="save-load-content">
         <button class="close-btn">&times;</button>

--- a/scripts/confirmPrompt.js
+++ b/scripts/confirmPrompt.js
@@ -1,0 +1,31 @@
+export function showConfirm(message, onConfirm, onCancel) {
+  const overlay = document.getElementById('confirm-overlay');
+  if (!overlay) {
+    if (confirm(message)) {
+      onConfirm();
+    } else if (onCancel) {
+      onCancel();
+    }
+    return;
+  }
+  const msgEl = overlay.querySelector('#confirm-message');
+  const yesBtn = overlay.querySelector('.confirm-yes');
+  const cancelBtn = overlay.querySelector('.confirm-cancel');
+  msgEl.textContent = message;
+  overlay.classList.add('active');
+  function cleanup() {
+    overlay.classList.remove('active');
+    yesBtn.removeEventListener('click', handleYes);
+    cancelBtn.removeEventListener('click', handleCancel);
+  }
+  function handleYes() {
+    cleanup();
+    onConfirm();
+  }
+  function handleCancel() {
+    cleanup();
+    if (onCancel) onCancel();
+  }
+  yesBtn.addEventListener('click', handleYes);
+  cancelBtn.addEventListener('click', handleCancel);
+}

--- a/style/main.css
+++ b/style/main.css
@@ -1333,6 +1333,59 @@ body {
   background: #555;
 }
 
+/* Confirmation Prompt */
+.confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 1200;
+}
+
+.confirm-overlay.active {
+  visibility: visible;
+  opacity: 1;
+}
+
+.confirm-content {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 260px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  text-align: center;
+}
+
+.confirm-actions {
+  margin-top: 15px;
+  display: flex;
+  justify-content: space-around;
+  gap: 10px;
+}
+
+.confirm-actions button {
+  padding: 6px 12px;
+  background: #444;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.confirm-actions button:hover {
+  background: #555;
+}
+
 /* Null Factor Summary */
 .null-summary-overlay {
   position: fixed;

--- a/ui/save_slots_menu.js
+++ b/ui/save_slots_menu.js
@@ -1,3 +1,5 @@
+import { showConfirm } from '../scripts/confirmPrompt.js';
+
 let mode = 'save';
 
 export function initSaveSlotsMenu() {
@@ -34,12 +36,29 @@ function buildMenu() {
     const hasData = !!json;
     btn.disabled = mode === 'load' && !hasData;
     btn.addEventListener('click', () => {
-      document.dispatchEvent(
-        new CustomEvent(mode === 'save' ? 'saveSlot' : 'loadSlot', {
-          detail: { slot: i }
-        })
-      );
-      hideMenu();
+      if (mode === 'save') {
+        if (localStorage.getItem(`game_save_slot_${i}`)) {
+          showConfirm(
+            'This slot already contains saved progress. Overwrite it?',
+            () => {
+              document.dispatchEvent(
+                new CustomEvent('saveSlot', { detail: { slot: i } })
+              );
+              buildMenu();
+            }
+          );
+        } else {
+          document.dispatchEvent(
+            new CustomEvent('saveSlot', { detail: { slot: i } })
+          );
+          buildMenu();
+        }
+      } else {
+        document.dispatchEvent(
+          new CustomEvent('loadSlot', { detail: { slot: i } })
+        );
+        hideMenu();
+      }
     });
     row.appendChild(btn);
 


### PR DESCRIPTION
## Summary
- add a confirmation overlay for overwriting saves
- update styles for new confirmation modal
- implement modal logic in save slots menu

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849aee738c083319eb5ff8d7827fa8c