### PR TITLE
Add negative defense logic

### DIFF
--- a/__tests__/negativeDefenseSaveLoad.test.js
+++ b/__tests__/negativeDefenseSaveLoad.test.js
@@ -1,0 +1,17 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let serializePlayer, deserializePlayer, player;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ serializePlayer, deserializePlayer, player } = await import('../scripts/player.js'));
+});
+
+test('negative defense persists through serialization', () => {
+  player.stats.defense = -2;
+  const saved = serializePlayer();
+  player.stats.defense = 0;
+  deserializePlayer(saved);
+  expect(player.stats.defense).toBe(-2);
+});

--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -77,7 +77,11 @@ export async function updateInventoryUI() {
   if (statsEl) {
     const stats = getTotalStats();
     const def = stats.defense || 0;
-    const defHtml = def < 0 ? `<span class="negative">Defense: ${def}</span>` : `Defense: ${def}`;
+    const tooltip = 'Negative defense increases damage taken by 10% per point.';
+    const defHtml =
+      def < 0
+        ? `<span class="negative" title="${tooltip}">Defense: ${def}</span>`
+        : `<span title="${tooltip}">Defense: ${def}</span>`;
     statsEl.innerHTML = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}  Attack: ${stats.attack || 0}  ${defHtml}`;
   }
   let cat = currentCategory;

--- a/scripts/logic.js
+++ b/scripts/logic.js
@@ -6,6 +6,15 @@ export function generateTileId(x, y) {
   return `${x},${y}`;
 }
 
+export function calculateDamage(attacker, target, baseDamage) {
+  const defense = target.stats?.defense ?? target.defense ?? 0;
+  const effectiveDefense = Math.max(defense, 0);
+  const penaltyMultiplier = defense < 0 ? 1 + 0.1 * Math.abs(defense) : 1;
+  const rawDamage = baseDamage - effectiveDefense;
+  const amplified = Math.floor(rawDamage * penaltyMultiplier);
+  return Math.max(amplified, 0);
+}
+
 export function applyDamage(target, amount) {
   let dmg = amount;
   if (typeof target.damageTakenMod === 'number') {
@@ -16,11 +25,7 @@ export function applyDamage(target, amount) {
     dmg -= absorbed;
     target.absorb -= absorbed;
   }
-  const defense = target.stats?.defense || 0;
-  const reduction = Math.max(0, defense);
-  const penalty = defense < 0 ? 1 + Math.abs(defense) * 0.1 : 1;
-  dmg = Math.max(0, (dmg - reduction) * penalty);
-  const final = Math.floor(dmg);
+  const final = calculateDamage(null, target, dmg);
   if (target.hasResolve && target.hp - final <= 0) {
     const lost = target.hp - 1;
     target.hasResolve = false;

--- a/scripts/ui/playerDisplay.js
+++ b/scripts/ui/playerDisplay.js
@@ -24,6 +24,8 @@ export function updateDefenseDisplay() {
     const stats = getTotalStats();
     const def = stats.defense || 0;
     defenseDisplay.textContent = `Defense: ${def}`;
+    defenseDisplay.title =
+      'Negative defense increases damage taken by 10% per point.';
     if (def < 0) defenseDisplay.classList.add('negative');
     else defenseDisplay.classList.remove('negative');
   }

--- a/ui/main_menu.js
+++ b/ui/main_menu.js
@@ -11,7 +11,11 @@ export function updateMenuStats() {
   if (!el) return;
   const stats = getTotalStats();
   const def = stats.defense || 0;
-  const defHtml = def < 0 ? `<span class="negative">${def}</span>` : def;
+  const tooltip =
+    'Negative defense increases damage taken by 10% per point.';
+  const defHtml = def < 0
+    ? `<span class="negative" title="${tooltip}">${def}</span>`
+    : `<span title="${tooltip}">${def}</span>`;
   el.innerHTML = `
     <div>Level: ${player.level}</div>
     <div>XP: ${player.xp} / ${player.xpToNextLevel}</div>


### PR DESCRIPTION
## Summary
- support negative defense with `calculateDamage`
- add tooltip for negative defense in player displays
- colorize negative defense in menu and inventory UIs
- add jest test to verify defense value persists through serialization

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b03800088833199aeb2e2bd7b8314