### PR TITLE
Fix prism fragment inventory visibility

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -442,6 +442,14 @@
     "icon": "🎵",
     "category": "general"
   },
+  "prism_fragment": {
+    "name": "Prism Fragment",
+    "description": "A shimmering piece of condensed prism memory.",
+    "type": "material",
+    "stackLimit": 99,
+    "icon": "🔶",
+    "category": "crafting"
+  },
   "maze_key_1": {
     "name": "Maze Key 1",
     "description": "A key used deep in the maze system.",

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -177,6 +177,9 @@ export function getItemsByCategory(category) {
     const data = getItemData(it.id);
     if (!data) return false;
     const cat = data.category || 'general';
+    if (Array.isArray(category)) {
+      return category.includes(cat);
+    }
     return cat === category;
   });
 }

--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -79,7 +79,7 @@ export async function updateInventoryUI() {
     statsEl.textContent = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}  Attack: ${stats.attack || 0}  Defense: ${stats.defense || 0}`;
   }
   let cat = currentCategory;
-  if (cat === 'items') cat = 'general';
+  if (cat === 'items') cat = ['general', 'crafting'];
   const filtered = getItemsByCategory(cat);
   if (filtered.length === 0) {
     const msg = document.createElement('div');


### PR DESCRIPTION
## Summary
- define `prism_fragment` in `items.json`
- allow `getItemsByCategory` to accept arrays
- include `crafting` items when viewing the Inventory's Items tab

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2dc57a288331a3dcccbf81f362e7