### PR TITLE
Add restart functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
           <div class="tab quests-tab">Quest</div>
           <div class="tab status-tab">Status Panel</div>
           <div class="tab null-tab">The Null Factor</div>
+          <div class="tab restart-tab">Restart</div>
         </div>
         <div id="menu-stats"></div>
       </div>
@@ -188,8 +189,8 @@
       <div class="confirm-content">
         <div id="confirm-message"></div>
         <div class="confirm-actions">
-          <button class="confirm-yes">Confirm</button>
           <button class="confirm-cancel">Cancel</button>
+          <button class="confirm-yes">Confirm</button>
         </div>
       </div>
     </div>

--- a/scripts/confirmPrompt.js
+++ b/scripts/confirmPrompt.js
@@ -1,4 +1,10 @@
-export function showConfirm(message, onConfirm, onCancel) {
+export function showConfirm(
+  message,
+  onConfirm,
+  onCancel,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel'
+) {
   const overlay = document.getElementById('confirm-overlay');
   if (!overlay) {
     if (confirm(message)) {
@@ -12,6 +18,8 @@ export function showConfirm(message, onConfirm, onCancel) {
   const yesBtn = overlay.querySelector('.confirm-yes');
   const cancelBtn = overlay.querySelector('.confirm-cancel');
   msgEl.textContent = message;
+  yesBtn.textContent = confirmText;
+  cancelBtn.textContent = cancelText;
   overlay.classList.add('active');
   function cleanup() {
     overlay.classList.remove('active');

--- a/scripts/restart.js
+++ b/scripts/restart.js
@@ -1,0 +1,33 @@
+export function restartGame() {
+  const keys = [
+    'gridquest.state',
+    'gridquest.memory',
+    'gridquest.finalFlags',
+    'gridquest.relics',
+    'gridquest.equipped_relics',
+    'gridquest.player_state',
+    'gridquest.blueprints',
+    'gridquest.fusion',
+    'gridquest.ending',
+    'gridquest.lore_flags',
+    'gridquest.class',
+    'gridquest.passives',
+    'gridquest.enemySkillSources',
+    'gridquest.skills',
+    'gridquest.save'
+  ];
+  keys.forEach((k) => localStorage.removeItem(k));
+  window.location.reload();
+}
+
+import { showConfirm } from './confirmPrompt.js';
+
+export function confirmRestart() {
+  showConfirm(
+    'Are you sure you want to restart your journey? This will erase all progress, items, and unlocks.',
+    restartGame,
+    null,
+    'Restart',
+    'Cancel'
+  );
+}

--- a/ui/main_menu.js
+++ b/ui/main_menu.js
@@ -4,6 +4,7 @@ import { toggleQuestLog } from '../scripts/quest_log.js';
 import { toggleInfoMenu } from './info_menu.js';
 import { toggleStatusPanel } from '../scripts/menu/status.js';
 import { toggleNullSummary } from './null_summary.js';
+import { confirmRestart } from '../scripts/restart.js';
 
 export function updateMenuStats() {
   const el = document.getElementById('menu-stats');
@@ -76,6 +77,12 @@ export function initMainMenu() {
     ?.addEventListener('click', () => {
       toggleMainMenu();
       toggleNullSummary();
+    });
+  document
+    .querySelector('#menu-overlay .restart-tab')
+    ?.addEventListener('click', () => {
+      toggleMainMenu();
+      confirmRestart();
     });
 
   document.addEventListener('inventoryUpdated', updateNullButton);


### PR DESCRIPTION
## Summary
- add restart button to main menu
- confirm restart with customizable prompt
- restart clears progress-related storage and reloads

## Testing
- `npm test` *(fails: jest not found)*
- `npx eslint .` *(fails: cannot find package @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684ab7b375a0833189fca7c15c23f2cc