### PR TITLE
Fix leech heal amount

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -249,6 +249,7 @@ export async function startCombat(enemy, player) {
     enemyBar.classList.add('damage');
     setTimeout(() => enemyBar.classList.remove('damage'), 300);
     log(`${enemy.name} takes ${applied} damage`);
+    return applied;
   }
 
   function healPlayer(amount) {


### PR DESCRIPTION
## Summary
- return the damage dealt from `damageEnemy`

## Testing
- `npm test` *(fails: `jest` not found)*
- `npx jest` *(fails: 403 Forbidden to fetch packages)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684a0db818988331aa2ecc3aae2fbddf