### PR TITLE
Fix enemy tile cleanup

### DIFF
--- a/scripts/map.js
+++ b/scripts/map.js
@@ -30,7 +30,20 @@ export function spawnEnemy(x, y, id) {
   const container = document.getElementById('game-grid');
   if (!grid || !container) return;
   if (!grid[y] || !grid[y][x]) return;
-  grid[y][x] = { type: 'E', enemyId: id };
+  grid[y][x] = { base: 'G', type: 'E', enemyId: id };
   renderGrid(grid, container, getCurrentEnvironment(), isFogEnabled());
   router.drawPlayer(player, container, router.getCols());
+}
+
+export function handleEnemyDefeat(x, y) {
+  const grid = getCurrentGrid();
+  const container = document.getElementById('game-grid');
+  if (!grid || !container) return;
+  if (!grid[y] || !grid[y][x]) return;
+  const tile = grid[y][x];
+  if (tile && ['E', 'A', 'B', 'X'].includes(tile.type)) {
+    grid[y][x] = { type: tile.base || 'G' };
+    renderGrid(grid, container, getCurrentEnvironment(), isFogEnabled());
+    router.drawPlayer(player, container, router.getCols());
+  }
 }

--- a/scripts/mapLoader.js
+++ b/scripts/mapLoader.js
@@ -114,6 +114,9 @@ export async function loadMap(name) {
       if (typeof cell === 'string') {
         return { type: cell };
       }
+      if (cell && ['E', 'A', 'B', 'X'].includes(cell.type)) {
+        return { base: 'G', ...cell };
+      }
       return cell;
     });
   });

--- a/scripts/startGame.js
+++ b/scripts/startGame.js
@@ -6,7 +6,7 @@ import { handleTileClick, isPlayerMoving } from './grid_click.js';
 import { handleTileInteraction } from './interaction.js';
 import { npcModules } from './npc/index.js';
 import { defeatEnemy } from './enemy.js';
-import { spawnEnemy } from './map.js';
+import { spawnEnemy, handleEnemyDefeat } from './map.js';
 import { setMemory } from './dialogue_state.js';
 import { hasItem } from './inventory.js';
 import {
@@ -72,13 +72,14 @@ export async function startGame(container, settings, state) {
       if (e.detail.enemyHp <= 0) {
         const enemyId = e.detail.enemy.id;
         defeatEnemy(enemyId);
+        const pos = gameState.lastEnemyPos;
+        if (pos) handleEnemyDefeat(pos.x, pos.y);
         if (
           enemyId === 'goblin01' &&
           !hasItem('goblin_ear') &&
           !hasItem('goblin_insignia') &&
           !hasItem('cracked_helmet')
         ) {
-          const pos = gameState.lastEnemyPos;
           if (pos) spawnEnemy(pos.x, pos.y, 'ghost_echo');
         }
         if (enemyId === 'goblin_scout') {

--- a/scripts/tile_type.js
+++ b/scripts/tile_type.js
@@ -135,13 +135,6 @@ export async function onInteractEffect(
     case 'A':
     case 'B':
     case 'X': {
-      const index = y * cols + x;
-      const tileEl = container.children[index];
-      if (tileEl) {
-        tileEl.classList.remove('tile-E', 'tile-A', 'tile-B', 'tile-X', 'blocked');
-        tileEl.classList.add('tile-G');
-      }
-      tile.type = 'G';
       gameState.lastEnemyPos = { x, y };
       const enemyId = tile.enemyId || 'goblin01';
       const enemy = getEnemyData(enemyId) || { name: 'Enemy', hp: 50 };


### PR DESCRIPTION
## Summary
- keep enemy tiles until combat ends
- restore ground tile on defeat
- add base tile metadata when loading maps

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b4c36a60c83319f1c6a12287b00b2