### PR TITLE
Add optional CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        id: install
+        run: npm ci
+        continue-on-error: true
+      - name: Lint
+        if: steps.install.outcome == 'success'
+        run: npm run lint
+      - name: Test
+        if: steps.install.outcome == 'success'
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Run this command before using `npm run lint` or `npm test`.
 - `npm run lint` – check code with ESLint
 - `npm run format` – format files using Prettier
 - `npm test` – run Jest tests (none included by default)
+## Continuous Integration
+
+This repository provides a GitHub Actions workflow that attempts to install dependencies and run `npm run lint` and `npm test`. If the install step fails, the workflow skips linting and tests.
 
 ## Deploying to GitHub Pages
 


### PR DESCRIPTION
## Summary
- run Node lint and tests in CI if the package install succeeds
- mention the optional workflow in the README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b20a47ed48331a56a572127a5b6bd