### PR TITLE
Enable crafting through in‑game menu

### DIFF
--- a/ui/craft_menu.js
+++ b/ui/craft_menu.js
@@ -1,3 +1,6 @@
+import { updateCraftUI } from '../scripts/craft_ui.js';
+import { beginCraftingSession, endCraftingSession } from '../scripts/craft.js';
+
 export function toggleCraftMenu() {
   const overlay = document.getElementById('craft-overlay');
   const grid = document.getElementById('game-grid');
@@ -5,13 +8,12 @@ export function toggleCraftMenu() {
   if (overlay.classList.contains('active')) {
     overlay.classList.remove('active');
     grid.classList.remove('blurred', 'no-interact');
+    endCraftingSession();
   } else {
-    const list = document.getElementById('craft-list');
-    if (list && list.children.length === 0) {
-      list.innerHTML = '<p>No recipes unlocked yet.</p>';
-    }
+    updateCraftUI();
     overlay.classList.add('active');
     grid.classList.add('blurred', 'no-interact');
+    beginCraftingSession();
   }
 }
 


### PR DESCRIPTION
## Summary
- hook craft UI into the crafting overlay
- start and end crafting sessions when the menu is toggled
- refresh available recipes and blueprints when opening

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing eslint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a100b8bfc8331b2cf4db8df072f17