### PR TITLE
Support multi ally combat

### DIFF
--- a/scripts/combat_engine.js
+++ b/scripts/combat_engine.js
@@ -7,20 +7,20 @@ import {
 
 export function initTurnOrder() {
   generateTurnQueue();
-  combatState.activeEntity = combatState.turnQueue.shift() || null;
+  combatState.turnIndex = 0;
+  combatState.activeEntity = combatState.turnQueue[0] || null;
   return combatState.activeEntity;
 }
 
 export function nextTurn() {
-  if (combatState.activeEntity) {
-    if (combatState.activeEntity.hp > 0)
-      combatState.turnQueue.push(combatState.activeEntity);
-  }
-  if (combatState.turnQueue.length === 0) {
+  combatState.turnIndex += 1;
+  if (combatState.turnIndex >= combatState.turnQueue.length) {
     generateTurnQueue();
+    combatState.turnIndex = 0;
     combatState.round += 1;
   }
-  combatState.activeEntity = combatState.turnQueue.shift() || null;
+  combatState.activeEntity =
+    combatState.turnQueue[combatState.turnIndex] || null;
   return combatState.activeEntity;
 }
 

--- a/scripts/combat_state.js
+++ b/scripts/combat_state.js
@@ -3,6 +3,7 @@ export const combatState = {
   players: [],
   enemies: [],
   turnQueue: [],
+  turnIndex: 0,
   activeEntity: null,
   selectedTarget: null
 };
@@ -12,6 +13,7 @@ export function initCombatState(player, enemy) {
   combatState.players = Array.isArray(player) ? player : [player];
   combatState.enemies = Array.isArray(enemy) ? enemy : [enemy];
   combatState.turnQueue = [];
+  combatState.turnIndex = 0;
   combatState.activeEntity = null;
   combatState.selectedTarget = null;
 }
@@ -30,6 +32,10 @@ export function getPlayer() {
 
 export function getEnemy() {
   return combatState.enemies[0] || null;
+}
+
+export function getActiveEntity() {
+  return combatState.activeEntity;
 }
 
 export function selectTarget(entity) {

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -54,6 +54,18 @@ function createCombatantEl(entity, isPlayer, index) {
   return wrapper;
 }
 
+export function highlightActing(root, isPlayer, index) {
+  if (!root) return;
+  const group = root.querySelectorAll(
+    isPlayer ? '.player-team .combatant' : '.enemy-team .combatant'
+  );
+  group.forEach((el) => {
+    const match = Number(el.dataset.index) === index;
+    if (match) el.classList.add('acting');
+    else el.classList.remove('acting');
+  });
+}
+
 export function setupTabs(overlay) {
   const offContainer = overlay.querySelector('.offensive-skill-buttons');
   const defContainer = overlay.querySelector('.defensive-skill-buttons');

--- a/scripts/enemy_ai.js
+++ b/scripts/enemy_ai.js
@@ -15,3 +15,7 @@ export function enemyAct(entity, players, context) {
   if (!skill || !target) return;
   skill.effect({ user: entity, target, ...context });
 }
+
+export function takeTurn(entity, players, context) {
+  enemyAct(entity, players, context);
+}

--- a/scripts/player_input.js
+++ b/scripts/player_input.js
@@ -1,0 +1,15 @@
+export const pendingInputs = new Map();
+
+export function waitForPlayerInput(player) {
+  return new Promise((resolve) => {
+    pendingInputs.set(player, resolve);
+  });
+}
+
+export function submitPlayerInput(player, skill, target) {
+  const cb = pendingInputs.get(player);
+  if (cb) {
+    pendingInputs.delete(player);
+    cb({ skill, target });
+  }
+}

--- a/style/combat.css
+++ b/style/combat.css
@@ -218,6 +218,11 @@
   animation: damageFlash 0.3s;
 }
 
+#battle-overlay .combatant.acting {
+  outline: 2px solid #ff0;
+  outline-offset: 2px;
+}
+
 @keyframes damageFlash {
   from {
     background: #fff;


### PR DESCRIPTION
## Summary
- track turn index and active entity in combat state
- process round queue in combat engine
- expose AI turn helper
- highlight current actor in combat UI
- add simple player input helper
- style active combatant indicator

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b69bf706c833191425592717690bf