### PR TITLE
Fix syntax error in mapLoader.js

### DIFF
--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -96,7 +96,6 @@ export async function loadMap(name) {
           }
         }
       }
-    }
   } catch (err) {
     console.error(err);
     showError(err.message || `Failed to load map ${name}`);


### PR DESCRIPTION
## Summary
- fix unmatched closing brace in mapLoader.js

## Testing
- `node -c scripts/mapLoader.js`
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ac81ff6688331bbd51950f813a2fb