### PR TITLE
Add turn queue display and active tile highlight

### DIFF
--- a/scripts/combat_engine.js
+++ b/scripts/combat_engine.js
@@ -4,6 +4,7 @@ import {
   livingPlayers,
   livingEnemies
 } from './combat_state.js';
+import { markActiveTile } from './grid_renderer.js';
 import { selectTarget, getSelectedTarget } from './combat_state.js';
 import { tickStatuses } from './status_effects.js';
 import { executeSkill } from './skill_engine.js';
@@ -12,6 +13,10 @@ export function initTurnOrder() {
   generateTurnQueue();
   combatState.turnIndex = 0;
   combatState.activeEntity = combatState.turnQueue[0] || null;
+  markActiveTile(combatState.activeEntity);
+  document.dispatchEvent(
+    new CustomEvent('turnStarted', { detail: combatState.activeEntity })
+  );
   return combatState.activeEntity;
 }
 
@@ -27,6 +32,10 @@ export function nextTurn() {
   }
   combatState.activeEntity =
     combatState.turnQueue[combatState.turnIndex] || null;
+  markActiveTile(combatState.activeEntity);
+  document.dispatchEvent(
+    new CustomEvent('turnStarted', { detail: combatState.activeEntity })
+  );
   return combatState.activeEntity;
 }
 

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -101,6 +101,28 @@ export function enableEnemyTargeting(root, onSelect) {
   });
 }
 
+function getTurnLabel(unit) {
+  if (!unit) return '';
+  if (unit.isPlayer) return `🧍 ${unit.name || 'Player'}`;
+  if (unit.isAlly) return unit.icon || unit.name || 'Ally';
+  return `${unit.name || 'Enemy'} ${unit.portrait || '👾'}`;
+}
+
+export function renderTurnQueue(container, queue = [], active, index = 0) {
+  if (!container) return;
+  container.innerHTML = '';
+  if (!Array.isArray(queue) || queue.length === 0) return;
+  const len = queue.length;
+  for (let i = 0; i < Math.min(len, 5); i++) {
+    const unit = queue[(index + i) % len];
+    const box = document.createElement('div');
+    box.className = 'turn-box';
+    box.textContent = getTurnLabel(unit);
+    if (unit === active) box.classList.add('active');
+    container.appendChild(box);
+  }
+}
+
 export function setupTabs(overlay) {
   const offContainer = overlay.querySelector('.offensive-skill-buttons');
   const defContainer = overlay.querySelector('.defensive-skill-buttons');

--- a/scripts/grid_renderer.js
+++ b/scripts/grid_renderer.js
@@ -1,0 +1,19 @@
+export function markActiveTile(entity) {
+  const grid = document.getElementById('game-grid');
+  if (!grid) return;
+  grid.querySelectorAll('.tile.active-turn').forEach((t) =>
+    t.classList.remove('active-turn')
+  );
+  if (!entity) return;
+  const selector = `.tile[data-x="${entity.x}"][data-y="${entity.y}"]`;
+  const tile = grid.querySelector(selector);
+  if (tile) tile.classList.add('active-turn');
+}
+
+export function clearActiveTile() {
+  const grid = document.getElementById('game-grid');
+  if (!grid) return;
+  grid.querySelectorAll('.tile.active-turn').forEach((t) =>
+    t.classList.remove('active-turn')
+  );
+}

--- a/style/combat.css
+++ b/style/combat.css
@@ -236,3 +236,38 @@
     background: #e74c3c;
   }
 }
+
+#battle-overlay .turn-queue {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+  flex-wrap: nowrap;
+}
+
+#battle-overlay .turn-queue .turn-box {
+  padding: 4px 8px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.5);
+  white-space: nowrap;
+}
+
+#battle-overlay .turn-queue .turn-box.active {
+  outline: 2px solid #ff0;
+  outline-offset: 2px;
+}
+
+.tile.active-turn {
+  outline: 2px solid #ff0;
+  outline-offset: -2px;
+}
+
+@media (max-width: 600px) {
+  #battle-overlay .turn-queue {
+    overflow-x: auto;
+  }
+  #battle-overlay .turn-queue .turn-box {
+    font-size: 12px;
+    padding: 2px 6px;
+  }
+}


### PR DESCRIPTION
## Summary
- render turn order queue in the combat overlay
- highlight the current acting unit both in the queue and on the grid
- update combat engine to dispatch turn events
- style turn order boxes and tile highlighting

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b767685bc8331b7748749c66eb147