### PR TITLE
Add responsive menu and overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,19 +12,18 @@
   </head>
   <body>
     <div id="game-grid"></div>
+    <div id="menu-bar">
+      <div class="tab settings-tab">Settings</div>
+      <div class="tab menu-tab">Menu</div>
+      <div class="tab inventory-tab">Inventory</div>
+      <div class="tab craft-tab" style="display: none">Craft</div>
+      <div class="tab save-tab">Save</div>
+      <div class="tab load-tab">Load</div>
+    </div>
     <div id="ui-bar">
       <div id="hp-display"></div>
       <div id="defense-display"></div>
       <div id="xp-display"></div>
-      <div class="tab settings-tab">Settings</div>
-      <div class="tab inventory-tab">Inventory</div>
-      <div class="tab craft-tab" style="display: none">Craft</div>
-      <div class="tab quests-tab">Quests</div>
-      <div class="tab status-tab">Status</div>
-      <div class="tab null-tab disabled">The Null Factor</div>
-      <div class="tab info-tab">Info</div>
-      <div class="tab save-tab">Save</div>
-      <div class="tab load-tab">Load</div>
     </div>
     <div id="inventory-overlay" class="inventory-overlay">
       <div class="inventory-content">
@@ -40,6 +39,19 @@
         </div>
         <div id="inventory-list"></div>
         <div id="forge-log" class="forge-log"></div>
+      </div>
+    </div>
+    <div id="menu-overlay" class="menu-overlay">
+      <div class="menu-content">
+        <button class="close-btn">&times;</button>
+        <div class="menu-buttons">
+          <div class="tab guide-tab">Guide</div>
+          <div class="tab info-tab">Info</div>
+          <div class="tab quests-tab">Quest</div>
+          <div class="tab status-tab">Status Panel</div>
+          <div class="tab null-tab">The Null Factor</div>
+        </div>
+        <div id="menu-stats"></div>
       </div>
     </div>
     <div id="craft-overlay" class="craft-overlay">
@@ -148,8 +160,12 @@
             <option value="ja">日本語</option>
           </select>
         </label>
-        <label class="setting-row" title="Keeps the player centered on screen when using a phone in portrait orientation.">
-          <input type="checkbox" id="center-toggle" /> Center Mode (Mobile Portrait Only)
+        <label
+          class="setting-row"
+          title="Keeps the player centered on screen when using a phone in portrait orientation."
+        >
+          <input type="checkbox" id="center-toggle" /> Center Mode (Mobile
+          Portrait Only)
         </label>
         <button id="reset-settings" class="reset-btn">
           Reset All Settings

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -34,7 +34,10 @@ import { initSkillSystem } from './skills.js';
 import { initPassiveSystem } from './passive_skills.js';
 import { toggleStatusPanel } from './menu/status.js';
 import { toggleInfoMenu, initInfoMenu } from '../ui/info_menu.js';
-import { refreshInventoryDisplay, initInventoryMenu } from '../ui/inventory_menu.js';
+import {
+  refreshInventoryDisplay,
+  initInventoryMenu
+} from '../ui/inventory_menu.js';
 import {
   initSaveSlotsMenu,
   openSaveMenu,
@@ -43,6 +46,7 @@ import {
 import { saveState, loadState, gameState } from './game_state.js';
 import { saveGame, loadGame } from './save_load.js';
 import { initMenuBar } from '../ui/menu_bar.js';
+import { initMainMenu } from '../ui/main_menu.js';
 import {
   loadSettings,
   saveSettings,
@@ -196,6 +200,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
   initMenuBar(handleSave, handleLoad);
+  initMainMenu();
   initInventoryUI();
   initInventoryMenu();
   initPlayerDisplay();

--- a/style/main.css
+++ b/style/main.css
@@ -253,6 +253,19 @@ body {
   gap: 4px;
 }
 
+#menu-bar {
+  display: flex;
+  justify-content: center;
+  padding: 8px;
+  background: #222;
+  color: #fff;
+  width: 100%;
+}
+#menu-bar.stacked {
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
 #hp-display {
   margin-right: auto;
   padding: 8px 12px;
@@ -269,6 +282,10 @@ body {
 }
 
 #ui-bar .tab {
+  margin: 4px 8px;
+}
+
+#menu-bar .tab {
   margin: 4px 8px;
 }
 
@@ -655,7 +672,6 @@ body {
   border-color: #666;
 }
 
-
 .inventory-item {
   border-bottom: 1px solid #ddd;
   padding: 6px 0;
@@ -691,6 +707,52 @@ body {
   margin-top: 8px;
   font-size: 14px;
   color: #fff;
+}
+
+/* Main Menu Overlay */
+.menu-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 900;
+}
+
+.menu-overlay.active {
+  visibility: visible;
+  opacity: 1;
+}
+
+.menu-content {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 300px;
+  max-width: 90%;
+  position: relative;
+}
+
+.menu-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 12px;
+  justify-content: center;
+}
+
+#menu-stats,
+.menu-stats {
+  text-align: left;
+  font-weight: bold;
 }
 
 /* Crafting UI */
@@ -732,7 +794,6 @@ body {
   margin-top: 0;
   text-align: center;
 }
