### PR TITLE
Add goblin sword reward and update goblin quest

### DIFF
--- a/data/quests.json
+++ b/data/quests.json
@@ -1,7 +1,7 @@
 {
   "goblin_gear": {
     "title": "Goblin Gear",
-    "description": "Collect three goblin ears for the quest giver.",
+    "description": "Collect five goblin gear for the quest giver.",
     "onCompleteUnlocks": ["scout_tracking"]
   },
   "scout_tracking": {

--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -1,4 +1,4 @@
-import { inventory } from './inventory.js';
+import { inventory, addItem as invAddItem, removeItem as invRemoveItem } from './inventory.js';
 import { player, reapplyEquipmentBonuses } from './player.js';
 
 export function serializeInventory() {
@@ -36,5 +36,11 @@ export const inventoryState = {
     deserializeInventory(savedInventory);
     reapplyEquipmentBonuses();
     document.dispatchEvent(new CustomEvent('inventoryUpdated'));
+  },
+  addItem(item) {
+    return invAddItem(item);
+  },
+  removeItem(id, qty = 1) {
+    return invRemoveItem(id, qty);
   }
 };

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -89,6 +89,17 @@ export const itemData = {
     stackLimit: 1,
     icon: '🏹'
   },
+  goblin_sword: {
+    id: 'goblin_sword',
+    name: 'Goblin Sword',
+    description: 'Crude blade favored by goblins.',
+    type: 'gear',
+    tags: ['equipable'],
+    category: 'equipable',
+    consumable: false,
+    stackLimit: 1,
+    icon: '🗡️'
+  },
   commander_badge: {
     id: 'commander_badge',
     name: 'Commander Badge',

--- a/scripts/item_stats.js
+++ b/scripts/item_stats.js
@@ -8,6 +8,7 @@ export const itemBonuses = {
   'cracked_helmet+3': { slot: 'armor', defense: 4 },
   focus_ring: { slot: 'accessory' },
   forgotten_ring: { slot: 'accessory', attack: 1 },
+  goblin_sword: { slot: 'weapon', attack: 3 },
   temple_sword: { slot: 'weapon', attack: 3 },
   temple_shell: { slot: 'armor', defense: 2, maxHp: 5 },
   temple_ring: { slot: 'accessory', attack: 1, defense: 1, maxHp: 2 }

--- a/scripts/npc_dialogues/goblin_quest_giver.js
+++ b/scripts/npc_dialogues/goblin_quest_giver.js
@@ -15,17 +15,17 @@ export const goblinQuestDialogue = [
     ]
   },
   {
-    text: "Have you managed to get some goblin gear?",
+    text: "Have you brought the goblin gear I asked for?",
     options: [
       {
         label: "Yes, here it is.",
         goto: 2,
-        condition: (state) => (state.inventory['goblin_ear'] || 0) >= 3,
+        condition: (state) => (state.inventory['goblin_gear'] || 0) >= 5,
         onChoose: async () => {
           await loadItems();
-          const data = getItemData('silver_key') || { name: 'Silver Key', description: '' };
-          removeItem('goblin_ear', 3);
-          addItem({ ...data, id: 'silver_key', quantity: 1 });
+          const data = getItemData('goblin_sword') || { name: 'Goblin Sword', description: '' };
+          removeItem('goblin_gear', 5);
+          addItem({ ...data, id: 'goblin_sword', quantity: 1 });
         },
         completeQuest: 'goblin_gear'
       },
@@ -41,7 +41,7 @@ export const goblinQuestDialogue = [
       {
         label: "Thank you.",
         goto: null,
-        memoryFlag: "quest_goblin_completed"
+        memoryFlag: "goblin_quest_completed"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- revise goblin gear quest description
- add `goblin_sword` item data
- give goblin sword for completing goblin gear quest
- register goblin sword item bonuses
- expose addItem and removeItem through `inventory_state`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint module missing)*


------
https://chatgpt.com/codex/tasks/task_e_6849b60606fc83318826d28f4d0f867c