### PR TITLE
Add Runic Sentinel miniboss

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -769,5 +769,30 @@
         "quantity": 1
       }
     ]
+  },
+  "runic_sentinel": {
+    "name": "Runic Sentinel",
+    "hp": 160,
+    "stats": {
+      "attack": 6,
+      "defense": 2
+    },
+    "xp": 50,
+    "description": "An ancient guardian of forgotten rites, pulsing with faint magic.",
+    "intro": "Runes flare as the Runic Sentinel awakens!",
+    "portrait": "📜",
+    "skills": [
+      "runic_blast",
+      "sigil_disrupt"
+    ],
+    "cycleSkills": true,
+    "behavior": "aggressive",
+    "boss": true,
+    "drops": [
+      {
+        "item": "sealing_dust",
+        "quantity": 1
+      }
+    ]
   }
 }

--- a/data/maps/map08.json
+++ b/data/maps/map08.json
@@ -132,7 +132,10 @@
       "G",
       "G",
       "G",
-      "G",
+      {
+        "type": "E",
+        "enemyId": "runic_sentinel"
+      },
       "G",
       "G",
       "G",

--- a/info/enemies.js
+++ b/info/enemies.js
@@ -104,6 +104,14 @@ export const enemies = [
     skills: 'blazing_claw, flame_pulse'
   },
   {
+    id: 'runic_sentinel',
+    name: 'Runic Sentinel',
+    map: 'Map08',
+    location: '10,5',
+    drops: 'Sealing Dust',
+    skills: 'runic_blast, sigil_disrupt'
+  },
+  {
     id: 'shattermind',
     name: 'Shattermind',
     map: 'Map05',

--- a/scripts/enemy_skills.js
+++ b/scripts/enemy_skills.js
@@ -884,6 +884,36 @@ export const enemySkills = {
       applyStatus(player, 'paralyzed', 1);
       log(`${enemy.name} invokes a blessed quake for ${applied} damage!`);
     }
+  },
+  runic_blast: {
+    id: 'runic_blast',
+    name: 'Runic Blast',
+    icon: '✨',
+    description: 'Fires a focused glyph of destructive force.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 0,
+    aiType: 'damage',
+    effect({ damagePlayer, log, enemy }) {
+      const applied = damagePlayer(25);
+      log(`${enemy.name} unleashes a runic blast for ${applied} damage!`);
+    }
+  },
+  sigil_disrupt: {
+    id: 'sigil_disrupt',
+    name: 'Sigil Disrupt',
+    icon: '🔮',
+    description: 'Disrupts your stance with arcane pressure.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 0,
+    aiType: 'status',
+    applies: ['weakened'],
+    statuses: [{ target: 'player', id: 'weakened', duration: 2 }],
+    effect({ player, applyStatus, log, enemy }) {
+      applyStatus(player, 'weakened', 2);
+      log(`${enemy.name} disrupts your stance with arcane pressure!`);
+    }
   }
 };
 

--- a/scripts/skill_data.js
+++ b/scripts/skill_data.js
@@ -131,5 +131,19 @@ export const skillData = {
     damage: 0,
     accuracy: 1,
     description: 'Leaves the target Fragile for a short time.'
+  },
+  runic_blast: {
+    id: 'runic_blast',
+    name: 'Runic Blast',
+    damage: 25,
+    accuracy: 1,
+    description: 'Fires a focused glyph of destructive force.'
+  },
+  sigil_disrupt: {
+    id: 'sigil_disrupt',
+    name: 'Sigil Disrupt',
+    damage: 0,
+    accuracy: 1,
+    description: 'Disrupts your stance with arcane pressure.'
   }
 };


### PR DESCRIPTION
## Summary
- place Runic Sentinel miniboss on map08
- define Runic Sentinel in enemies data
- add Runic Sentinel to bestiary info
- implement runic_blast and sigil_disrupt skills
- register skills in data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae00670ac833189d71c566be0a0fc