### PR TITLE
Fix empty chests and add traps in map09_floor01

### DIFF
--- a/data/maps/map09_floor01.json
+++ b/data/maps/map09_floor01.json
@@ -92,8 +92,8 @@
       "G",
       "G",
       "G",
-      "F",
-      "F",
+      "T",
+      "t",
       {
         "type": "E",
         "enemyId": "temple_warden"
@@ -230,10 +230,10 @@
       "T",
       "G",
       "t",
-      "F",
-      "F",
-      "F",
-      "F",
+      "T",
+      "t",
+      "T",
+      "t",
       {
         "type": "C",
         "key": "temple_chest_key",
@@ -343,7 +343,7 @@
         "type": "E",
         "enemyId": "silent_idol"
       },
-      "F",
+      "t",
       "G",
       "G",
       "G",
@@ -420,12 +420,12 @@
       },
       "G",
       "G",
-      "F",
-      "F",
-      "F",
-      "F",
-      "F",
-      "F",
+      "t",
+      "T",
+      "t",
+      "T",
+      "t",
+      "T",
       {
         "type": "E",
         "enemyId": "obsidian_disciple"

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -118,9 +118,17 @@ const chestContents = {
     item: 'old_coin',
     message: 'An aged coin rests within.'
   },
+  'map09_floor01:4,5': {
+    item: 'ritual_oil',
+    message: 'You find a vial of ritual oil.'
+  },
   'map09_floor01:16,10': {
     item: 'aegis_invocation_scroll',
     message: 'You discover a sacred scroll hidden within.'
+  },
+  'map09_floor01:15,13': {
+    item: 'polished_shard',
+    message: 'You uncover a gleaming polished shard.'
   },
   'map09_floor02:3,8': {
     item: 'temple_chest_key',


### PR DESCRIPTION
## Summary
- give the missing chests on map09_floor01 actual loot
- add a pattern of `T` and `t` traps on floor I of the temple

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2f2279fc83318e71924f0df0f2cb