### PR TITLE
Fix inventory not visible after loading save

### DIFF
--- a/scripts/save_load.js
+++ b/scripts/save_load.js
@@ -7,7 +7,7 @@ import {
 } from './game_state.js';
 import { serializeInventory, inventoryState } from './inventory_state.js';
 import { serializeQuestState, deserializeQuestState } from './quest_state.js';
-import { serializePlayer, deserializePlayer } from './player.js';
+import { serializePlayer, deserializePlayer, player } from './player.js';
 import { refreshInventoryDisplay } from '../ui/inventory_menu.js';
 
 import { gameState } from './game_state.js';
@@ -38,6 +38,8 @@ export function loadGame(slot = 1) {
     const data = JSON.parse(json);
     deserializeGameState(data.game || {});
     inventoryState.loadFromObject(data.inventory || {});
+    console.log('Loaded inventory:', inventory);
+    console.log('Equipped:', player.equipment);
     refreshInventoryDisplay();
     validateLoadedInventory(data.inventory?.items || []);
     deserializeQuestState(data.quests || {});

--- a/ui/inventory_menu.js
+++ b/ui/inventory_menu.js
@@ -1,10 +1,12 @@
 import { updateInventoryUI } from '../scripts/inventory_ui.js';
+import { loadItems } from '../scripts/item_loader.js';
 
 /**
  * Refresh the inventory display after the internal state has changed or been
  * loaded from a save. Re-renders the item list so quantities, equipped
  * highlights and action handlers are accurate.
  */
-export function refreshInventoryDisplay() {
+export async function refreshInventoryDisplay() {
+  await loadItems();
   updateInventoryUI();
 }


### PR DESCRIPTION
## Summary
- load item data before refreshing inventory
- log inventory contents after load for debugging

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6849b118f1d483319a509949ee5b6a77