### PR TITLE
Add Blueprints inventory view

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
           <button data-cat="combat" class="tab">Combat Items</button>
           <button data-cat="key" class="tab">Key Items</button>
           <button data-cat="lore" class="tab">Lore Items</button>
+          <button data-cat="blueprints" class="tab">Blueprints</button>
         </div>
         <div class="inventory-panel">
           <div class="inventory-scroll">

--- a/scripts/inventory_state.js
+++ b/scripts/inventory_state.js
@@ -1,5 +1,11 @@
-import { inventory, addItem as invAddItem, removeItem as invRemoveItem } from './inventory.js';
+import {
+  inventory,
+  addItem as invAddItem,
+  removeItem as invRemoveItem
+} from './inventory.js';
 import { player, reapplyEquipmentBonuses } from './player.js';
+import { getUnlockedBlueprints } from './craft_state.js';
+import { loadRecipes } from './craft.js';
 
 export function serializeInventory() {
   return {
@@ -60,3 +66,11 @@ export const inventoryState = {
     return changed;
   }
 };
+
+export async function getBlueprints() {
+  const recipeData = await loadRecipes();
+  const ids = getUnlockedBlueprints();
+  return ids
+    .map((bid) => Object.values(recipeData).find((r) => r.blueprintId === bid))
+    .filter(Boolean);
+}


### PR DESCRIPTION
## Summary
- show unlocked blueprints in their own inventory tab
- support retrieving unlocked blueprints from craft state and recipes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab0c26744833191db0fa873fd67ca