### PR TITLE
Adjust Resolve Break skill

### DIFF
--- a/scripts/enemy_skills.js
+++ b/scripts/enemy_skills.js
@@ -954,17 +954,16 @@ export const enemySkills = {
     id: 'resolve_break',
     name: 'Resolve Break',
     icon: '🪓',
-    description: '50% ATK and permanently reduces defense by 2.',
+    description: 'A fierce blow dealing 60% ATK damage.',
     category: 'offensive',
     cost: 0,
     cooldown: 10,
     aiType: 'damage',
     effect({ enemy, player, damagePlayer, log }) {
       const atk = enemy.stats?.attack || 0;
-      const dmg = Math.round(0.5 * (atk + (enemy.tempAttack || 0)));
+      const dmg = Math.round(0.6 * (atk + (enemy.tempAttack || 0)));
       const applied = damagePlayer(dmg);
-      if (player.stats) player.stats.defense = (player.stats.defense || 0) - 2;
-      log(`${enemy.name} shatters your resolve for ${applied} damage!`);
+      log(`${enemy.name} slams down with force, dealing ${applied} damage!`);
     }
   },
   quaking_step: {


### PR DESCRIPTION
## Summary
- remove permanent defense penalty from the warden's `resolve_break`
- boost the skill damage slightly and update log text

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b2b417b808331af4011d2f8a60301