### PR TITLE
Enable negative defense values

### DIFF
--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -76,7 +76,9 @@ export async function updateInventoryUI() {
   const statsEl = document.getElementById('player-stats');
   if (statsEl) {
     const stats = getTotalStats();
-    statsEl.textContent = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}  Attack: ${stats.attack || 0}  Defense: ${stats.defense || 0}`;
+    const def = stats.defense || 0;
+    const defHtml = def < 0 ? `<span class="negative">Defense: ${def}</span>` : `Defense: ${def}`;
+    statsEl.innerHTML = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}  Attack: ${stats.attack || 0}  ${defHtml}`;
   }
   let cat = currentCategory;
   if (cat === 'items') cat = ['general', 'crafting'];

--- a/scripts/logic.js
+++ b/scripts/logic.js
@@ -17,7 +17,9 @@ export function applyDamage(target, amount) {
     target.absorb -= absorbed;
   }
   const defense = target.stats?.defense || 0;
-  dmg = Math.max(0, dmg - defense);
+  const reduction = Math.max(0, defense);
+  const penalty = defense < 0 ? 1 + Math.abs(defense) * 0.1 : 1;
+  dmg = Math.max(0, (dmg - reduction) * penalty);
   const final = Math.floor(dmg);
   if (target.hasResolve && target.hp - final <= 0) {
     const lost = target.hp - 1;

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -240,8 +240,10 @@ export function serializePlayer() {
     level: player.level,
     xp: player.xp,
     xpToNextLevel: player.xpToNextLevel,
-    // stats like defense and attack are derived from level and equipment
-    // and will be recalculated when loading a save
+    stats: {
+      attack: player.stats?.attack || 0,
+      defense: player.stats?.defense || 0
+    },
     learnedSkills: Array.isArray(player.learnedSkills)
       ? [...player.learnedSkills]
       : [],
@@ -256,6 +258,11 @@ export function deserializePlayer(data) {
   player.level = data.level ?? player.level;
   player.xp = data.xp ?? player.xp;
   player.xpToNextLevel = data.xpToNextLevel ?? player.xpToNextLevel;
+  if (data.stats) {
+    if (!player.stats) player.stats = { attack: 0, defense: 0 };
+    player.stats.attack = data.stats.attack ?? player.stats.attack;
+    player.stats.defense = data.stats.defense ?? player.stats.defense;
+  }
   // derived stats will be recalculated from the level
   if (Array.isArray(data.learnedSkills)) {
     player.learnedSkills = [...data.learnedSkills];

--- a/scripts/ui/playerDisplay.js
+++ b/scripts/ui/playerDisplay.js
@@ -22,7 +22,10 @@ export function updateHpDisplay() {
 export function updateDefenseDisplay() {
   if (defenseDisplay) {
     const stats = getTotalStats();
-    defenseDisplay.textContent = `Defense: ${stats.defense || 0}`;
+    const def = stats.defense || 0;
+    defenseDisplay.textContent = `Defense: ${def}`;
+    if (def < 0) defenseDisplay.classList.add('negative');
+    else defenseDisplay.classList.remove('negative');
   }
 }
 

--- a/ui/main_menu.js
+++ b/ui/main_menu.js
@@ -10,12 +10,14 @@ export function updateMenuStats() {
   const el = document.getElementById('menu-stats');
   if (!el) return;
   const stats = getTotalStats();
+  const def = stats.defense || 0;
+  const defHtml = def < 0 ? `<span class="negative">${def}</span>` : def;
   el.innerHTML = `
     <div>Level: ${player.level}</div>
     <div>XP: ${player.xp} / ${player.xpToNextLevel}</div>
     <div>HP: ${player.hp} / ${player.maxHp}</div>
     <div>ATK: ${stats.attack || 0}</div>
-    <div>DEF: ${stats.defense || 0}</div>
+    <div>DEF: ${defHtml}</div>
   `;
 }
 


### PR DESCRIPTION
## Summary
- allow negative defense bonuses to persist in save data
- account for negative defense when calculating damage
- highlight negative defense in various stat displays

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b022efed88331a81689d703f02d4b