### PR TITLE
Fix known issues numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ Distributed under the MIT License. See [LICENSE](LICENSE) for details.
 
 ## Known Issues
 
-5. Large Untested Modules
+1. Large Untested Modules
 
    - Some JavaScript files (e.g., `scripts/main.js`) are several hundred lines long, making them hard to maintain and test.
 
-6. Manual Asset Loading
+2. Manual Asset Loading
    - Many JSON assets are fetched at runtime (e.g., `loadMap` in `scripts/mapLoader.js`), requiring a local HTTP server. If any file is missing or malformed, the error handling is minimal.


### PR DESCRIPTION
## Summary
- correct numbering for `Known Issues` in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684b193f9718833186ec3147b0180f62