### PR TITLE
Implement temple passive update

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -304,9 +304,6 @@
     "type": "gear",
     "stackLimit": 1,
     "icon": "🎯",
-    "passiveModifier": {
-      "accuracy": 0.1
-    },
     "category": "equipable"
   },
   "goblin_bow": {

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -205,8 +205,11 @@ export async function startCombat(enemy, player) {
       log('Reflected the damage back!');
       reflectActive = false;
     }
-    if (player.templeSetActive && applied > 0) {
-      damageEnemy(2);
+    if (player.hasTemplePassive && applied > 0) {
+      enemyHp = Math.max(0, enemyHp - 2);
+      enemy.hp = enemyHp;
+      updateHpBar(enemyBar, enemyHp, enemyMax);
+      log('Sacred Counter retaliates!');
       healPlayer(1);
     }
     return applied;

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -1,5 +1,5 @@
 import { getItemData } from './item_loader.js';
-import { player } from './player.js';
+import { player, updatePassiveEffects } from './player.js';
 import { gameState } from './game_state.js';
 import { getItemBonuses } from './item_stats.js';
 import { checkTempleSet } from './equipment.js';
@@ -226,10 +226,19 @@ export function equipItem(itemId) {
   player.equipment[bonus.slot] = itemId;
   recalcPassiveModifiers();
   checkTempleSet();
+  updatePassiveEffects();
   document.dispatchEvent(new CustomEvent('equipmentChanged'));
   return true;
 }
 
 export function getEquippedItem(slot) {
   return player.equipment ? player.equipment[slot] : null;
+}
+
+export function isEquipped(itemId) {
+  const { baseId } = parseItemId(itemId);
+  const eq = player.equipment || {};
+  return Object.values(eq).some(
+    (eqId) => eqId && parseItemId(eqId).baseId === baseId
+  );
 }

--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -154,7 +154,7 @@ export async function updateInventoryUI() {
     if (baseId === 'temple_sword' || baseId === 'temple_shell' || baseId === 'temple_ring') {
       if (tooltipText) tooltipText += '\n';
       tooltipText += 'Temple Set piece';
-      if (player.templeSetActive) tooltipText += ' (Set active)';
+      if (player.hasTemplePassive) tooltipText += ' (Set active)';
     }
     if (tooltipText) {
       row.addEventListener('mouseenter', () =>

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -108,8 +108,7 @@ export const itemData = {
     category: 'equipable',
     consumable: false,
     stackLimit: 1,
-    icon: '🎯',
-    passiveModifier: { accuracy: 0.1 }
+    icon: '🎯'
   },
   goblin_bow: {
     id: 'goblin_bow',

--- a/scripts/menu/status.js
+++ b/scripts/menu/status.js
@@ -54,7 +54,7 @@ export function updateStatusPanel() {
     }
     equipList.appendChild(row);
   });
-  if (player.templeSetActive) {
+  if (player.hasTemplePassive) {
     const row = document.createElement('div');
     row.classList.add('status-equip');
     row.innerHTML = '<strong>Set Bonus:</strong> Temple Harmony';

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -13,9 +13,18 @@ import {
   addItem,
   removeItem as removeInvItem,
   getPassiveModifiers,
-  recalcPassiveModifiers
+  recalcPassiveModifiers,
+  isEquipped
 } from './inventory.js';
 import { checkTempleSet } from './equipment.js';
+
+export function updatePassiveEffects() {
+  const hasTempleSet =
+    isEquipped('temple_sword') &&
+    isEquipped('temple_shell') &&
+    isEquipped('temple_ring');
+  player.hasTemplePassive = hasTempleSet;
+}
 
 export const player = {
   x: 0,
@@ -39,6 +48,7 @@ export const player = {
   passiveImmunities: [],
   tempDefense: 0,
   tempAttack: 0,
+  hasTemplePassive: false,
   statuses: [],
   isPlayer: true
 };
@@ -245,6 +255,7 @@ export function deserializePlayer(data) {
     player.equipment.accessory = data.equipment.accessory || null;
     recalcPassiveModifiers();
     checkTempleSet();
+    updatePassiveEffects();
     document.dispatchEvent(new CustomEvent('equipmentChanged'));
   }
   updateStatsFromLevel();
@@ -311,8 +322,10 @@ export async function enterDoor(target, spawn) {
 export function reapplyEquipmentBonuses() {
   recalcPassiveModifiers();
   checkTempleSet();
+  updatePassiveEffects();
   document.dispatchEvent(new CustomEvent('equipmentChanged'));
 }
 
 // initialize stats based on starting level
 updateStatsFromLevel();
+updatePassiveEffects();


### PR DESCRIPTION
## Summary
- strip stat modifiers from Focus Ring
- add updatePassiveEffects utility
- expose inventory.isEquipped
- enable Temple set passive logic using `hasTemplePassive`
- show passive info in UI panels

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849cbecb3f4833194dbf254149ec4b9