### PR TITLE
Add Snealer advanced NPC

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -175,6 +175,14 @@
     "icon": "☀️",
     "category": "general"
   },
+  "shadow_token": {
+    "name": "Shadow Token",
+    "description": "A dark token that seems to absorb light.",
+    "type": "key",
+    "stackLimit": 1,
+    "icon": "🗝️",
+    "category": "key"
+  },
   "defense_potion_I": {
     "name": "Defense Potion I",
     "description": "Increases defense by 1 for this fight.",

--- a/data/maps/map01.json
+++ b/data/maps/map01.json
@@ -233,7 +233,11 @@
       "G",
       "G",
       "G",
-      "G",
+      {
+        "type": "N",
+        "npc": "snealer",
+        "advanced": true
+      },
       "G",
       "G",
       "G",

--- a/scripts/dialogue/npcs/snealer.js
+++ b/scripts/dialogue/npcs/snealer.js
@@ -1,0 +1,53 @@
+export default {
+  name: 'Snealer, the Whisperer',
+  start: {
+    text: 'Psst... not all treasures are in chests, you know.',
+    labels: [
+      { text: 'What do you mean?', goto: 1 },
+      { text: 'You look suspicious.', goto: 2 },
+      { text: 'I\u2019ll be going.', goto: null }
+    ]
+  },
+  1: {
+    text: 'Some secrets lie where footsteps vanish...',
+    labels: [
+      { text: 'Where should I look?', goto: 3 },
+      { text: 'Sounds like nonsense.', goto: null }
+    ]
+  },
+  2: {
+    text: 'Suspicious? Me? I\u2019m just a humble observer of the unseen.',
+    labels: [
+      { text: 'Observer of what exactly?', goto: 4 },
+      { text: 'Still sounds suspicious.', goto: null }
+    ]
+  },
+  3: {
+    text: 'If you can answer this: What walks without a sound, and lives only when no one\u2019s around?',
+    labels: [
+      { text: 'A shadow?', goto: 5 },
+      { text: 'A ghost?', goto: 6 },
+      { text: 'No idea.', goto: null }
+    ]
+  },
+  4: {
+    text: 'The sort of things that disappear when light hits them...',
+    labels: [{ text: 'Interesting.', goto: null }]
+  },
+  5: {
+    text: 'Sharp. I wasn\u2019t sure you had it in you.',
+    givesItem: { item: 'shadow_token', quantity: 1 },
+    labels: [
+      { text: 'What is this token?', goto: 7 },
+      { text: 'Thanks.', goto: null }
+    ]
+  },
+  6: {
+    text: 'Heh. Close, but shadows don\u2019t haunt.',
+    labels: [{ text: 'Fair point.', goto: null }]
+  },
+  7: {
+    text: 'It might open a path for those who prefer to stay unseen...',
+    labels: [{ text: 'I\u2019ll keep that in mind.', goto: null }]
+  }
+};

--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -38,7 +38,7 @@ export function renderGrid(
         type = cell.classType[cls];
       }
 
-      if (type === 'N' && cell.style === 'advanced') {
+      if (type === 'N' && (cell.style === 'advanced' || cell.advanced)) {
         type = 'n';
       }
 

--- a/scripts/npc/snealer.js
+++ b/scripts/npc/snealer.js
@@ -1,21 +1,6 @@
-export const snealer = {
-  id: 'snealer',
-  name: 'Snealer',
-  description: 'A cloaked figure with a sly grin and watchful eyes.',
-  style: 'advanced',
-  portrait: '⚪', // Advanced NPC (white circle)
-  dialogue: {
-    start: {
-      text: 'Psst... not all treasures are in chests, you know.',
-      options: [
-        { text: 'What do you mean?', next: 'hint' },
-        { text: 'I\u2019m not interested.', next: null }
-      ]
-    },
-    hint: {
-      text: 'Some secrets lie where footsteps vanish...'
-    }
-  }
-};
+import { startDialogueTree } from '../dialogueSystem.js';
+import snealerDialogue from '../dialogue/npcs/snealer.js';
 
-export default snealer;
+export function interact() {
+  startDialogueTree(snealerDialogue);
+}


### PR DESCRIPTION
## Summary
- add new advanced Snealer NPC to map01
- create full dialogue for Snealer
- support `advanced: true` NPC tiles
- add shadow_token key item
- connect Snealer NPC script to the new dialogue

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b585c81708331ac258273634ac170