### PR TITLE
Add non-walkable opened chest tile

### DIFF
--- a/__tests__/openedChestBehavior.test.js
+++ b/__tests__/openedChestBehavior.test.js
@@ -1,0 +1,7 @@
+/** @jest-environment jsdom */
+import { isWalkable, isInteractable } from '../scripts/tile_type.js';
+
+it('opened chest tile behaves like a wall', () => {
+  expect(isWalkable('c')).toBe(false);
+  expect(isInteractable('c')).toBe(false);
+});

--- a/scripts/tile_definitions.js
+++ b/scripts/tile_definitions.js
@@ -5,7 +5,12 @@ export const TILE_INFO = {
   t: { color: '#aaaaaa', shape: 'square', walkable: true, interactable: false },
   T: { color: '#444444', shape: 'square', walkable: true, interactable: false },
   C: { color: '#d4af37', shape: 'square', walkable: false, interactable: true },
-  c: { color: '#8b4513', shape: 'square', walkable: true, interactable: false },
+  c: {
+    color: '#b08d57',
+    shape: 'square',
+    walkable: false,
+    interactable: false
+  },
   D: { color: '#5a381e', shape: 'square', walkable: false, interactable: true },
   N: { color: '#9b59b6', shape: 'circle', walkable: false, interactable: true },
   n: { color: '#ffffff', shape: 'circle', walkable: false, interactable: true },

--- a/scripts/tile_type.js
+++ b/scripts/tile_type.js
@@ -9,7 +9,11 @@ export const TILE_DEFS = {
   t: { walkable: true, interactable: false, description: 'Light Trap' },
   T: { walkable: true, interactable: false, description: 'Heavy Trap' },
   C: { walkable: false, interactable: true, description: 'Chest' },
-  c: { walkable: true, interactable: false, description: 'Opened Chest' },
+  c: {
+    walkable: false,
+    interactable: false,
+    description: 'Opened Chest'
+  },
   D: { walkable: false, interactable: true, description: 'Door' },
   N: { walkable: false, interactable: true, description: 'NPC' },
   n: { walkable: false, interactable: true, description: 'Advanced NPC' },
@@ -182,8 +186,8 @@ export async function onInteractEffect(
           const idx = y * cols + x;
           const tileEl = container.children[idx];
           if (tileEl) {
-            tileEl.classList.remove('tile-C', 'blocked');
-            tileEl.classList.add('chest-opened', 'tile-c');
+            tileEl.classList.remove('tile-C');
+            tileEl.classList.add('chest-opened', 'tile-c', 'blocked');
           }
           tile.type = 'c';
           for (const [id, skill] of Object.entries(getAllSkills())) {

--- a/style/layout.css
+++ b/style/layout.css
@@ -120,7 +120,7 @@ body {
 }
 
 .chest-opened {
-  background: #8b4513;
+  background: #b08d57;
 }
 
 .enemy {

--- a/style/tile.css
+++ b/style/tile.css
@@ -25,7 +25,7 @@
 .tile-t { background: #aaaaaa; }
 .tile-T { background: #444444; }
 .tile-C { background: #d4af37; }
-.tile-c { background: #8b4513; }
+.tile-c { background: #b08d57; }
 .tile-D { background: #5a381e; }
 .tile-N { background: #9b59b6; }
 .tile-n { background: #ffffff; }


### PR DESCRIPTION
## Summary
- make opened chest tile behave like a wall
- update color of opened chest and keep blocked class when opened
- add tests for opened chest behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b52b250ac8331b7b460f1e1f8c897