### PR TITLE
Add Warden balancing

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -799,8 +799,8 @@
     "name": "Warden of the Threshold",
     "hp": 260,
     "stats": {
-      "attack": 20,
-      "defense": 4
+      "attack": 15,
+      "defense": 3
     },
     "xp": 110,
     "description": "An ancient guardian forged to test those who would enter the temple.",
@@ -812,7 +812,7 @@
       "resolve_break",
       "quaking_step"
     ],
-    "behavior": "aggressive",
+    "behavior": "balanced",
     "boss": true,
     "drops": [
       {

--- a/enemies/warden_threshold.js
+++ b/enemies/warden_threshold.js
@@ -2,11 +2,11 @@ export const warden_threshold = {
   id: 'warden_threshold',
   name: 'Warden of the Threshold',
   hp: 260,
-  stats: { attack: 20, defense: 4 },
+  stats: { attack: 15, defense: 3 },
   xp: 110,
   skills: ['stone_lash', 'earthbind', 'resolve_break', 'quaking_step'],
   boss: true,
-  behavior: 'aggressive',
+  behavior: 'balanced',
   description:
     'An ancient guardian forged to test those who would enter the temple.',
   drops: [{ item: 'temple_key', quantity: 1 }]


### PR DESCRIPTION
## Summary
- tone down the Warden of the Threshold

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b2617c7e4833188cb6252103965ea