### PR TITLE
Improve JSON loading errors

### DIFF
--- a/scripts/dataService.js
+++ b/scripts/dataService.js
@@ -1,21 +1,21 @@
 export async function loadJson(path) {
+  let res;
   try {
-    const res = await fetch(path);
-    if (!res.ok) {
-      const msg =
-        res.status === 404
-          ? `File not found: ${path}`
-          : `${res.status} ${res.statusText} (${path})`;
-      throw new Error(msg);
-    }
-    const text = await res.text();
-    try {
-      return JSON.parse(text);
-    } catch (err) {
-      throw new Error(`Malformed JSON in ${path}: ${err.message}`);
-    }
+    res = await fetch(path);
   } catch (err) {
-    console.error(`Failed to load ${path}`, err);
-    return null;
+    throw new Error(`Network error while fetching ${path}: ${err.message}`);
+  }
+  if (!res.ok) {
+    const msg =
+      res.status === 404
+        ? `File not found: ${path}`
+        : `${res.status} ${res.statusText} (${path})`;
+    throw new Error(msg);
+  }
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(`Malformed JSON in ${path}: ${err.message}`);
   }
 }

--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -18,11 +18,12 @@ let dataLoaded = false;
 
 async function loadDialogData() {
   if (dataLoaded) return;
-  const data = await loadJson('data/dialog.json');
-  if (data) {
+  try {
+    const data = await loadJson('data/dialog.json');
     dialogueLines = data;
-  } else {
-    showError('Failed to load dialogue');
+  } catch (err) {
+    dialogueLines = {};
+    showError(err.message || 'Failed to load dialogue');
   }
   dataLoaded = true;
 }

--- a/scripts/enemy.js
+++ b/scripts/enemy.js
@@ -6,11 +6,12 @@ let enemyData = {};
 
 export async function loadEnemyData() {
   if (Object.keys(enemyData).length) return enemyData;
-  const data = await loadJson('data/enemies.json');
-  if (data) {
+  try {
+    const data = await loadJson('data/enemies.json');
     enemyData = data;
-  } else {
-    showError('Failed to load enemies');
+  } catch (err) {
+    enemyData = {};
+    showError(err.message || 'Failed to load enemies');
   }
   return enemyData;
 }

--- a/scripts/forge.js
+++ b/scripts/forge.js
@@ -1,4 +1,5 @@
 import { loadJson } from './dataService.js';
+import { showError } from './errorPrompt.js';
 import { inventory, removeItem, addItem } from './inventory.js';
 import { getItemData } from './item_loader.js';
 import { getItemDisplayName } from './inventory.js';
@@ -11,8 +12,13 @@ let sessionActive = false;
 
 export async function loadUpgradeData() {
   if (loaded) return upgrades;
-  const data = await loadJson('data/upgrade_data.json');
-  if (data) upgrades = data;
+  try {
+    const data = await loadJson('data/upgrade_data.json');
+    upgrades = data;
+  } catch (err) {
+    upgrades = {};
+    showError(err.message || 'Failed to load upgrade data');
+  }
   loaded = true;
   return upgrades;
 }

--- a/scripts/item_loader.js
+++ b/scripts/item_loader.js
@@ -6,12 +6,12 @@ let items = {};
 
 export async function loadItems() {
   if (Object.keys(items).length) return items;
-  const data = await loadJson('data/items.json');
-  if (data) {
+  try {
+    const data = await loadJson('data/items.json');
     items = { ...data, ...itemData };
-  } else {
+  } catch (err) {
     items = { ...itemData };
-    showError('Failed to load items');
+    showError(err.message || 'Failed to load items');
   }
   return items;
 }

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -52,10 +52,6 @@ export async function loadMap(name) {
   let data;
   try {
     data = await loadJson(`data/maps/${name}.json`);
-    if (!data) {
-      showError(`Failed to load map ${name}`);
-      return null;
-    }
     if (name === 'map06_left') markForkVisited('left');
     if (name === 'map06_right') markForkVisited('right');
     if (name === 'map07' && visitedBothForks()) {

--- a/scripts/quest_state.js
+++ b/scripts/quest_state.js
@@ -14,11 +14,12 @@ export function getQuests() {
 
 export async function loadQuestData() {
   if (state.loaded) return state.data;
-  const data = await loadJson('data/quests.json');
-  if (data) {
+  try {
+    const data = await loadJson('data/quests.json');
     state.data = data;
-  } else {
-    showError('Failed to load quests');
+  } catch (err) {
+    state.data = {};
+    showError(err.message || 'Failed to load quests');
   }
   state.loaded = true;
   return state.data;

--- a/scripts/relic_state.js
+++ b/scripts/relic_state.js
@@ -45,11 +45,12 @@ document.dispatchEvent(new CustomEvent('relicsLoaded'));
 
 export async function loadRelics() {
   if (Object.keys(relicState.data).length) return relicState.data;
-  const data = await loadJson('data/relics.json');
-  if (data) {
+  try {
+    const data = await loadJson('data/relics.json');
     relicState.data = data;
-  } else {
-    showError('Failed to load relics');
+  } catch (err) {
+    relicState.data = {};
+    showError(err.message || 'Failed to load relics');
   }
   return relicState.data;
 }


### PR DESCRIPTION
## Summary
- better network and parse error messages in `loadJson`
- show loading errors with details for enemies, items, quests, relics, dialogue and forge upgrades
- simplify map loader check

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1e11bad08331a18ba94a39ad5866