### PR TITLE
Improve crafting menu UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
     />
     <link rel="stylesheet" href="style/main.css" />
-    <link rel="stylesheet" href="style/craft_menu.css" />
+    <link rel="stylesheet" href="style/crafting.css" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
   </head>
   <body>
@@ -63,7 +63,7 @@
       <div class="craft-content">
         <button class="close-btn">&times;</button>
         <h2>Crafting</h2>
-        <div id="craft-list"></div>
+        <div id="craft-list" class="recipe-list"></div>
       </div>
     </div>
     <div id="quest-log-overlay" class="quest-overlay">

--- a/scripts/craft_state.js
+++ b/scripts/craft_state.js
@@ -52,6 +52,10 @@ export function isBlueprintUnlocked(id) {
   return craftState.unlockedBlueprints.has(id);
 }
 
+export function getUnlockedBlueprints() {
+  return Array.from(craftState.unlockedBlueprints);
+}
+
 export function unlockFusion() {
   if (!craftState.fusionUnlocked) {
     craftState.fusionUnlocked = true;

--- a/scripts/craft_ui.js
+++ b/scripts/craft_ui.js
@@ -31,9 +31,22 @@ export async function updateCraftUI() {
   ids.forEach((id) => {
     const data = getRecipe(id) || getBlueprint(id);
     if (!data) return;
-    const row = document.createElement('div');
-    row.classList.add('craft-item');
-    row.dataset.recipeId = id;
+    const card = document.createElement('div');
+    card.classList.add('recipe-card');
+    card.dataset.recipeId = id;
+    const reqs = Object.entries(data.ingredients)
+      .map(([itm, qty]) => {
+        const base = getItemData(itm) || { name: itm };
+        const have = getItemCount(itm);
+        const cls = have >= qty ? 'have' : 'missing';
+        return `<span class="req ${cls}">${base.name} x${qty}</span>`;
+      })
+      .join(' + ');
+    const resultName = getItemData(data.result)?.name || data.result;
+    card.innerHTML = `
+      <strong>${data.name}</strong>
+      <div class="ingredients">${reqs}</div>
+      <div class="result">&rarr; ${resultName}</div>`;
     const btn = document.createElement('button');
     btn.textContent = 'Craft';
     btn.dataset.recipeId = id;
@@ -43,20 +56,14 @@ export async function updateCraftUI() {
       const ok = await craft(rid);
       if (ok) updateCraftUI();
     });
-    const reqs = Object.entries(data.ingredients)
-      .map(([itm, qty]) => {
-        const base = getItemData(itm) || { name: itm };
-        const have = getItemCount(itm);
-        const cls = have >= qty ? 'have' : 'missing';
-        return `<span class="req ${cls}">${base.name} x${qty}</span>`;
-      })
-      .join(', ');
-    row.innerHTML = `<strong>${data.name}</strong><div class="desc">${reqs}</div>`;
-    row.appendChild(btn);
-    list.appendChild(row);
+    card.appendChild(btn);
+    list.appendChild(card);
   });
   if (ids.length === 0) {
-    list.innerHTML = '<em>No known recipes</em>';
+    const msg = document.createElement('div');
+    msg.classList.add('info-empty');
+    msg.textContent = "You don't know any crafting recipes yet.";
+    list.appendChild(msg);
   }
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2,7 +2,7 @@ import { getCurrentGrid, isFogEnabled } from './mapLoader.js';
 import { onStepEffect, isWalkable } from './tile_type.js';
 import { toggleInventoryView, initInventoryUI } from './inventory_ui.js';
 import { toggleQuestLog } from './quest_log.js';
-import { toggleCraftMenu, initCraftMenu } from '../ui/craft_menu.js';
+import { toggleCraftMenu, initCraftMenu } from '../ui/crafting_menu_new.js';
 import { player, stepTo, updateStatsFromLevel } from './player.js';
 import { initFog, reveal, revealAll } from './fog_system.js';
 import { loadEnemyData, defeatEnemy } from './enemy.js';

--- a/style/crafting.css
+++ b/style/crafting.css
@@ -1,0 +1,79 @@
+.craft-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 900;
+}
+
+.craft-overlay.active {
+  visibility: visible;
+  opacity: 1;
+}
+
+.craft-content {
+  background: #fff;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  width: 320px;
+  max-width: 90%;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+}
+
+.recipe-list {
+  overflow-y: auto;
+  margin-top: 10px;
+  flex: 1;
+}
+
+.recipe-card {
+  border-bottom: 1px solid #ddd;
+  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.recipe-card:last-child {
+  border-bottom: none;
+}
+
+.recipe-card .ingredients {
+  font-size: 13px;
+  color: #555;
+}
+
+.recipe-card .result {
+  font-size: 13px;
+  color: #333;
+  margin: 4px 0;
+}
+
+.req.missing {
+  color: #c0392b;
+}
+
+.req.have {
+  color: #27ae60;
+}
+
+@media (max-width: 480px) {
+  .craft-content {
+    width: 100%;
+    max-width: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
+}

--- a/ui/crafting_menu_new.js
+++ b/ui/crafting_menu_new.js
@@ -1,0 +1,27 @@
+import { updateCraftUI } from '../scripts/craft_ui.js';
+import { beginCraftingSession, endCraftingSession } from '../scripts/craft.js';
+
+export function toggleCraftMenu() {
+  const overlay = document.getElementById('craft-overlay');
+  const grid = document.getElementById('game-grid');
+  if (!overlay || !grid) return;
+  if (overlay.classList.contains('active')) {
+    overlay.classList.remove('active');
+    grid.classList.remove('blurred', 'no-interact');
+    endCraftingSession();
+  } else {
+    updateCraftUI();
+    overlay.classList.add('active');
+    grid.classList.add('blurred', 'no-interact');
+    beginCraftingSession();
+  }
+}
+
+export function initCraftMenu() {
+  const overlay = document.getElementById('craft-overlay');
+  const closeBtn = overlay?.querySelector('.close-btn');
+  closeBtn?.addEventListener('click', toggleCraftMenu);
+  overlay?.addEventListener('click', (e) => {
+    if (e.target === overlay) toggleCraftMenu();
+  });
+}


### PR DESCRIPTION
## Summary
- add responsive crafting menu styles
- show recipe cards with ingredients and craft button
- load crafting menu with new UI module
- expose unlocked blueprint list
- link new stylesheet in HTML

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2af13d5483319d934e344e6db890