### PR TITLE
Add sealing dust key item

### DIFF
--- a/__tests__/sealingDust.test.js
+++ b/__tests__/sealingDust.test.js
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../scripts/item_loader.js', () => ({
+  loadItems: jest.fn(async () => ({})),
+  getItemData: jest.fn(() => ({ name: 'Sealing Dust', description: '', category: 'key' }))
+}));
+
+jest.unstable_mockModule('../scripts/inventory_ui.js', () => ({
+  updateInventoryUI: jest.fn()
+}));
+
+let solveSealPuzzle, getItemCount, inventory, serializeInventory, loadInventoryFromObject;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ solveSealPuzzle } = await import('../scripts/player_memory.js'));
+  ({ getItemCount, inventory } = await import('../scripts/inventory.js'));
+  ({ serializeInventory, loadInventoryFromObject } = await import('../scripts/inventory_state.js'));
+  inventory.length = 0;
+});
+
+test('sealing_dust obtained from puzzle persists after save/load', async () => {
+  await solveSealPuzzle();
+  expect(getItemCount('sealing_dust')).toBe(1);
+  const saved = serializeInventory();
+  inventory.length = 0;
+  loadInventoryFromObject(saved);
+  expect(getItemCount('sealing_dust')).toBe(1);
+});

--- a/data/items.json
+++ b/data/items.json
@@ -401,5 +401,14 @@
     "stackLimit": 1,
     "icon": "🗝️",
     "category": "quest"
+  },
+  "sealing_dust": {
+    "name": "Sealing Dust",
+    "description": "Fine powder that breaks arcane seals.",
+    "type": "key",
+    "stackLimit": 1,
+    "icon": "✨",
+    "category": "key",
+    "consumable": false
   }
 }

--- a/info/items.js
+++ b/info/items.js
@@ -57,7 +57,9 @@ export const itemDescriptions = {
   clarity_shard:
     'Clarity Shard \u2013 clears debuffs and grants Focus when used in combat.',
   gentle_flask: 'Gentle Flask \u2013 restores a little health outside combat.',
-  dreamleaf: 'Dreamleaf \u2013 useful for brewing potions later.'
+  dreamleaf: 'Dreamleaf \u2013 useful for brewing potions later.',
+  sealing_dust:
+    'Sealing Dust \u2013 mystical powder that dissolves the barrier to Map09.'
 };
 
 export function markItemUsed(id) {

--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -1,3 +1,4 @@
+import { giveItem, hasItem } from './inventory.js';
 const STORAGE_KEY = 'gridquest.memory';
 
 const memory = {
@@ -137,9 +138,10 @@ export function visitedBothForks() {
   return memory.forksVisited.left && memory.forksVisited.right;
 }
 
-export function solveSealPuzzle() {
+export async function solveSealPuzzle() {
   memory.sealPuzzleSolved = true;
   memory.sealingDust = true;
+  await giveItem('sealing_dust', 1);
   saveMemory();
 }
 
@@ -148,7 +150,7 @@ export function isSealPuzzleSolved() {
 }
 
 export function hasSealingDust() {
-  return memory.sealingDust;
+  return memory.sealingDust || hasItem('sealing_dust');
 }
 
 export function consumeSealingDust() {

--- a/scripts/puzzle_state.js
+++ b/scripts/puzzle_state.js
@@ -19,7 +19,7 @@ export async function stepSymbol(symbol) {
     if (symbol === expected) {
       state.index++;
       if (state.index === sequence.length) {
-        solveSealPuzzle();
+        await solveSealPuzzle();
       }
     } else if (sequence.includes(symbol)) {
       state.index = 0;


### PR DESCRIPTION
## Summary
- add `sealing_dust` key item in `items.json`
- document sealing dust in item descriptions
- grant sealing dust on seal puzzle completion and check inventory when opening door
- await puzzle completion when solving the seal puzzle
- add test covering save/load of sealing dust item

## Testing
- `npx jest` *(fails: 403 Forbidden - cannot download jest)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684adddf03b08331889f9413d1f04fd1