### PR TITLE
Fix blueprint unlock logic and remove healing salve

### DIFF
--- a/__tests__/blueprintPersistence.test.js
+++ b/__tests__/blueprintPersistence.test.js
@@ -8,7 +8,7 @@ beforeEach(async () => {
   ({ giveBlueprint } = await import('../scripts/dialogue_state.js'));
   ({ craftState } = await import('../scripts/craft_state.js'));
   ({ saveGame, loadGame } = await import('../scripts/save_load.js'));
-  craftState.unlockedBlueprints = new Set(['healing_salve_blueprint']);
+  craftState.unlockedBlueprints = new Set();
   localStorage.clear();
 });
 

--- a/__tests__/craftMenuFilter.test.js
+++ b/__tests__/craftMenuFilter.test.js
@@ -2,10 +2,10 @@
 import { jest } from '@jest/globals';
 
 const recipeData = {
-  healing_salve: {
-    id: 'healing_salve',
-    name: 'Healing Salve',
-    blueprintId: 'healing_salve_blueprint',
+  health_amulet: {
+    id: 'health_amulet',
+    name: 'Health Amulet',
+    blueprintId: 'health_amulet_blueprint',
     ingredients: {}
   },
   defense_potion_I: {
@@ -20,8 +20,8 @@ let getKnownRecipes, unlockedRecipes, unlockedBlueprints;
 
 beforeEach(async () => {
   jest.resetModules();
-  unlockedRecipes = new Set(['healing_salve']);
-  unlockedBlueprints = new Set(['healing_salve_blueprint']);
+  unlockedRecipes = new Set();
+  unlockedBlueprints = new Set();
 
   jest.unstable_mockModule('../scripts/craft.js', () => ({
     loadRecipes: jest.fn(async () => recipeData),
@@ -53,12 +53,17 @@ beforeEach(async () => {
 
 test('filters recipes based on unlocked lists', async () => {
   let ids = await getKnownRecipes();
-  expect(ids).toEqual(['healing_salve']);
+  expect(ids).toEqual([]);
 
   unlockedRecipes.add('defense_potion_I');
   unlockedBlueprints.add('defense_potion_I_blueprint');
   ids = await getKnownRecipes();
-  expect(ids).toEqual(expect.arrayContaining(['healing_salve', 'defense_potion_I']));
+  expect(ids).toEqual(['defense_potion_I']);
+
+  unlockedRecipes.add('health_amulet');
+  unlockedBlueprints.add('health_amulet_blueprint');
+  ids = await getKnownRecipes();
+  expect(ids).toEqual(expect.arrayContaining(['defense_potion_I', 'health_amulet']));
 
   unlockedBlueprints.delete('defense_potion_I_blueprint');
   ids = await getKnownRecipes();

--- a/data/recipes.json
+++ b/data/recipes.json
@@ -1,12 +1,4 @@
 {
-  "healing_salve": {
-    "id": "healing_salve",
-    "name": "Healing Salve",
-    "blueprintId": "healing_salve_blueprint",
-    "ingredients": { "goblin_ear": 1, "rotten_tooth": 1 },
-    "result": "health_potion",
-    "quantity": 1
-  },
   "health_amulet": {
     "id": "health_amulet",
     "name": "Health Amulet",

--- a/scripts/craft_state.js
+++ b/scripts/craft_state.js
@@ -32,9 +32,6 @@ function saveUnlockedBlueprints(list) {
 }
 
 craftState.unlockedBlueprints = new Set(loadUnlockedBlueprints());
-if (!craftState.unlockedBlueprints.size) {
-  craftState.unlockedBlueprints.add('healing_salve_blueprint');
-}
 document.dispatchEvent(new CustomEvent('blueprintsLoaded'));
 craftState.fusionUnlocked = readFusionState();
 

--- a/scripts/recipe_state.js
+++ b/scripts/recipe_state.js
@@ -1,5 +1,5 @@
 export const recipeState = {
-  unlocked: new Set(['healing_salve'])
+  unlocked: new Set()
 };
 
 const recipeFlags = {


### PR DESCRIPTION
## Summary
- remove Healing Salve from recipes
- stop unlocking Healing Salve by default
- adjust recipe list default and update tests

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ace3a1864833193d47df716ade643