### PR TITLE
Implement speed-based initiative

### DIFF
--- a/scripts/combat_state.js
+++ b/scripts/combat_state.js
@@ -22,7 +22,11 @@ export function generateTurnQueue() {
   const livingPlayers = combatState.players.filter((p) => p.hp > 0);
   const livingEnemies = combatState.enemies.filter((e) => e.hp > 0);
   const all = [...livingPlayers, ...livingEnemies];
-  all.sort((a, b) => (b.stats?.speed ?? 0) - (a.stats?.speed ?? 0));
+  all.sort((a, b) => {
+    const diff = (b.stats?.speed ?? 0) - (a.stats?.speed ?? 0);
+    if (diff !== 0) return diff;
+    return Math.random() < 0.5 ? -1 : 1;
+  });
   combatState.turnQueue = all.slice();
 }
 

--- a/scripts/enemy.js
+++ b/scripts/enemy.js
@@ -33,7 +33,12 @@ export function initEnemyState(enemy) {
   if (!Array.isArray(enemy.statuses)) enemy.statuses = [];
   if (typeof enemy.tempDefense !== 'number') enemy.tempDefense = 0;
   if (typeof enemy.tempAttack !== 'number') enemy.tempAttack = 0;
-  if (!enemy.stats) enemy.stats = { attack: 0, defense: 0, speed: 8 };
-  if (typeof enemy.stats.speed !== 'number') enemy.stats.speed = 8;
+  if (!enemy.stats) enemy.stats = { attack: 0, defense: 0 };
+  if (typeof enemy.stats.speed !== 'number') {
+    let base = 5;
+    if (enemy.boss) base = 4;
+    else if (enemy.type === 'elite') base = 7;
+    enemy.stats.speed = base;
+  }
   enemy.isPlayer = false;
 }

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -41,7 +41,7 @@ export const player = {
   stats: {
     attack: 0,
     defense: 0,
-    speed: 10
+    speed: 6
   },
   equipment: {
     weapon: null,
@@ -64,7 +64,7 @@ export function calculateStatsFromLevel(level) {
   const maxHp = 100 + lvl * 2 + milestoneHp;
   const attack = 15 + Math.floor(lvl / 5);
   const defense = Math.floor(lvl / 10);
-  const speed = 10;
+  const speed = 6;
   return { maxHp, defense, attack, speed };
 }
 
@@ -73,10 +73,10 @@ export function updateStatsFromLevel() {
   player.maxHp = maxHp;
   player.atk = attack;
   player.def = defense;
-  if (!player.stats) player.stats = { attack: 0, defense: 0, speed: 10 };
+  if (!player.stats) player.stats = { attack: 0, defense: 0, speed: 6 };
   player.stats.defense = 0;
   player.stats.attack = 0;
-  if (typeof player.stats.speed !== 'number') player.stats.speed = 10;
+  if (typeof player.stats.speed !== 'number') player.stats.speed = 6;
   if (player.hp > player.maxHp) player.hp = player.maxHp;
 }
 
@@ -245,7 +245,8 @@ export function serializePlayer() {
     xpToNextLevel: player.xpToNextLevel,
     stats: {
       attack: player.stats?.attack || 0,
-      defense: player.stats?.defense || 0
+      defense: player.stats?.defense || 0,
+      speed: player.stats?.speed ?? 6
     },
     learnedSkills: Array.isArray(player.learnedSkills)
       ? [...player.learnedSkills]
@@ -262,9 +263,10 @@ export function deserializePlayer(data) {
   player.xp = data.xp ?? player.xp;
   player.xpToNextLevel = data.xpToNextLevel ?? player.xpToNextLevel;
   if (data.stats) {
-    if (!player.stats) player.stats = { attack: 0, defense: 0 };
+    if (!player.stats) player.stats = { attack: 0, defense: 0, speed: 6 };
     player.stats.attack = data.stats.attack ?? player.stats.attack;
     player.stats.defense = data.stats.defense ?? player.stats.defense;
+    player.stats.speed = data.stats.speed ?? player.stats.speed;
   }
   // derived stats will be recalculated from the level
   if (Array.isArray(data.learnedSkills)) {
@@ -287,7 +289,7 @@ export function getTotalStats() {
   const base = {
     attack: (player.atk || 0) + (player.stats?.attack || 0),
     defense: (player.def || 0) + (player.stats?.defense || 0),
-    speed: player.stats?.speed ?? 10
+    speed: player.stats?.speed ?? 6
   };
   const total = { ...base };
   const eq = player.equipment || {};

--- a/scripts/player_stats.js
+++ b/scripts/player_stats.js
@@ -1,5 +1,5 @@
 export const basePlayerStats = {
   attack: 0,
   defense: 0,
-  speed: 10
+  speed: 6
 };


### PR DESCRIPTION
## Summary
- add `speed` stat to players and enemies
- base player speed is now `6`
- assign default enemy speeds based on type
- generate turn order using speed with random tie breaks
- persist speed in player save data

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b746ecdd08331bd71cf2155b34c0f