### PR TITLE
Improve mobile centering and disable zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <title>Grid Quest</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
     <link rel="stylesheet" href="style/main.css" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
   </head>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -97,6 +97,28 @@ function handleTileClick(e, player, container, cols) {
 
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('game-grid');
+  // Prevent double-tap zoom on mobile devices
+  document.addEventListener(
+    'touchstart',
+    (event) => {
+      if (event.touches.length > 1) {
+        event.preventDefault();
+      }
+    },
+    { passive: false }
+  );
+  let lastTouch = 0;
+  document.addEventListener(
+    'touchend',
+    (e) => {
+      const now = Date.now();
+      if (now - lastTouch <= 300) {
+        e.preventDefault();
+      }
+      lastTouch = now;
+    },
+    { passive: false }
+  );
   const inventoryTab = document.querySelector('.inventory-tab');
   const inventoryOverlay = document.getElementById('inventory-overlay');
   const closeBtn = inventoryOverlay.querySelector('.close-btn');

--- a/scripts/mobile_ui.js
+++ b/scripts/mobile_ui.js
@@ -4,13 +4,15 @@ export const isMobilePortrait = () =>
   window.innerWidth < 768 && window.innerHeight > window.innerWidth;
 
 export function centerGridOnPlayer(container) {
+  if (!gameState.settings?.centerMode) return;
+  if (!isMobilePortrait()) return;
   const playerTile = container.querySelector('.tile.player');
   if (!playerTile) return;
   const rect = playerTile.getBoundingClientRect();
   const cRect = container.getBoundingClientRect();
   const scrollX = rect.left - cRect.left + rect.width / 2 - cRect.width / 2;
   const scrollY = rect.top - cRect.top + rect.height / 2 - cRect.height / 2;
-  container.scrollBy(scrollX, scrollY);
+  container.scrollBy({ top: scrollY, left: scrollX, behavior: 'smooth' });
 }
 
 export function initMobileCenter(container) {


### PR DESCRIPTION
## Summary
- add viewport meta tag for mobile layout
- disable mobile double-tap zoom in `main.js`
- smooth mobile centering of grid in `mobile_ui.js`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cfbb36208331b1eddd892377d8fc