### PR TITLE
Remove temple key check for map09

### DIFF
--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -37,10 +37,6 @@ export function normalizeGrid(grid, size = 20) {
 }
 
 const mapEntryConditions = {
-  map09: {
-    check: () => hasItem('temple_key'),
-    message: 'An unyielding gate bars your way. A key may exist somewhere...'
-  },
   map10: {
     check: () => isMirrorPuzzleSolved(),
     message: 'Ancient glyphs refuse to yield.'


### PR DESCRIPTION
## Summary
- allow entry to map09 without requiring `temple_key`

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0c6df2488331b3a798fb404d0cc9