### PR TITLE
Fix chest not granting Maze Key 1

### DIFF
--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -101,6 +101,10 @@ const chestContents = {
     item: 'forgotten_ring',
     message: 'This false dead end conceals a forgotten ring.'
   },
+  'map07_maze01:14,7': {
+    item: 'maze_key_1',
+    message: 'Inside you find Maze Key 1.'
+  },
   'map08:3,3': {
     item: 'defense_potion_I',
     message: 'You find a basic Defense Potion.'


### PR DESCRIPTION
## Summary
- ensure the chest in map07_maze01 grants Maze Key 1

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684a0f22bf68833186f72322b5c6f5e3