### PR TITLE
Enable mobile center mode

### DIFF
--- a/scripts/mobile_ui.js
+++ b/scripts/mobile_ui.js
@@ -1,16 +1,22 @@
 import { gameState } from './game_state.js';
 
+export const isMobilePortrait = () =>
+  window.innerWidth < 768 && window.innerHeight > window.innerWidth;
+
+export function centerGridOnPlayer(container) {
+  const playerTile = container.querySelector('.tile.player');
+  if (!playerTile) return;
+  const rect = playerTile.getBoundingClientRect();
+  const cRect = container.getBoundingClientRect();
+  const scrollX = rect.left - cRect.left + rect.width / 2 - cRect.width / 2;
+  const scrollY = rect.top - cRect.top + rect.height / 2 - cRect.height / 2;
+  container.scrollBy(scrollX, scrollY);
+}
+
 export function initMobileCenter(container) {
   document.addEventListener('playerMoved', () => {
     if (!gameState.settings?.centerMode) return;
-    if (window.innerWidth > window.innerHeight) return;
-    const playerTile = container.querySelector('.player');
-    if (!playerTile) return;
-    const rect = playerTile.getBoundingClientRect();
-    const cRect = container.getBoundingClientRect();
-    const offsetX = rect.left - cRect.left - container.clientWidth / 2 + rect.width / 2;
-    const offsetY = rect.top - cRect.top - container.clientHeight / 2 + rect.height / 2;
-    container.scrollLeft += offsetX;
-    container.scrollTop += offsetY;
+    if (!isMobilePortrait()) return;
+    centerGridOnPlayer(container);
   });
 }

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -4,6 +4,7 @@ import { showDialogue } from './dialogueSystem.js';
 import { movePlayerTo } from './map.js';
 import { transitionToMap } from './transition.js';
 import { handleMoveCorruption } from './corruption_state.js';
+import { isMobilePortrait, centerGridOnPlayer } from './mobile_ui.js';
 import { unlockPassivesForLevel, getPassive } from './passive_skills.js';
 import { getItemBonuses } from './item_stats.js';
 import { getRelicBonuses } from './relic_state.js';
@@ -79,6 +80,12 @@ export function stepTo(x, y) {
   player.y = y;
   handleMoveCorruption(x, y);
   document.dispatchEvent(new CustomEvent('playerMoved', { detail: { x, y } }));
+  if (gameState.settings?.centerMode && isMobilePortrait()) {
+    const container = document.getElementById('game-grid');
+    if (container) {
+      centerGridOnPlayer(container);
+    }
+  }
 }
 
 export function takeDamage(amount) {


### PR DESCRIPTION
## Summary
- implement `isMobilePortrait` and `centerGridOnPlayer`
- automatically center the grid on the player when moving in mobile portrait

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cdfb0be88331ae414c2f128a7a6b