### PR TITLE
Add Warden Threshold boss and temple key

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -794,5 +794,31 @@
         "quantity": 1
       }
     ]
+  },
+  "warden_threshold": {
+    "name": "Warden of the Threshold",
+    "hp": 260,
+    "stats": {
+      "attack": 20,
+      "defense": 4
+    },
+    "xp": 110,
+    "description": "An ancient guardian forged to test those who would enter the temple.",
+    "intro": "The Warden rumbles awake, blocking your path!",
+    "portrait": "🚪",
+    "skills": [
+      "stone_lash",
+      "earthbind",
+      "resolve_break",
+      "quaking_step"
+    ],
+    "behavior": "aggressive",
+    "boss": true,
+    "drops": [
+      {
+        "item": "temple_key",
+        "quantity": 1
+      }
+    ]
   }
 }

--- a/data/items.json
+++ b/data/items.json
@@ -33,7 +33,7 @@
   },
   "temple_key": {
     "name": "Temple Key",
-    "description": "Opens the sealed temple gate.",
+    "description": "A heavy bronze key etched with ancient runes. It unlocks the entrance to the Temple.",
     "type": "quest",
     "stackLimit": 1,
     "icon": "🗝️",

--- a/data/maps/map07_maze03.json
+++ b/data/maps/map07_maze03.json
@@ -233,7 +233,10 @@
       "G",
       "G",
       "G",
-      "G",
+      {
+        "type": "E",
+        "enemyId": "warden_threshold"
+      },
       "G",
       "G",
       "G",

--- a/enemies/warden_threshold.js
+++ b/enemies/warden_threshold.js
@@ -1,0 +1,15 @@
+export const warden_threshold = {
+  id: 'warden_threshold',
+  name: 'Warden of the Threshold',
+  hp: 260,
+  stats: { attack: 20, defense: 4 },
+  xp: 110,
+  skills: ['stone_lash', 'earthbind', 'resolve_break', 'quaking_step'],
+  boss: true,
+  behavior: 'aggressive',
+  description:
+    'An ancient guardian forged to test those who would enter the temple.',
+  drops: [{ item: 'temple_key', quantity: 1 }]
+};
+
+export default warden_threshold;

--- a/info/enemies.js
+++ b/info/enemies.js
@@ -118,5 +118,13 @@ export const enemies = [
     location: '8,17',
     drops: 'Rift Eye, Memory Gem',
     skills: 'fracture_wave, mind_spike, echo_wound'
+  },
+  {
+    id: 'warden_threshold',
+    name: 'Warden of the Threshold',
+    map: 'Map07_maze03',
+    location: '10,10',
+    drops: 'Temple Key',
+    skills: 'stone_lash, earthbind, resolve_break, quaking_step'
   }
 ];

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -783,6 +783,21 @@ export async function startCombat(enemy, player) {
       } else {
         skill = getEnemySkill('prism_shot');
       }
