### PR TITLE
Implement multi-unit combat support

### DIFF
--- a/scripts/combat_engine.js
+++ b/scripts/combat_engine.js
@@ -1,4 +1,9 @@
-import { combatState, generateTurnQueue } from './combat_state.js';
+import {
+  combatState,
+  generateTurnQueue,
+  livingPlayers,
+  livingEnemies
+} from './combat_state.js';
 
 export function initTurnOrder() {
   generateTurnQueue();
@@ -8,7 +13,8 @@ export function initTurnOrder() {
 
 export function nextTurn() {
   if (combatState.activeEntity) {
-    combatState.turnQueue.push(combatState.activeEntity);
+    if (combatState.activeEntity.hp > 0)
+      combatState.turnQueue.push(combatState.activeEntity);
   }
   if (combatState.turnQueue.length === 0) {
     generateTurnQueue();
@@ -16,4 +22,12 @@ export function nextTurn() {
   }
   combatState.activeEntity = combatState.turnQueue.shift() || null;
   return combatState.activeEntity;
+}
+
+export function checkCombatEnd() {
+  const allEnemiesDefeated = livingEnemies().every((e) => e.hp <= 0);
+  const allPlayersDefeated = livingPlayers().every((p) => p.hp <= 0);
+  if (allEnemiesDefeated) return 'victory';
+  if (allPlayersDefeated) return 'defeat';
+  return null;
 }

--- a/scripts/combat_state.js
+++ b/scripts/combat_state.js
@@ -3,7 +3,8 @@ export const combatState = {
   players: [],
   enemies: [],
   turnQueue: [],
-  activeEntity: null
+  activeEntity: null,
+  selectedTarget: null
 };
 
 export function initCombatState(player, enemy) {
@@ -12,10 +13,13 @@ export function initCombatState(player, enemy) {
   combatState.enemies = Array.isArray(enemy) ? enemy : [enemy];
   combatState.turnQueue = [];
   combatState.activeEntity = null;
+  combatState.selectedTarget = null;
 }
 
 export function generateTurnQueue() {
-  const all = [...combatState.players, ...combatState.enemies];
+  const livingPlayers = combatState.players.filter((p) => p.hp > 0);
+  const livingEnemies = combatState.enemies.filter((e) => e.hp > 0);
+  const all = [...livingPlayers, ...livingEnemies];
   all.sort((a, b) => (b.stats?.speed ?? 0) - (a.stats?.speed ?? 0));
   combatState.turnQueue = all.slice();
 }
@@ -26,4 +30,20 @@ export function getPlayer() {
 
 export function getEnemy() {
   return combatState.enemies[0] || null;
+}
+
+export function selectTarget(entity) {
+  combatState.selectedTarget = entity;
+}
+
+export function getSelectedTarget() {
+  return combatState.selectedTarget;
+}
+
+export function livingPlayers() {
+  return combatState.players.filter((p) => p.hp > 0);
+}
+
+export function livingEnemies() {
+  return combatState.enemies.filter((e) => e.hp > 0);
 }

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -2,6 +2,58 @@ import { getStatusEffect } from './status_effects.js';
 import { getStatusList } from './statusManager.js';
 import { attachTooltip } from '../ui/skillsPanel.js';
 
+export function renderCombatants(root, players = [], enemies = [], onSelect) {
+  if (!root) return;
+  root.innerHTML = '';
+  const container = document.createElement('div');
+  container.className = 'combatants';
+  const playerSide = document.createElement('div');
+  playerSide.className = 'player-team';
+  const enemySide = document.createElement('div');
+  enemySide.className = 'enemy-team';
+
+  players.forEach((p, idx) => {
+    const el = createCombatantEl(p, true, idx);
+    playerSide.appendChild(el);
+  });
+  enemies.forEach((e, idx) => {
+    const el = createCombatantEl(e, false, idx);
+    if (typeof onSelect === 'function') {
+      el.classList.add('selectable');
+      el.addEventListener('click', () => onSelect(e, idx, el));
+    }
+    enemySide.appendChild(el);
+  });
+
+  container.appendChild(playerSide);
+  container.appendChild(enemySide);
+  root.appendChild(container);
+}
+
+function createCombatantEl(entity, isPlayer, index) {
+  const wrapper = document.createElement('div');
+  wrapper.className = `combatant ${isPlayer ? 'player' : 'enemy'}`;
+  wrapper.dataset.index = index;
+  if (entity.portrait) {
+    const portrait = document.createElement('div');
+    portrait.className = 'portrait';
+    portrait.textContent = entity.portrait;
+    wrapper.appendChild(portrait);
+  }
+  const name = document.createElement('div');
+  name.className = 'name';
+  name.textContent = entity.name || (isPlayer ? 'Player' : 'Enemy');
+  wrapper.appendChild(name);
+  const hpBar = document.createElement('div');
+  hpBar.className = 'hp-bar';
+  hpBar.innerHTML = '<div class="hp"></div>';
+  wrapper.appendChild(hpBar);
+  const status = document.createElement('div');
+  status.className = 'statuses status-effects';
+  wrapper.appendChild(status);
+  return wrapper;
+}
+
 export function setupTabs(overlay) {
   const offContainer = overlay.querySelector('.offensive-skill-buttons');
   const defContainer = overlay.querySelector('.defensive-skill-buttons');

--- a/scripts/enemy_ai.js
+++ b/scripts/enemy_ai.js
@@ -7,8 +7,11 @@ export function chooseEnemySkill(entity) {
   return list[0] || null;
 }
 
-export function enemyAct(entity, player, context) {
+export function enemyAct(entity, players, context) {
+  const target = Array.isArray(players)
+    ? players.find((p) => p.hp > 0) || players[0]
+    : players;
   const skill = chooseEnemySkill(entity);
-  if (!skill) return;
-  skill.effect({ enemy: entity, player, ...context });
+  if (!skill || !target) return;
+  skill.effect({ user: entity, target, ...context });
 }

--- a/scripts/skill_engine.js
+++ b/scripts/skill_engine.js
@@ -1,0 +1,4 @@
+export function executeSkill(skill, user, target, context = {}) {
+  if (!skill || typeof skill.effect !== 'function') return;
+  return skill.effect({ user, target, ...context });
+}


### PR DESCRIPTION
## Summary
- render combatants dynamically for multiple players and enemies
- track target selection and living combatants in state
- update combat engine for multi-unit turn order and victory checks
- add simple skill engine with user/target parameters
- have enemies target the first living player

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b66b5e3f083318d19ea6d05aeab3b