### PR TITLE
Fix welcome modal closing

### DIFF
--- a/ui/greeting.js
+++ b/ui/greeting.js
@@ -6,11 +6,13 @@ export function initGreeting(startCallback) {
   const howClose = howtoOverlay?.querySelector('.close-btn');
 
   function showHowto() {
+    greetOverlay?.classList.remove('active');
     howtoOverlay?.classList.add('active');
   }
 
   function hideHowto() {
     howtoOverlay?.classList.remove('active');
+    greetOverlay?.classList.add('active');
   }
 
   function startGame() {


### PR DESCRIPTION
## Summary
- hide the greeting overlay when showing the How To Play dialog
- restore the greeting overlay when closing How To Play

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b11f13b648331a6323cf7cec0539e