### PR TITLE
Add Cracked Crystal Sentry and maze key

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -972,5 +972,28 @@
         "quantity": 1
       }
     ]
+  },
+  "cracked_crystal_sentry": {
+    "name": "Cracked Crystal Sentry",
+    "hp": 300,
+    "stats": {
+      "attack": 4,
+      "defense": 5
+    },
+    "xp": 100,
+    "description": "A fractured sentinel brimming with unstable power.",
+    "intro": "Fragments stir as a Cracked Crystal Sentry emerges!",
+    "portrait": "💠",
+    "skills": [
+      "refract_crack",
+      "prism_crack"
+    ],
+    "behavior": "balanced",
+    "drops": [
+      {
+        "item": "prism_fragment",
+        "quantity": 1
+      }
+    ]
   }
 }

--- a/data/items.json
+++ b/data/items.json
@@ -441,5 +441,13 @@
     "stackLimit": 99,
     "icon": "🎵",
     "category": "general"
+  },
+  "maze_key_1": {
+    "name": "Maze Key 1",
+    "description": "A key used deep in the maze system.",
+    "type": "quest",
+    "stackLimit": 1,
+    "icon": "🗝️",
+    "category": "quest"
   }
 }

--- a/data/maps/map07_maze01.json
+++ b/data/maps/map07_maze01.json
@@ -177,7 +177,10 @@
       "F",
       "F",
       "F",
-      "G",
+      {
+        "type": "C",
+        "item": "maze_key_1"
+      },
       "F",
       "G",
       "F",
@@ -201,7 +204,7 @@
       "F",
       {
         "type": "E",
-        "enemyId": "crystal_sentry"
+        "enemyId": "cracked_crystal_sentry"
       },
       "F",
       "G",

--- a/enemies/cracked_crystal_sentry.js
+++ b/enemies/cracked_crystal_sentry.js
@@ -1,0 +1,13 @@
+export const cracked_crystal_sentry = {
+  id: 'cracked_crystal_sentry',
+  name: 'Cracked Crystal Sentry',
+  hp: 300,
+  stats: { attack: 4, defense: 5 },
+  xp: 100,
+  skills: ['refract_crack', 'prism_crack'],
+  behavior: 'balanced',
+  description: 'A damaged sentry whose fractures shimmer with unstable energy.',
+  drops: [{ item: 'prism_fragment', quantity: 1 }]
+};
+
+export default cracked_crystal_sentry;

--- a/info/enemies.js
+++ b/info/enemies.js
@@ -80,6 +80,14 @@ export const enemies = [
     skills: 'prism_shot, refract_guard'
   },
   {
+    id: 'cracked_crystal_sentry',
+    name: 'Cracked Crystal Sentry',
+    map: 'Map07 Maze',
+    location: '14,8',
+    drops: 'Prism Fragment',
+    skills: 'refract_crack, prism_crack'
+  },
+  {
     id: 'pain_lattice',
     name: 'Pain Lattice',
     map: 'Map05',

--- a/info_data/enemies.json
+++ b/info_data/enemies.json
@@ -2,10 +2,36 @@
   {
     "id": "goblin_scout",
     "name": "Goblin Scout",
-    "locations": ["Map03"],
-    "drops": ["Scout Blade"],
-    "skills": ["strike"],
-    "weaknesses": ["fire"],
-    "resistances": ["poison"]
+    "locations": [
+      "Map03"
+    ],
+    "drops": [
+      "Scout Blade"
+    ],
+    "skills": [
+      "strike"
+    ],
+    "weaknesses": [
+      "fire"
+    ],
+    "resistances": [
+      "poison"
+    ]
+  },
+  {
+    "id": "cracked_crystal_sentry",
+    "name": "Cracked Crystal Sentry",
+    "locations": [
+      "Map07 Maze"
+    ],
+    "drops": [
+      "Prism Fragment"
+    ],
+    "skills": [
+      "refract_crack",
+      "prism_crack"
+    ],
+    "weaknesses": [],
+    "resistances": []
   }
 ]

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -765,7 +765,17 @@ export async function startCombat(enemy, player) {
     const behavior = enemy.behavior || 'balanced';
     const special = isElite(enemy) || isBoss(enemy);
 
-    if (enemy.id === 'crystal_sentry') {
+    if (enemy.id === 'cracked_crystal_sentry') {
+      enemy.prismCooldown = enemy.prismCooldown || 0;
+      if (enemy.prismCooldown > 0) enemy.prismCooldown--;
+      const currentDef = enemy.stats?.defense || 0;
+      if (currentDef >= 30 && enemy.prismCooldown === 0) {
+        skill = getEnemySkill('prism_crack');
+        enemy.prismCooldown = skill.cooldown;
+      } else {
+        skill = getEnemySkill('refract_crack');
+      }
+    } else if (enemy.id === 'crystal_sentry') {
       const currentDef = enemy.stats?.defense || 0;
       if (currentDef < 20) {
         skill = getEnemySkill('refract_guard');

--- a/scripts/enemy_skills.js
+++ b/scripts/enemy_skills.js
@@ -410,6 +410,35 @@ export const enemySkills = {
       log(`${enemy.name}'s facets harden! (+1 defense)`);
     }
   },
+  refract_crack: {
+    id: 'refract_crack',
+    name: 'Refract Crack',
+    icon: '🔷',
+    description: 'Permanently increases defense by 2.',
+    category: 'defensive',
+    cost: 0,
+    cooldown: 0,
+    aiType: 'buff',
+    effect({ enemy, log }) {
+      enemy.stats.defense = (enemy.stats?.defense || 0) + 2;
+      log(`${enemy.name}'s cracked shards realign! (+2 defense)`);
+    }
+  },
+  prism_crack: {
+    id: 'prism_crack',
+    name: 'Prism Crack',
+    icon: '🔶',
+    description: 'Crushing prism blast for 100 damage that lowers defense by 30.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 10,
+    aiType: 'damage',
+    effect({ enemy, damagePlayer, log }) {
+      const applied = damagePlayer(100);
+      enemy.stats.defense = (enemy.stats?.defense || 0) - 30;
+      log(`${enemy.name} unleashes a prism crack for ${applied} damage!`);
+    }
+  },
   neural_lash: {
     id: 'neural_lash',
     name: 'Neural Lash',


### PR DESCRIPTION
## Summary
- place Maze Key chest and new enemy in map07_maze01
- add `maze_key_1` item
- define `Cracked Crystal Sentry` enemy and skills
- register enemy in info lists
- implement combat logic and skills

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6849fe5605f48331a0164d7113aa91f2