### PR TITLE
Switch Eryndor blueprint to goblin gear

### DIFF
--- a/data/blueprints.json
+++ b/data/blueprints.json
@@ -16,7 +16,7 @@
   "defense_potion_I": {
     "id": "defense_potion_I",
     "name": "Defense Potion I",
-    "ingredients": { "bone_fragment": 1, "armor_piece": 1 },
+    "ingredients": { "bone_fragment": 1, "goblin_gear": 1 },
     "result": "defense_potion_I",
     "quantity": 1
   }

--- a/data/recipes.json
+++ b/data/recipes.json
@@ -16,7 +16,7 @@
   "defense_potion_I": {
     "id": "defense_potion_I",
     "name": "Defense Potion I",
-    "ingredients": { "bone_fragment": 1, "armor_piece": 1 },
+    "ingredients": { "bone_fragment": 1, "goblin_gear": 1 },
     "result": "defense_potion_I",
     "quantity": 1,
     "type": "combat",

--- a/scripts/npc_dialogues/eryndor_dialogue.js
+++ b/scripts/npc_dialogues/eryndor_dialogue.js
@@ -13,7 +13,7 @@ export const eryndorDialogue = [
     ]
   },
   {
-    text: "Combine a bone fragment with a broken armor piece. You\u2019ll find resilience in that.",
+    text: "Combine a bone fragment with some goblin gear. You\u2019ll find resilience in that.",
     options: [
       {
         label: "Got it. Thanks.",


### PR DESCRIPTION
## Summary
- use `goblin_gear` instead of `armor_piece` for the Defense Potion I blueprint
- update the corresponding recipe
- adjust Eryndor's dialogue to mention goblin gear

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684a16a44ec08331a25dc35a177a9f4d