### PR TITLE
Ensure defense recalculated on load

### DIFF
--- a/scripts/player.js
+++ b/scripts/player.js
@@ -235,7 +235,8 @@ export function serializePlayer() {
     level: player.level,
     xp: player.xp,
     xpToNextLevel: player.xpToNextLevel,
-    stats: { ...player.stats },
+    // stats like defense and attack are derived from level and equipment
+    // and will be recalculated when loading a save
     learnedSkills: Array.isArray(player.learnedSkills)
       ? [...player.learnedSkills]
       : [],
@@ -252,7 +253,7 @@ export function deserializePlayer(data) {
   player.level = data.level ?? player.level;
   player.xp = data.xp ?? player.xp;
   player.xpToNextLevel = data.xpToNextLevel ?? player.xpToNextLevel;
-  player.stats = { ...player.stats, ...(data.stats || {}) };
+  // derived stats will be recalculated from the level
   if (Array.isArray(data.learnedSkills)) {
     player.learnedSkills = [...data.learnedSkills];
   }


### PR DESCRIPTION
## Summary
- avoid persisting derived player stats in saves
- recompute defense from level when loading a game

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d782b48c8331a9ad62a237652601