### PR TITLE
Add shadow_token item data

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -177,11 +177,12 @@
   },
   "shadow_token": {
     "name": "Shadow Token",
-    "description": "A dark token that seems to absorb light.",
+    "description": "A strange obsidian token said to whisper in the dark. It may open unseen doors.",
     "type": "key",
     "stackLimit": 1,
-    "icon": "🗝️",
-    "category": "key"
+    "icon": "🕳️",
+    "category": "key",
+    "consumable": false
   },
   "defense_potion_I": {
     "name": "Defense Potion I",

--- a/versions/v0.7.3/data/items.json
+++ b/versions/v0.7.3/data/items.json
@@ -410,5 +410,14 @@
     "icon": "✨",
     "category": "key",
     "consumable": false
+  },
+  "shadow_token": {
+    "name": "Shadow Token",
+    "type": "key",
+    "description": "A strange obsidian token said to whisper in the dark. It may open unseen doors.",
+    "icon": "🕳️",
+    "stackLimit": 1,
+    "category": "key",
+    "consumable": false
   }
 }


### PR DESCRIPTION
## Summary
- define non-consumable **shadow_token** key item
- propagate the new item to versioned data

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5c3fe9a48331ae0ac9cd29fe2d9e