### PR TITLE
Conditional blueprint unlock for Eryndor

### DIFF
--- a/scripts/npc/eryndor.js
+++ b/scripts/npc/eryndor.js
@@ -1,8 +1,9 @@
 import { startDialogueTree, showDialogue } from '../dialogueSystem.js';
-import { eryndorDialogue } from '../npc_dialogues/eryndor_dialogue.js';
+import { createEryndorDialogue } from '../npc_dialogues/eryndor_dialogue.js';
 import { npcAppearance } from '../npc_data.js';
 
-export function interact() {
+export async function interact() {
   const title = npcAppearance.eryndor.displayTitle || 'Eryndor';
-  showDialogue(title, () => startDialogueTree(eryndorDialogue));
+  const dialogue = await createEryndorDialogue();
+  showDialogue(title, () => startDialogueTree(dialogue));
 }

--- a/scripts/npc_dialogues/eryndor_dialogue.js
+++ b/scripts/npc_dialogues/eryndor_dialogue.js
@@ -1,24 +1,38 @@
-export const eryndorDialogue = [
-  {
-    text: 'These lands are littered with fragments of what once was.',
-    options: [{ label: 'What can I do with them?', goto: 1 }]
-  },
-  {
-    text: 'Some bones remember purpose. Some scraps still shield.',
-    options: [
-      { label: 'That sounds useful.', goto: 2 },
-      { label: 'I prefer smashing things.', goto: null }
-    ]
-  },
-  {
-    text: 'Combine a bone fragment with some goblin gear. You\u2019ll find resilience in that.',
-    options: [
+import { isBlueprintUnlocked } from '../craft_state.js';
+
+export async function createEryndorDialogue() {
+  const hasBlueprint = isBlueprintUnlocked('defense_potion_I_blueprint');
+  if (!hasBlueprint) {
+    return [
       {
-        label: 'Got it. Thanks.',
-        goto: null,
-        memoryFlag: 'learned_defense_potion_I',
-        giveBlueprint: 'defense_potion_I_blueprint'
+        text: 'These lands are littered with fragments of what once was.',
+        options: [{ label: 'What can I do with them?', goto: 1 }]
+      },
+      {
+        text: 'Some bones remember purpose. Some scraps still shield.',
+        options: [
+          { label: 'That sounds useful.', goto: 2 },
+          { label: 'I prefer smashing things.', goto: null }
+        ]
+      },
+      {
+        text:
+          'Combine a bone fragment with some goblin gear. You\u2019ll find resilience in that.',
+        options: [
+          {
+            label: 'Got it. Thanks.',
+            goto: null,
+            memoryFlag: 'learned_defense_blueprint',
+            giveBlueprint: 'defense_potion_I_blueprint'
+          }
+        ]
       }
-    ]
+    ];
   }
-];
+  return [
+    {
+      text: "You've already mastered what I had to share. Go craft your strength.",
+      options: [{ label: 'Thanks again.', goto: null }]
+    }
+  ];
+}

--- a/scripts/save_load.js
+++ b/scripts/save_load.js
@@ -48,6 +48,10 @@ export function loadGame(slot = 1) {
     deserializePlayer(data.player || {});
     if (Array.isArray(data.blueprints)) {
       craftState.unlockedBlueprints = new Set(data.blueprints);
+      localStorage.setItem(
+        'gridquest.blueprints',
+        JSON.stringify(data.blueprints)
+      );
       document.dispatchEvent(new CustomEvent('blueprintsLoaded'));
     }
     return true;

--- a/scripts/save_system.js
+++ b/scripts/save_system.js
@@ -16,6 +16,10 @@ export function loadGame() {
     const data = JSON.parse(json);
     if (Array.isArray(data.blueprints)) {
       craftState.unlockedBlueprints = new Set(data.blueprints);
+      localStorage.setItem(
+        'gridquest.blueprints',
+        JSON.stringify(data.blueprints)
+      );
       document.dispatchEvent(new CustomEvent('blueprintsLoaded'));
     }
   } catch {


### PR DESCRIPTION
## Summary
- teach the defense potion recipe through a new `createEryndorDialogue` function
- call the dynamic dialogue in the Eryndor NPC
- persist blueprint unlocks when loading game saves

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aad3ffb0c83318ac722554014fd55