### PR TITLE
Fix crafting item consumption and add toast notifications

### DIFF
--- a/scripts/craft.js
+++ b/scripts/craft.js
@@ -15,7 +15,7 @@ import { getItemBonuses } from './item_stats.js';
 import { isRecipeUnlocked } from './recipe_state.js';
 import { loadJson } from './dataService.js';
 import { showError } from './errorPrompt.js';
-import { showDialogue } from './dialogueSystem.js';
+import { notify } from '../ui/notification.js';
 
 let craftingAllowed = false;
 
@@ -84,7 +84,7 @@ export async function craft(id) {
   if (blueprints[id] && !isBlueprintUnlocked(id)) return false;
   if (recipes[id] && !isRecipeUnlocked(id)) return false;
   if (!canCraft(id)) {
-    showDialogue('Missing materials.');
+    notify('Missing materials.');
     return false;
   }
   for (const [item, qty] of Object.entries(recipe.ingredients)) {
@@ -103,7 +103,7 @@ export async function craft(id) {
         new CustomEvent('equipmentCrafted', { detail: recipe.result })
       );
     }
-    showDialogue(`You've crafted ${data.name}!`);
+    notify(`Crafted ${data.name}!`);
     return true;
   }
   return false;

--- a/scripts/craft_ui.js
+++ b/scripts/craft_ui.js
@@ -28,11 +28,14 @@ export async function updateCraftUI() {
     if (!data) return;
     const row = document.createElement('div');
     row.classList.add('craft-item');
+    row.dataset.recipeId = id;
     const btn = document.createElement('button');
     btn.textContent = 'Craft';
+    btn.dataset.recipeId = id;
     btn.disabled = !canCraft(id);
-    btn.addEventListener('click', async () => {
-      const ok = await craft(id);
+    btn.addEventListener('click', async (e) => {
+      const rid = e.currentTarget.dataset.recipeId;
+      const ok = await craft(rid);
       if (ok) updateCraftUI();
     });
     const reqs = Object.entries(data.ingredients)

--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -42,5 +42,21 @@ export const inventoryState = {
   },
   removeItem(id, qty = 1) {
     return invRemoveItem(id, qty);
+  },
+  addItems(map) {
+    if (!map) return false;
+    let changed = false;
+    Object.entries(map).forEach(([id, qty]) => {
+      if (invAddItem({ id, quantity: qty })) changed = true;
+    });
+    return changed;
+  },
+  removeItems(map) {
+    if (!map) return false;
+    let changed = false;
+    Object.entries(map).forEach(([id, qty]) => {
+      if (invRemoveItem(id, qty)) changed = true;
+    });
+    return changed;
   }
 };

--- a/ui/notification.js
+++ b/ui/notification.js
@@ -1,0 +1,15 @@
+export function notify(text) {
+  if (!text) return;
+  let container = document.getElementById('message-log');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'message-log';
+    document.body.appendChild(container);
+  }
+  const entry = document.createElement('div');
+  entry.textContent = text;
+  container.appendChild(entry);
+  container.scrollTop = container.scrollHeight;
+  setTimeout(() => entry.remove(), 2000);
+}
+


### PR DESCRIPTION
## Summary
- add bulk addItems/removeItems utilities
- notify player when crafting fails or succeeds
- wire up craft button dataset ids
- simple notification UI helper

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684a1c32e13c8331aa3f2b0cbbeac381