### PR TITLE
Implement blueprint unlocking via dialogue

### DIFF
--- a/data/recipes.json
+++ b/data/recipes.json
@@ -2,6 +2,7 @@
   "healing_salve": {
     "id": "healing_salve",
     "name": "Healing Salve",
+    "blueprintId": "healing_salve_blueprint",
     "ingredients": { "goblin_ear": 1, "rotten_tooth": 1 },
     "result": "health_potion",
     "quantity": 1
@@ -9,6 +10,7 @@
   "health_amulet": {
     "id": "health_amulet",
     "name": "Health Amulet",
+    "blueprintId": "health_amulet_blueprint",
     "ingredients": { "health_potion": 2 },
     "result": "health_amulet",
     "quantity": 1
@@ -16,6 +18,7 @@
   "defense_potion_I": {
     "id": "defense_potion_I",
     "name": "Defense Potion I",
+    "blueprintId": "defense_potion_I_blueprint",
     "ingredients": { "bone_fragment": 1, "goblin_gear": 1 },
     "result": "defense_potion_I",
     "quantity": 1,

--- a/scripts/craft.js
+++ b/scripts/craft.js
@@ -67,8 +67,11 @@ export function getRecipe(id) {
 }
 
 export function canCraft(id) {
-  const recipe = recipes[id] || blueprints[id];
+  const recipe = recipes[id];
   if (!recipe) return false;
+  if (recipe.blueprintId && !isBlueprintUnlocked(recipe.blueprintId))
+    return false;
+  if (!isRecipeUnlocked(id)) return false;
   return Object.entries(recipe.ingredients).every(
     ([item, qty]) => getItemCount(item) >= qty
   );
@@ -79,10 +82,11 @@ export async function craft(id) {
   await loadBlueprints();
   await loadItems();
   if (!craftingAllowed) return false;
-  const recipe = recipes[id] || blueprints[id];
+  const recipe = recipes[id];
   if (!recipe) return false;
-  if (blueprints[id] && !isBlueprintUnlocked(id)) return false;
-  if (recipes[id] && !isRecipeUnlocked(id)) return false;
+  if (recipe.blueprintId && !isBlueprintUnlocked(recipe.blueprintId))
+    return false;
+  if (!isRecipeUnlocked(id)) return false;
   if (!canCraft(id)) {
     notify('Missing materials.');
     return false;

--- a/scripts/craft_state.js
+++ b/scripts/craft_state.js
@@ -32,6 +32,9 @@ function saveUnlockedBlueprints(list) {
 }
 
 craftState.unlockedBlueprints = new Set(loadUnlockedBlueprints());
+if (!craftState.unlockedBlueprints.size) {
+  craftState.unlockedBlueprints.add('healing_salve_blueprint');
+}
 document.dispatchEvent(new CustomEvent('blueprintsLoaded'));
 craftState.fusionUnlocked = readFusionState();
 

--- a/scripts/craft_ui.js
+++ b/scripts/craft_ui.js
@@ -17,12 +17,13 @@ export async function updateCraftUI() {
   await loadRecipes();
   await loadBlueprints();
   list.innerHTML = '';
-  const ids = [
-    ...Object.keys(await loadRecipes()).filter((id) => isRecipeUnlocked(id)),
-    ...Object.keys(await loadBlueprints()).filter((id) =>
-      isBlueprintUnlocked(id)
-    )
-  ];
+  const recipeData = await loadRecipes();
+  const ids = Object.keys(recipeData).filter((id) => {
+    const rec = recipeData[id];
+    const blueprintOk =
+      !rec.blueprintId || isBlueprintUnlocked(rec.blueprintId);
+    return isRecipeUnlocked(id) && blueprintOk;
+  });
   ids.forEach((id) => {
     const data = getRecipe(id) || getBlueprint(id);
     if (!data) return;

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -93,7 +93,8 @@ export function addItem(item) {
     quantity: Math.min(qty, limit)
   });
   if (item.id && item.id.startsWith('blueprint_')) {
-    unlockBlueprint(item.id.replace('blueprint_', ''));
+    const base = item.id.replace('blueprint_', '');
+    unlockBlueprint(`${base}_blueprint`);
   }
   discover('items', parseItemId(item.id).baseId);
   document.dispatchEvent(new CustomEvent('inventoryUpdated'));
@@ -189,7 +190,6 @@ export function getItemsByType(type) {
     );
   });
 }
-
 
 export function removePrismFragments(qty = 10) {
   return removeItem('prism_fragment', qty);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -37,6 +37,7 @@ import {
   refreshInventoryDisplay,
   initInventoryMenu
 } from '../ui/inventory_menu.js';
+import '../ui/system_message.js';
 import {
   initSaveSlotsMenu,
   openSaveMenu,
@@ -271,7 +272,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     updateNullTab();
   }
   document.addEventListener('inventoryUpdated', updateNullTab);
-
 
   function showSettings() {
     settingsOverlay.classList.add('active');

--- a/scripts/npc_dialogue.js
+++ b/scripts/npc_dialogue.js
@@ -2,7 +2,11 @@ export const testNpcDialogue = [
   {
     text: 'Hello adventurer, I have a special blueprint for you.',
     options: [
-      { label: 'Thanks!', goto: null, giveBlueprint: 'cracked_helmet' }
+      {
+        label: 'Thanks!',
+        goto: null,
+        giveBlueprint: 'cracked_helmet_blueprint'
+      }
     ]
   }
 ];

--- a/scripts/npc_dialogues/eryndor_dialogue.js
+++ b/scripts/npc_dialogues/eryndor_dialogue.js
@@ -1,25 +1,23 @@
 export const eryndorDialogue = [
   {
-    text: "These lands are littered with fragments of what once was.",
+    text: 'These lands are littered with fragments of what once was.',
+    options: [{ label: 'What can I do with them?', goto: 1 }]
+  },
+  {
+    text: 'Some bones remember purpose. Some scraps still shield.',
     options: [
-      { label: "What can I do with them?", goto: 1 }
+      { label: 'That sounds useful.', goto: 2 },
+      { label: 'I prefer smashing things.', goto: null }
     ]
   },
   {
-    text: "Some bones remember purpose. Some scraps still shield.",
-    options: [
-      { label: "That sounds useful.", goto: 2 },
-      { label: "I prefer smashing things.", goto: null }
-    ]
-  },
-  {
-    text: "Combine a bone fragment with some goblin gear. You\u2019ll find resilience in that.",
+    text: 'Combine a bone fragment with some goblin gear. You\u2019ll find resilience in that.',
     options: [
       {
-        label: "Got it. Thanks.",
+        label: 'Got it. Thanks.',
         goto: null,
-        memoryFlag: "learned_defense_potion_I",
-        giveBlueprint: "defense_potion_I"
+        memoryFlag: 'learned_defense_potion_I',
+        giveBlueprint: 'defense_potion_I_blueprint'
       }
     ]
   }

--- a/scripts/save_load.js
+++ b/scripts/save_load.js
@@ -12,6 +12,7 @@ import { refreshInventoryDisplay } from '../ui/inventory_menu.js';
 
 import { gameState } from './game_state.js';
 import { inventory } from './inventory.js';
+import { craftState } from './craft_state.js';
 
 export function saveGame(slot = 1) {
   const data = {
@@ -21,7 +22,8 @@ export function saveGame(slot = 1) {
     game: serializeGameState(),
     inventory: serializeInventory(),
     quests: serializeQuestState(),
-    player: serializePlayer()
+    player: serializePlayer(),
+    blueprints: Array.from(craftState.unlockedBlueprints)
   };
   const key = `${STORAGE_PREFIX}${slot}`;
   localStorage.setItem(key, JSON.stringify(data));
@@ -44,6 +46,10 @@ export function loadGame(slot = 1) {
     validateLoadedInventory(data.inventory?.items || []);
     deserializeQuestState(data.quests || {});
     deserializePlayer(data.player || {});
+    if (Array.isArray(data.blueprints)) {
+      craftState.unlockedBlueprints = new Set(data.blueprints);
+      document.dispatchEvent(new CustomEvent('blueprintsLoaded'));
+    }
     return true;
   } catch (err) {
     console.error('Failed to load save', err);

--- a/style/main.css
+++ b/style/main.css
@@ -794,7 +794,6 @@ body {
   font-weight: bold;
 }
 
-
 /* Quest Log UI */
 .quest-overlay {
   position: fixed;
@@ -1604,4 +1603,25 @@ body {
     margin-top: 4px;
     flex-direction: column;
   }
+}
+
+/* System message banner */
+#system-message {
+  position: fixed;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 4px;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease;
+  z-index: 1300;
+}
+
+#system-message.active {
+  opacity: 1;
+  visibility: visible;
 }

--- a/ui/system_message.js
+++ b/ui/system_message.js
@@ -1,0 +1,18 @@
+export function showSystemMessage(text, duration = 2000) {
+  if (!text) return;
+  let box = document.getElementById('system-message');
+  if (!box) {
+    box = document.createElement('div');
+    box.id = 'system-message';
+    document.body.appendChild(box);
+  }
+  box.textContent = text;
+  box.classList.add('active');
+  setTimeout(() => {
+    box.classList.remove('active');
+  }, duration);
+}
+
+document.addEventListener('blueprintUnlocked', () => {
+  showSystemMessage('🧪 New crafting blueprint unlocked!');
+});


### PR DESCRIPTION
## Summary
- add `blueprintId` metadata to all recipes
- filter crafting list by unlocked blueprints
- persist unlocked blueprints in save files
- show a banner when a blueprint is unlocked
- add initial healing salve blueprint for new games

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a23a7101083319ad7491664779776