### PR TITLE
Fix craft menu layout on mobile

### DIFF
--- a/scripts/craft_ui.js
+++ b/scripts/craft_ui.js
@@ -59,6 +59,7 @@ export function toggleCraftView() {
     overlay.classList.remove('active');
   } else {
     updateCraftUI();
+    overlay.scrollTop = 0;
     overlay.classList.add('active');
   }
 }

--- a/style/main.css
+++ b/style/main.css
@@ -817,6 +817,17 @@ body {
   color: #27ae60;
 }
 
+@media (max-width: 768px) {
+  .craft-overlay {
+    align-items: flex-start;
+    padding-top: 20px;
+  }
+  .craft-content {
+    width: 95%;
+    max-height: calc(100vh - 40px);
+  }
+}
+
 /* Quest Log UI */
 .quest-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- adjust craft overlay and panel for smaller screens
- ensure craft panel scroll position resets when opened

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a09bae57c83318836900061e20be0