+    }
+    else if (enemy.id === 'warden_threshold') {
+      enemy.cooldowns = enemy.cooldowns || { earthbind: 0, resolve_break: 0, quaking_step: 0 };
+      for (const k in enemy.cooldowns) { if (enemy.cooldowns[k] > 0) enemy.cooldowns[k]--; }
+      const opts = [];
+      if (enemy.cooldowns.earthbind === 0) opts.push('earthbind');
+      if (enemy.cooldowns.resolve_break === 0) opts.push('resolve_break');
+      if (enemy.cooldowns.quaking_step === 0) opts.push('quaking_step');
+      const choice = opts.length ? opts[Math.floor(Math.random()*opts.length)] : null;
+      if (choice) {
+        skill = getEnemySkill(choice);
+        if (skill.cooldown > 0) enemy.cooldowns[choice] = skill.cooldown;
+      } else {
+        skill = getEnemySkill('stone_lash');
+      }
     } else if (enemy.cycleSkills && list.length) {
       const idx = enemy.skillIndex || 0;
       skill = list[idx % list.length];

--- a/scripts/enemy_skills.js
+++ b/scripts/enemy_skills.js
@@ -913,8 +913,79 @@ export const enemySkills = {
     effect({ player, applyStatus, log, enemy }) {
       applyStatus(player, 'weakened', 2);
       log(`${enemy.name} disrupts your stance with arcane pressure!`);
+    },
+  },
+  stone_lash: {
+    id: 'stone_lash',
+    name: 'Stone Lash',
+    icon: '🪨',
+    description: 'A heavy strike of stone.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 0,
+    aiType: 'damage',
+    effect({ enemy, damagePlayer, log }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = atk + (enemy.tempAttack || 0);
+      const applied = damagePlayer(dmg);
+      log(`${enemy.name} lashes out with stone for ${applied} damage!`);
     }
-  }
+  },
+  earthbind: {
+    id: 'earthbind',
+    name: 'Earthbind',
+    icon: '⛓️',
+    description: '90% ATK and inflicts Weakened for 3 turns.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 5,
+    aiType: 'damage',
+    applies: ['weakened'],
+    statuses: [{ target: 'player', id: 'weakened', duration: 3 }],
+    effect({ enemy, player, damagePlayer, applyStatus, log }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = Math.round(0.9 * (atk + (enemy.tempAttack || 0)));
+      const applied = damagePlayer(dmg);
+      applyStatus(player, 'weakened', 3);
+      log(`${enemy.name} binds you with earth for ${applied} damage!`);
+    }
+  },
+  resolve_break: {
+    id: 'resolve_break',
+    name: 'Resolve Break',
+    icon: '🪓',
+    description: '50% ATK and permanently reduces defense by 2.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 10,
+    aiType: 'damage',
+    effect({ enemy, player, damagePlayer, log }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = Math.round(0.5 * (atk + (enemy.tempAttack || 0)));
+      const applied = damagePlayer(dmg);
+      if (player.stats) player.stats.defense = (player.stats.defense || 0) - 2;
+      log(`${enemy.name} shatters your resolve for ${applied} damage!`);
+    }
+  },
+  quaking_step: {
+    id: 'quaking_step',
+    name: 'Quaking Step',
+    icon: '💥',
+    description: '50% ATK and stuns for 1 turn.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 5,
+    aiType: 'damage',
+    applies: ['stunned'],
+    statuses: [{ target: 'player', id: 'stunned', duration: 1 }],
+    effect({ enemy, player, damagePlayer, applyStatus, log }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = Math.round(0.5 * (atk + (enemy.tempAttack || 0)));
+      const applied = damagePlayer(dmg);
+      applyStatus(player, 'stunned', 1);
+      log(`${enemy.name} stomps the ground for ${applied} damage!`);
+    }
+  },
 };
 
 export function getEnemySkill(id) {

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -13,7 +13,7 @@ export const itemData = {
   temple_key: {
     id: 'temple_key',
     name: 'Temple Key',
-    description: 'Opens the sealed temple gate.',
+    description: 'A heavy bronze key etched with ancient runes. It unlocks the entrance to the Temple.',
     type: 'key',
     tags: ['lore'],
     category: 'key',

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -3,9 +3,6 @@ import { loadJson } from './dataService.js';
 import {
   markForkVisited,
   visitedBothForks,
-  hasSealingDust,
-  consumeSealingDust,
-  isSealPuzzleSolved,
   isMirrorPuzzleSolved,
   isCorruptionPuzzleSolved,
   isRotationPuzzleSolved,
@@ -41,8 +38,8 @@ export function normalizeGrid(grid, size = 20) {
 
 const mapEntryConditions = {
   map09: {
-    check: () => hasSealingDust() || isSealPuzzleSolved(),
-    message: 'A shimmering seal bars your way.'
+    check: () => hasItem('temple_key'),
+    message: 'An unyielding gate bars your way. A key may exist somewhere...'
   },
   map10: {
     check: () => isMirrorPuzzleSolved(),
@@ -67,18 +64,6 @@ export async function loadMap(name) {
     if (name === 'map06_right') markForkVisited('right');
     if (name === 'map07' && visitedBothForks()) {
       showDialogue('The air hums as the twin trials align.');
-    }
-    if (name === 'map08' && isSealPuzzleSolved()) {
-      for (const row of data.grid) {
-        for (const cell of row) {
-          if (cell && cell.type === 'D' && cell.target === 'map09.json') {
-            cell.locked = false;
-          }
-        }
-      }
-    }
-    if (name === 'map09' && hasSealingDust()) {
-      consumeSealingDust();
     }
     if (name === 'map09' && isMirrorPuzzleSolved()) {
       // Unlock the door leading to map10 once the mirror puzzle is solved
@@ -113,6 +98,15 @@ export async function loadMap(name) {
           }
         }
       }
+    for (const row of data.grid) {
+      for (const cell of row) {
+        if (cell && cell.type === 'E' && cell.enemyId === 'warden_threshold') {
+          if (isEnemyDefeated('warden_threshold')) {
+            cell.type = 'G';
+          }
+        }
+      }
+    }
   } catch (err) {
     console.error(err);
     showError(err.message || `Failed to load map ${name}`);

--- a/scripts/status_effects.js
+++ b/scripts/status_effects.js
@@ -313,6 +313,14 @@ export const statusEffects = {
     type: 'negative',
     duration: 2
   },
+  stunned: {
+    id: 'stunned',
+    name: 'Stunned',
+    icon: '💫',
+    description: 'Skip next turn.',
+    type: 'negative',
+    duration: 1
+  },
   silenced: {
     id: 'silenced',
     name: 'Silenced',


### PR DESCRIPTION
## Summary
- place `warden_threshold` boss on map07_maze03
- define `warden_threshold` enemy and add enemy info entry
- add temple key item description
- implement Warden Threshold skills and stunned status
- update enemy AI with Warden Threshold logic
- gate map09 with Temple Key instead of sealing dust
- persist defeated Warden Threshold

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae36c56ec8331b68bccad1e9e35f3