### PR TITLE
Implement level-based stat progression with XP items

### DIFF
--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -3,7 +3,7 @@ import { addItem, giveItem } from './inventory.js';
 import { updateInventoryUI } from './inventory_ui.js';
 import { giveRelic, setMemory } from './dialogue_state.js';
 import { getItemData, loadItems } from './item_loader.js';
-import { increaseMaxHp, loseHpNonLethal } from './player.js';
+import { loseHpNonLethal } from './player.js';
 import { unlockSkillsFromItem, unlockSkillsFromRelic } from './skills.js';
 
 const chestContents = {
@@ -20,8 +20,8 @@ const chestContents = {
     message: 'You pick up an old coin.'
   },
   'map02:5,5': {
-    item: 'health_amulet',
-    message: 'You found a shimmering amulet.',
+    item: 'xp_scroll',
+    message: 'You found a shimmering scroll.',
     memoryFlag: 'map02_health_amulet'
   },
   'map02:9,9': {
@@ -35,8 +35,8 @@ const chestContents = {
     memoryFlag: 'empty_chest_seen'
   },
   'map03:10,12': {
-    item: 'health_amulet',
-    message: 'You feel stronger.'
+    item: 'xp_scroll',
+    message: 'You feel knowledge flow into you.'
   },
   'map04:10,11': {
     item: 'mana_gem',
@@ -132,19 +132,19 @@ const chestContents = {
     message: 'Inside rests a sealed scroll etched in ember.'
   },
   'map09_floor03:4,3': {
-    item: 'temple_sword',
+    item: 'xp_scroll',
     hpLoss: 10,
-    message: 'A guardian trap drains your strength as you claim the sword.'
+    message: 'A guardian trap drains your strength as you snatch the scroll.'
   },
   'map09_floor03:9,5': {
-    item: 'temple_shell',
+    item: 'xp_potion',
     hpLoss: 10,
-    message: 'Ancient energies lash out when the shell is taken.'
+    message: 'Ancient energies lash out as you secure the potion.'
   },
   'map09_floor03:15,8': {
-    item: 'temple_ring',
+    item: 'xp_relic',
     hpLoss: 10,
-    message: 'Cursed fumes seep out as you grasp the ring.'
+    message: 'Cursed fumes seep out as you grasp the relic.'
   },
   'map_alchemist:18,18': {
     relic: 'alchemist_catalyst',
@@ -179,10 +179,6 @@ export async function openChest(id, player) {
         await giveItem(itm, 1);
         items.push(data);
         unlockedSkills.push(...unlockSkillsFromItem(itm));
-        if (player && itm === 'health_potion') {
-          increaseMaxHp(1);
-          gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
-        }
       }
     }
     updateInventoryUI();
@@ -191,10 +187,6 @@ export async function openChest(id, player) {
     if (item) {
       const qty = config.quantity || 1;
       await giveItem(config.item, qty);
-      if (player && config.item === 'health_potion') {
-        increaseMaxHp(1);
-        gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 1;
-      }
       updateInventoryUI();
       unlockedSkills = unlockSkillsFromItem(config.item);
     }

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -1,14 +1,13 @@
 import { getSkill } from './skills.js';
 import { getEnemySkill } from './enemy_skills.js';
-import { respawn, increaseMaxHp, gainXP, getTotalStats } from './player.js';
+import { respawn, gainXP, getTotalStats } from './player.js';
 import { getClassBonuses } from './class_state.js';
 import { getPassive } from './passive_skills.js';
 import { applyDamage } from './logic.js';
 import {
   addItem,
   getItemsByCategory,
-  addItemToInventory,
-  removeHealthBonusItem
+  addItemToInventory
 } from './inventory.js';
 import { loadItems, getItemData } from './item_loader.js';
 import {
@@ -692,10 +691,6 @@ export async function startCombat(enemy, player) {
   async function defeat() {
     log('Defeated...');
     showDialogue('Defeated...');
-    if (removeHealthBonusItem()) {
-      increaseMaxHp(-1);
-      gameState.maxHpBonus = Math.max(0, (gameState.maxHpBonus || 0) - 1);
-    }
     clearStatuses(player);
     await respawn();
     if (enemy.id === 'echo_absolute') {

--- a/scripts/game_state.js
+++ b/scripts/game_state.js
@@ -6,7 +6,6 @@ export const gameState = {
   openedChests: new Set(),
   defeatedEnemies: new Set(),
   environment: 'clear',
-  maxHpBonus: 0,
   isDead: false,
   lastEnemyPos: null,
   inCombat: false,
@@ -18,7 +17,6 @@ export function serializeGameState() {
     currentMap: gameState.currentMap,
     openedChests: Array.from(gameState.openedChests),
     defeatedEnemies: Array.from(gameState.defeatedEnemies),
-    maxHpBonus: gameState.maxHpBonus,
     settings: gameState.settings
   };
 }
@@ -28,7 +26,6 @@ export function deserializeGameState(data) {
   gameState.currentMap = data.currentMap || '';
   gameState.openedChests = new Set(data.openedChests || []);
   gameState.defeatedEnemies = new Set(data.defeatedEnemies || []);
-  gameState.maxHpBonus = data.maxHpBonus || 0;
   gameState.settings = data.settings || {};
 }
 

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -1,5 +1,5 @@
 import { getItemData } from './item_loader.js';
-import { player, applyItemReward } from './player.js';
+import { player } from './player.js';
 import { gameState } from './game_state.js';
 import { getItemBonuses } from './item_stats.js';
 import { checkTempleSet } from './equipment.js';
@@ -78,12 +78,6 @@ export function addItem(item) {
     if ((existing.quantity || 0) >= limit) return false;
     existing.quantity = Math.min(limit, (existing.quantity || 0) + qty);
     discover('items', parseItemId(item.id).baseId);
-    if (baseId === 'health_amulet') {
-      if (!player.bonusHpGiven?.health_amulet) {
-        gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 2;
-      }
-      applyItemReward(baseId);
-    }
     document.dispatchEvent(new CustomEvent('inventoryUpdated'));
     return true;
   }
@@ -102,12 +96,6 @@ export function addItem(item) {
     unlockBlueprint(item.id.replace('blueprint_', ''));
   }
   discover('items', parseItemId(item.id).baseId);
-  if (baseId === 'health_amulet') {
-    if (!player.bonusHpGiven?.health_amulet) {
-      gameState.maxHpBonus = (gameState.maxHpBonus || 0) + 2;
-    }
-    applyItemReward(baseId);
-  }
   document.dispatchEvent(new CustomEvent('inventoryUpdated'));
   return true;
 }
@@ -202,15 +190,6 @@ export function getItemsByType(type) {
   });
 }
 
-export function removeHealthBonusItem() {
-  const idx = inventory.findIndex((it) => it.id === 'health_potion');
-  if (idx !== -1) {
-    inventory.splice(idx, 1);
-    document.dispatchEvent(new CustomEvent('inventoryUpdated'));
-    return true;
-  }
-  return false;
-}
 
 export function removePrismFragments(qty = 10) {
   return removeItem('prism_fragment', qty);

--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -4,11 +4,11 @@ import {
   getEquippedItem,
   getItemDisplayName,
   getItemLevel,
-  getItemsByCategory
+  getItemsByCategory,
+  consumeItem
 } from './inventory.js';
-import { player, getTotalStats } from './player.js';
+import { player, getTotalStats, gainXP } from './player.js';
 import {
-  useArmorPiece,
   useHealthPotion,
   useDefensePotion,
   useDefensePotionII,
@@ -97,11 +97,6 @@ export async function updateInventoryUI() {
     if (upgradeLevel > 0) {
       row.classList.add('gear-upgraded');
     }
-    row.addEventListener('click', () => {
-      if (item.id === 'armor_piece') {
-        useArmorPiece();
-      }
-    });
     const bonus = getItemBonuses(item.id);
     if (bonus && bonus.slot && getEquippedItem(bonus.slot) === item.id) {
       row.classList.add('equipped-item');
@@ -261,6 +256,16 @@ function handleInventoryItemUse(id) {
   } else if (id === 'ember_prayer_scroll') {
     const res = useEmberPrayerScroll();
     if (res) used = true;
+  } else if (typeof data.use === 'function') {
+    if (data.inventoryOnly && gameState.inCombat) {
+      logMessage('Cannot use this item in combat.');
+      return;
+    }
+    const res = data.use();
+    if (res !== false) {
+      consumeItem(id, 1);
+      used = true;
+    }
   }
   if (used) {
     markItemUsed(id);

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -44,16 +44,49 @@ export const itemData = {
     icon: '🧪',
     useInCombat: true
   },
-  health_amulet: {
-    id: 'health_amulet',
-    name: 'Health Amulet',
-    description: 'Permanently increases max HP when found.',
-    type: 'passive',
-    tags: ['equipable'],
-    category: 'equipable',
-    consumable: false,
+  xp_scroll: {
+    id: 'xp_scroll',
+    name: 'XP Scroll',
+    description: 'Use to gain 25 experience.',
+    type: 'consumable',
+    tags: ['items'],
+    category: 'general',
+    consumable: true,
     stackLimit: 99,
-    icon: '🩸'
+    icon: '📜',
+    use() {
+      import('./player.js').then((m) => m.gainXP(25));
+    }
+  },
+  xp_potion: {
+    id: 'xp_potion',
+    name: 'XP Potion',
+    description: 'Use in battle to gain 50 XP.',
+    type: 'consumable',
+    tags: ['combat'],
+    category: 'combat',
+    consumable: true,
+    stackLimit: 5,
+    icon: '🧪',
+    useInCombat: true,
+    use() {
+      import('./player.js').then((m) => m.gainXP(50));
+    }
+  },
+  xp_relic: {
+    id: 'xp_relic',
+    name: 'XP Relic',
+    description: 'Grants 100 XP when used from your pack.',
+    type: 'consumable',
+    tags: ['items'],
+    category: 'general',
+    consumable: true,
+    stackLimit: 1,
+    icon: '🔮',
+    inventoryOnly: true,
+    use() {
+      import('./player.js').then((m) => m.gainXP(100));
+    }
   },
   empty_note: {
     id: 'empty_note',

--- a/scripts/item_logic.js
+++ b/scripts/item_logic.js
@@ -1,13 +1,6 @@
 import { consumeItem } from './inventory.js';
-import { increaseDefense, addTempAttack } from './player.js';
+import { addTempAttack } from './player.js';
 
-export function useArmorPiece() {
-  if (consumeItem('armor_piece', 1)) {
-    increaseDefense(1);
-    return true;
-  }
-  return false;
-}
 
 export function useDefensePotion() {
   if (consumeItem('defense_potion_I', 1)) {

--- a/scripts/item_stats.js
+++ b/scripts/item_stats.js
@@ -2,16 +2,16 @@ import { splitItemId } from './utils.js';
 import { enchantments } from './enchantments.js';
 
 export const itemBonuses = {
-  cracked_helmet: { slot: 'armor', defense: 1 },
-  'cracked_helmet+1': { slot: 'armor', defense: 2 },
-  'cracked_helmet+2': { slot: 'armor', defense: 3 },
-  'cracked_helmet+3': { slot: 'armor', defense: 4 },
+  cracked_helmet: { slot: 'armor' },
+  'cracked_helmet+1': { slot: 'armor' },
+  'cracked_helmet+2': { slot: 'armor' },
+  'cracked_helmet+3': { slot: 'armor' },
   focus_ring: { slot: 'accessory' },
-  forgotten_ring: { slot: 'accessory', attack: 1 },
-  goblin_sword: { slot: 'weapon', attack: 3 },
-  temple_sword: { slot: 'weapon', attack: 3 },
-  temple_shell: { slot: 'armor', defense: 2, maxHp: 5 },
-  temple_ring: { slot: 'accessory', attack: 1, defense: 1, maxHp: 2 }
+  forgotten_ring: { slot: 'accessory' },
+  goblin_sword: { slot: 'weapon' },
+  temple_sword: { slot: 'weapon' },
+  temple_shell: { slot: 'armor' },
+  temple_ring: { slot: 'accessory' }
 };
 
 export function getItemBonuses(id) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,7 +3,7 @@ import { onStepEffect, isWalkable } from './tile_type.js';
 import { toggleInventoryView, initInventoryUI } from './inventory_ui.js';
 import { toggleQuestLog } from './quest_log.js';
 import { toggleCraftView } from './craft_ui.js';
-import { player, stepTo } from './player.js';
+import { player, stepTo, updateStatsFromLevel } from './player.js';
 import { initFog, reveal, revealAll } from './fog_system.js';
 import { loadEnemyData, defeatEnemy } from './enemy.js';
 import { setMemory } from './dialogue_state.js';
@@ -153,7 +153,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           reveal(player.x, player.y);
         }
       }
-      player.maxHp = 100 + (gameState.maxHpBonus || 0);
+      updateStatsFromLevel();
       player.hp = Math.min(player.hp, player.maxHp);
       updateHpDisplay();
       updateXpDisplay();


### PR DESCRIPTION
## Summary
- derive player HP, defense, and attack directly from level
- add helper `calculateStatsFromLevel` and `updateStatsFromLevel`
- introduce XP Scroll, Potion and Relic items
- remove permanent stat boosts from items and equipment
- convert temple chest rewards to XP items
- ensure inventories and combat use new XP items
- simplify item bonus table to slots only

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6849c85d6dcc833183de28115e521e4b