### PR TITLE
Register defense potion blueprint from Eryndor

### DIFF
--- a/data/blueprints.json
+++ b/data/blueprints.json
@@ -12,5 +12,12 @@
     "ingredients": { "armor_piece": 3 },
     "result": "cracked_helmet",
     "quantity": 1
+  },
+  "defense_potion_I": {
+    "id": "defense_potion_I",
+    "name": "Defense Potion I",
+    "ingredients": { "bone_fragment": 1, "armor_piece": 1 },
+    "result": "defense_potion_I",
+    "quantity": 1
   }
 }

--- a/scripts/craft_ui.js
+++ b/scripts/craft_ui.js
@@ -67,3 +67,4 @@ export function toggleCraftView() {
 document.addEventListener('inventoryUpdated', updateCraftUI);
 document.addEventListener('blueprintUnlocked', updateCraftUI);
 document.addEventListener('blueprintsLoaded', updateCraftUI);
+document.addEventListener('recipeUnlocked', updateCraftUI);

--- a/scripts/npc_dialogues/eryndor_dialogue.js
+++ b/scripts/npc_dialogues/eryndor_dialogue.js
@@ -19,7 +19,7 @@ export const eryndorDialogue = [
         label: "Got it. Thanks.",
         goto: null,
         memoryFlag: "learned_defense_potion_I",
-        grantRecipe: "defense_potion_I"
+        giveBlueprint: "defense_potion_I"
       }
     ]
   }

--- a/scripts/recipe_state.js
+++ b/scripts/recipe_state.js
@@ -3,7 +3,7 @@ export const recipeState = {
 };
 
 const recipeFlags = {
-  learned_defense_potion_I: 'defense_potion_I'
+  // map memory flags to recipes for automatic unlocking
 };
 
 export function unlockRecipe(id) {


### PR DESCRIPTION
## Summary
- add Defense Potion I to blueprints
- grant blueprint from Eryndor dialogue
- update recipe system to no longer auto-unlock from memory flag
- refresh crafting UI when recipes unlock

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a11fc2500833187a766e1c95cef2f