### PR TITLE
Add modular map entry conditions and sealing door check

### DIFF
--- a/data/maps/map08.json
+++ b/data/maps/map08.json
@@ -468,7 +468,10 @@
         "spawn": {
           "x": 10,
           "y": 1
-        }
+        },
+        "locked": true,
+        "requiresItem": "sealing_dust",
+        "message": "A shimmering seal bars your way."
       },
       "F",
       "F",

--- a/scripts/interaction.js
+++ b/scripts/interaction.js
@@ -10,6 +10,7 @@ import { markItemUsed } from '../info/items.js';
 import { setMemory } from './dialogue_state.js';
 import { enterDoor } from './player.js';
 import { tryVicarDoor } from './door_logic.js';
+import { hasSealingDust, isSealPuzzleSolved } from './player_memory.js';
 
 /**
  * Handles double click interactions on tiles.
@@ -111,6 +112,16 @@ export async function handleTileInteraction(
     useKey('maze_key_2');
     markItemUsed('maze_key_2');
     updateInventoryUI();
+    tile.locked = false;
+    const newCols = await enterDoor(tile.target, tile.spawn);
+    return newCols;
+  }
+
+  if (tile.type === 'D' && tile.requiresItem === 'sealing_dust' && tile.locked) {
+    if (!hasSealingDust() && !isSealPuzzleSolved()) {
+      showDialogue(tile.message || 'A shimmering seal bars your way.');
+      return;
+    }
     tile.locked = false;
     const newCols = await enterDoor(tile.target, tile.spawn);
     return newCols;

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -39,13 +39,21 @@ export function normalizeGrid(grid, size = 20) {
   return normalized;
 }
 
-export async function loadMap(name) {
-  if (name === 'map09' && !hasSealingDust() && !isSealPuzzleSolved()) {
-    showDialogue('A shimmering seal bars your way.');
-    return null;
+const mapEntryConditions = {
+  map09: {
+    check: () => hasSealingDust() || isSealPuzzleSolved(),
+    message: 'A shimmering seal bars your way.'
+  },
+  map10: {
+    check: () => isMirrorPuzzleSolved(),
+    message: 'Ancient glyphs refuse to yield.'
   }
-  if (name === 'map10' && !isMirrorPuzzleSolved()) {
-    showDialogue('Ancient glyphs refuse to yield.');
+};
+
+export async function loadMap(name) {
+  const condition = mapEntryConditions[name];
+  if (condition && !condition.check()) {
+    showDialogue(condition.message);
     return null;
   }
   let data;
@@ -59,6 +67,15 @@ export async function loadMap(name) {
     if (name === 'map06_right') markForkVisited('right');
     if (name === 'map07' && visitedBothForks()) {
       showDialogue('The air hums as the twin trials align.');
+    }
+    if (name === 'map08' && isSealPuzzleSolved()) {
+      for (const row of data.grid) {
+        for (const cell of row) {
+          if (cell && cell.type === 'D' && cell.target === 'map09.json') {
+            cell.locked = false;
+          }
+        }
+      }
     }
     if (name === 'map09' && hasSealingDust()) {
       consumeSealingDust();


### PR DESCRIPTION
## Summary
- update the map08 exit to map09 so it requires the sealing dust
- implement modular `mapEntryConditions` in `loadMap`
- unlock map08 door after the puzzle is solved
- add door check for `sealing_dust`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adc26033c8331a72c6ce95911f967