-
 
 .craft-item {
   border-bottom: 1px solid #ddd;
@@ -794,7 +855,6 @@ body {
   text-align: center;
 }
 
-
 /* Status/Passive Panel */
 .status-overlay {
   position: fixed;
@@ -834,7 +894,6 @@ body {
   margin-top: 0;
   text-align: center;
 }
-
 
 #status-info {
   margin-bottom: 10px;
@@ -952,7 +1011,6 @@ body {
   overflow-y: auto;
 }
 
-
 #info-panel .info-tabs {
   display: flex;
   justify-content: center;
@@ -1040,7 +1098,6 @@ body {
   overflow-y: auto;
 }
 
-
 #info-menu .info-nav {
   display: flex;
   justify-content: center;
@@ -1114,7 +1171,6 @@ body {
   margin-top: 0;
   text-align: center;
 }
-
 
 .setting-row {
   display: flex;
@@ -1429,7 +1485,6 @@ body {
   overflow-y: auto;
 }
 
-
 .null-summary-entry {
   margin-bottom: 12px;
 }
@@ -1541,7 +1596,6 @@ body {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
   position: relative;
 }
-
 
 .slot-row {
   display: flex;

--- a/ui/main_menu.js
+++ b/ui/main_menu.js
@@ -1,0 +1,86 @@
+import { player, getTotalStats } from '../scripts/player.js';
+import { hasCodeFile } from '../scripts/inventory.js';
+import { toggleQuestLog } from '../scripts/quest_log.js';
+import { toggleInfoMenu } from './info_menu.js';
+import { toggleStatusPanel } from '../scripts/menu/status.js';
+import { toggleNullSummary } from './null_summary.js';
+
+export function updateMenuStats() {
+  const el = document.getElementById('menu-stats');
+  if (!el) return;
+  const stats = getTotalStats();
+  el.innerHTML = `
+    <div>Level: ${player.level}</div>
+    <div>XP: ${player.xp} / ${player.xpToNextLevel}</div>
+    <div>HP: ${player.hp} / ${player.maxHp}</div>
+    <div>ATK: ${stats.attack || 0}</div>
+    <div>DEF: ${stats.defense || 0}</div>
+  `;
+}
+
+function updateNullButton() {
+  const btn = document.querySelector('#menu-overlay .null-tab');
+  if (!btn) return;
+  btn.style.display = hasCodeFile() ? 'inline-block' : 'none';
+}
+
+export function toggleMainMenu() {
+  const overlay = document.getElementById('menu-overlay');
+  const grid = document.getElementById('game-grid');
+  if (!overlay || !grid) return;
+  if (overlay.classList.contains('active')) {
+    overlay.classList.remove('active');
+    grid.classList.remove('blurred', 'no-interact');
+  } else {
+    updateMenuStats();
+    updateNullButton();
+    overlay.classList.add('active');
+    grid.classList.add('blurred', 'no-interact');
+  }
+}
+
+export function initMainMenu() {
+  const menuBtn = document.querySelector('#menu-bar .menu-tab');
+  const closeBtn = document.querySelector('#menu-overlay .close-btn');
+  menuBtn?.addEventListener('click', toggleMainMenu);
+  closeBtn?.addEventListener('click', toggleMainMenu);
+  const overlay = document.getElementById('menu-overlay');
+  overlay?.addEventListener('click', (e) => {
+    if (e.target === overlay) toggleMainMenu();
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && overlay?.classList.contains('active')) {
+      toggleMainMenu();
+    }
+  });
+  document
+    .querySelector('#menu-overlay .quests-tab')
+    ?.addEventListener('click', () => {
+      toggleMainMenu();
+      toggleQuestLog();
+    });
+  document
+    .querySelector('#menu-overlay .info-tab')
+    ?.addEventListener('click', () => {
+      toggleMainMenu();
+      toggleInfoMenu();
+    });
+  document
+    .querySelector('#menu-overlay .status-tab')
+    ?.addEventListener('click', () => {
+      toggleMainMenu();
+      toggleStatusPanel();
+    });
+  document
+    .querySelector('#menu-overlay .null-tab')
+    ?.addEventListener('click', () => {
+      toggleMainMenu();
+      toggleNullSummary();
+    });
+
+  document.addEventListener('inventoryUpdated', updateNullButton);
+  document.addEventListener('playerHpChanged', updateMenuStats);
+  document.addEventListener('playerXpChanged', updateMenuStats);
+  document.addEventListener('playerLevelUp', updateMenuStats);
+  document.addEventListener('equipmentChanged', updateMenuStats);
+}

--- a/ui/menu_bar.js
+++ b/ui/menu_bar.js
@@ -1,6 +1,6 @@
 export function initMenuBar(onSave, onLoad) {
-  const saveBtn = document.querySelector('.save-tab');
-  const loadBtn = document.querySelector('.load-tab');
+  const saveBtn = document.querySelector('#menu-bar .save-tab');
+  const loadBtn = document.querySelector('#menu-bar .load-tab');
   if (saveBtn && typeof onSave === 'function') {
     saveBtn.addEventListener('click', onSave);
   }
@@ -8,7 +8,7 @@ export function initMenuBar(onSave, onLoad) {
     loadBtn.addEventListener('click', onLoad);
   }
 
-  const bar = document.getElementById('ui-bar');
+  const bar = document.getElementById('menu-bar');
   function updateLayout() {
     if (!bar) return;
     if (window.innerWidth < 480) {


### PR DESCRIPTION
## Summary
- create responsive menu bar
- add modal menu overlay with player stats
- update main entry JS to initialize new UI
- support layout via CSS

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a03da5e548331b23c86e75b0ab176