### PR TITLE
Add opened chest tile

### DIFF
--- a/scripts/router.js
+++ b/scripts/router.js
@@ -42,25 +42,22 @@ export async function loadMap(filename, spawnPoint) {
     return { grid: getCurrentGrid(), cols };
   }
   const { grid, environment, properties } = result;
+
+  // Convert previously opened chests to opened chest tiles before rendering
+  for (const id of gameState.openedChests) {
+    const [map, coord] = id.split(':');
+    if (map !== name) continue;
+    const [cx, cy] = coord.split(',').map(Number);
+    if (grid[cy] && grid[cy][cx]) {
+      grid[cy][cx].type = 'c';
+    }
+  }
   currentMap = name;
   gameState.currentMap = name;
   gameState.environment = environment;
   discoverMap(name);
   cols = grid[0].length;
   renderGrid(grid, container, environment, properties?.fog);
-
-  // Mark chests that were previously opened
-  for (const id of gameState.openedChests) {
-    const [map, coord] = id.split(':');
-    if (map !== name) continue;
-    const [cx, cy] = coord.split(',').map(Number);
-    const index = cy * cols + cx;
-    const tileEl = container.children[index];
-    if (tileEl) {
-      tileEl.classList.remove('chest');
-      tileEl.classList.add('chest-opened');
-    }
-  }
 
   if (spawnPoint) {
     player.x = spawnPoint.x;

--- a/scripts/tile_definitions.js
+++ b/scripts/tile_definitions.js
@@ -5,6 +5,7 @@ export const TILE_INFO = {
   t: { color: '#aaaaaa', shape: 'square', walkable: true, interactable: false },
   T: { color: '#444444', shape: 'square', walkable: true, interactable: false },
   C: { color: '#d4af37', shape: 'square', walkable: false, interactable: true },
+  c: { color: '#8b4513', shape: 'square', walkable: true, interactable: false },
   D: { color: '#5a381e', shape: 'square', walkable: false, interactable: true },
   N: { color: '#9b59b6', shape: 'circle', walkable: false, interactable: true },
   n: { color: '#ffffff', shape: 'circle', walkable: false, interactable: true },

--- a/scripts/tile_type.js
+++ b/scripts/tile_type.js
@@ -9,6 +9,7 @@ export const TILE_DEFS = {
   t: { walkable: true, interactable: false, description: 'Light Trap' },
   T: { walkable: true, interactable: false, description: 'Heavy Trap' },
   C: { walkable: false, interactable: true, description: 'Chest' },
+  c: { walkable: true, interactable: false, description: 'Opened Chest' },
   D: { walkable: false, interactable: true, description: 'Door' },
   N: { walkable: false, interactable: true, description: 'NPC' },
   n: { walkable: false, interactable: true, description: 'Advanced NPC' },
@@ -182,9 +183,9 @@ export async function onInteractEffect(
           const tileEl = container.children[idx];
           if (tileEl) {
             tileEl.classList.remove('tile-C', 'blocked');
-            tileEl.classList.add('chest-opened', 'tile-G');
+            tileEl.classList.add('chest-opened', 'tile-c');
           }
-          tile.type = 'G';
+          tile.type = 'c';
           for (const [id, skill] of Object.entries(getAllSkills())) {
             if (skill.unlockCondition?.chest === chestId) {
               if (unlockSkill(id)) {

--- a/style/tile.css
+++ b/style/tile.css
@@ -25,6 +25,7 @@
 .tile-t { background: #aaaaaa; }
 .tile-T { background: #444444; }
 .tile-C { background: #d4af37; }
+.tile-c { background: #8b4513; }
 .tile-D { background: #5a381e; }
 .tile-N { background: #9b59b6; }
 .tile-n { background: #ffffff; }


### PR DESCRIPTION
## Summary
- support `c` tiles for opened chests
- swap chest tiles to `c` when opened and preserve across loads
- color the opened chest like a dulled chest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4f5b844c8331afe1be6392a38f30