### PR TITLE
Fix craft menu exit and test blueprint persistence

### DIFF
--- a/__tests__/blueprintPersistence.test.js
+++ b/__tests__/blueprintPersistence.test.js
@@ -1,0 +1,27 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let giveBlueprint, craftState, saveGame, loadGame;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ giveBlueprint } = await import('../scripts/dialogue_state.js'));
+  ({ craftState } = await import('../scripts/craft_state.js'));
+  ({ saveGame, loadGame } = await import('../scripts/save_load.js'));
+  craftState.unlockedBlueprints = new Set(['healing_salve_blueprint']);
+  localStorage.clear();
+});
+
+test('unlocked blueprint persists through save/load', () => {
+  giveBlueprint('defense_potion_I_blueprint');
+  expect(craftState.unlockedBlueprints.has('defense_potion_I_blueprint')).toBe(true);
+
+  saveGame(1);
+
+  craftState.unlockedBlueprints.delete('defense_potion_I_blueprint');
+  expect(craftState.unlockedBlueprints.has('defense_potion_I_blueprint')).toBe(false);
+
+  const loaded = loadGame(1);
+  expect(loaded).toBe(true);
+  expect(craftState.unlockedBlueprints.has('defense_potion_I_blueprint')).toBe(true);
+});

--- a/__tests__/craftMenuFilter.test.js
+++ b/__tests__/craftMenuFilter.test.js
@@ -1,0 +1,66 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+const recipeData = {
+  healing_salve: {
+    id: 'healing_salve',
+    name: 'Healing Salve',
+    blueprintId: 'healing_salve_blueprint',
+    ingredients: {}
+  },
+  defense_potion_I: {
+    id: 'defense_potion_I',
+    name: 'Defense Potion I',
+    blueprintId: 'defense_potion_I_blueprint',
+    ingredients: {}
+  }
+};
+
+let getKnownRecipes, unlockedRecipes, unlockedBlueprints;
+
+beforeEach(async () => {
+  jest.resetModules();
+  unlockedRecipes = new Set(['healing_salve']);
+  unlockedBlueprints = new Set(['healing_salve_blueprint']);
+
+  jest.unstable_mockModule('../scripts/craft.js', () => ({
+    loadRecipes: jest.fn(async () => recipeData),
+    loadBlueprints: jest.fn(async () => ({})),
+    getRecipe: jest.fn((id) => recipeData[id]),
+    getBlueprint: jest.fn(() => null),
+    canCraft: jest.fn(() => true),
+    craft: jest.fn()
+  }));
+
+  jest.unstable_mockModule('../scripts/item_loader.js', () => ({
+    getItemData: jest.fn(() => ({}))
+  }));
+
+  jest.unstable_mockModule('../scripts/inventory.js', () => ({
+    getItemCount: jest.fn(() => 0)
+  }));
+
+  jest.unstable_mockModule('../scripts/recipe_state.js', () => ({
+    isRecipeUnlocked: jest.fn((id) => unlockedRecipes.has(id))
+  }));
+
+  jest.unstable_mockModule('../scripts/craft_state.js', () => ({
+    isBlueprintUnlocked: jest.fn((id) => unlockedBlueprints.has(id))
+  }));
+
+  ({ getKnownRecipes } = await import('../scripts/craft_ui.js'));
+});
+
+test('filters recipes based on unlocked lists', async () => {
+  let ids = await getKnownRecipes();
+  expect(ids).toEqual(['healing_salve']);
+
+  unlockedRecipes.add('defense_potion_I');
+  unlockedBlueprints.add('defense_potion_I_blueprint');
+  ids = await getKnownRecipes();
+  expect(ids).toEqual(expect.arrayContaining(['healing_salve', 'defense_potion_I']));
+
+  unlockedBlueprints.delete('defense_potion_I_blueprint');
+  ids = await getKnownRecipes();
+  expect(ids).not.toContain('defense_potion_I');
+});

--- a/style/crafting.css
+++ b/style/crafting.css
@@ -25,12 +25,12 @@
   padding: 20px;
   border-radius: 8px;
   width: 320px;
-  max-width: 90%;
+  max-width: 90vw;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
   position: relative;
   display: flex;
   flex-direction: column;
-  max-height: 90vh;
+  max-height: 80vh;
 }
 
 .recipe-list {

--- a/ui/craft_menu.js
+++ b/ui/craft_menu.js
@@ -24,4 +24,9 @@ export function initCraftMenu() {
   overlay?.addEventListener('click', (e) => {
     if (e.target === overlay) toggleCraftMenu();
   });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && overlay?.classList.contains('active')) {
+      toggleCraftMenu();
+    }
+  });
 }

--- a/ui/crafting_menu_new.js
+++ b/ui/crafting_menu_new.js
@@ -24,4 +24,9 @@ export function initCraftMenu() {
   overlay?.addEventListener('click', (e) => {
     if (e.target === overlay) toggleCraftMenu();
   });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && overlay?.classList.contains('active')) {
+      toggleCraftMenu();
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- constrain the crafting modal to 80vh/90vw
- add Escape key support for closing the craft menu
- verify blueprint persistence across save/load
- ensure crafting menu filters recipes by unlocked blueprints

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a3062ce148331b6b17ffda8e88376