### PR TITLE
Fix door placement on temple floor1

### DIFF
--- a/data/maps/map09_floor01.json
+++ b/data/maps/map09_floor01.json
@@ -2,7 +2,35 @@
   "name": "Temple of Depths — Floor I",
   "environment": "ruins",
   "grid": [
-    "FFFFFFFFFFFFFFFFFFFF",
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "D",
+        "target": "map09.json",
+        "spawn": {
+          "x": 10,
+          "y": 18
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ],
     [
       "F",
       "F",
@@ -14,14 +42,7 @@
       "F",
       "F",
       "G",
-      {
-        "type": "D",
-        "target": "map09_floor02.json",
-        "spawn": {
-          "x": 10,
-          "y": 1
-        }
-      },
+      "G",
       "G",
       "F",
       "F",
@@ -410,14 +431,7 @@
       "F",
       "F",
       "F",
-      {
-        "type": "D",
-        "target": "map09.json",
-        "spawn": {
-          "x": 10,
-          "y": 18
-        }
-      },
+      "G",
       "G",
       "G",
       "t",
@@ -432,6 +446,34 @@
       },
       "F"
     ],
-    "FFFFFFFFFFFFFFFFFFFF"
+    [
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      {
+        "type": "D",
+        "target": "map09_floor02.json",
+        "spawn": {
+          "x": 10,
+          "y": 1
+        }
+      },
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F",
+      "F"
+    ]
   ]
 }


### PR DESCRIPTION
## Summary
- move the exit door to the bottom of map09_floor01
- update top row door to return to `map09.json`
- adjust ground tiles around the moved doors

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b314b7eb48331802ae2a3f2dc4442