### PR TITLE
Add package-lock and setup note

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Refresh the browser after editing files in `scripts/`, `style/` or `data/`. Node
 ```bash
 npm install
 ```
+Run this command before using `npm run lint` or `npm test`.
 
 ### Available commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "grid-quest",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "name": "grid-quest",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@eslint/js": "^9.0.0",
+        "eslint": "^9.0.0",
+        "jest": "^29.7.0",
+        "prettier": "^3.2.5"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- generate a placeholder `package-lock.json`
- mention installing dependencies before running lints or tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1bec30f0833197c97ead447289df