### PR TITLE
Implement combat target highlighting

### DIFF
--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -1,6 +1,7 @@
 import { getStatusEffect } from './status_effects.js';
 import { getStatusList } from './statusManager.js';
 import { attachTooltip } from '../ui/skillsPanel.js';
+import { highlightTiles, clearHighlightedTiles } from './grid_renderer.js';
 
 export function renderCombatants(root, players = [], enemies = [], onSelect) {
   if (!root) return;
@@ -99,6 +100,27 @@ export function enableEnemyTargeting(root, onSelect) {
     const handler = () => onSelect?.(idx, el);
     el.addEventListener('click', handler, { once: true });
   });
+}
+
+export function highlightSkillTargets(skill, actor, players, enemies, onSelect) {
+  const type = skill.targetType || 'enemy';
+  let targets = [];
+  if (type === 'self') {
+    targets = [actor];
+  } else if (type === 'enemy') {
+    targets = actor.isPlayer ? enemies : players;
+  } else if (type === 'ally') {
+    targets = (actor.isPlayer ? players : enemies).filter((t) => t !== actor);
+  } else if (type === 'allEnemies') {
+    targets = actor.isPlayer ? enemies : players;
+  } else if (type === 'allAllies') {
+    targets = actor.isPlayer ? players : enemies;
+  }
+  highlightTiles(targets, onSelect);
+}
+
+export function clearSkillTargetHighlights() {
+  clearHighlightedTiles();
 }
 
 function getTurnLabel(unit) {

--- a/scripts/enemy_ai.js
+++ b/scripts/enemy_ai.js
@@ -41,16 +41,16 @@ export function chooseEnemySkill(entity) {
   return list[0] || null;
 }
 
-export function enemyAct(entity, players, context) {
+export async function enemyAct(entity, players, context) {
   const target = chooseTarget(players, entity.behavior);
   const skill = chooseEnemySkill(entity);
   if (!skill || !target) return;
   recordSkill(skill.id);
   recordTarget(target);
   logAction(entity, skill, target);
-  executeAction(skill, entity, target);
+  await executeAction(skill, entity, target);
 }
 
-export function takeTurn(entity, players, context) {
-  enemyAct(entity, players, context);
+export async function takeTurn(entity, players, context) {
+  await enemyAct(entity, players, context);
 }

--- a/scripts/grid_renderer.js
+++ b/scripts/grid_renderer.js
@@ -17,3 +17,30 @@ export function clearActiveTile() {
     t.classList.remove('active-turn')
   );
 }
+
+export function highlightTiles(entities = [], onClick) {
+  const grid = document.getElementById('game-grid');
+  if (!grid) return;
+  const list = Array.isArray(entities) ? entities : [entities];
+  list.forEach((e) => {
+    if (!e) return;
+    const selector = `.tile[data-x="${e.x}"][data-y="${e.y}"]`;
+    const tile = grid.querySelector(selector);
+    if (!tile) return;
+    tile.classList.add('highlight-tile');
+    if (typeof onClick === 'function') {
+      tile.classList.add('clickable-target');
+      tile.addEventListener('click', () => onClick(e), { once: true });
+    }
+  });
+}
+
+export function clearHighlightedTiles() {
+  const grid = document.getElementById('game-grid');
+  if (!grid) return;
+  grid.querySelectorAll('.tile.highlight-tile').forEach((tile) => {
+    tile.classList.remove('highlight-tile', 'clickable-target');
+    const clone = tile.cloneNode(true);
+    tile.replaceWith(clone);
+  });
+}

--- a/scripts/turn_handler.js
+++ b/scripts/turn_handler.js
@@ -23,10 +23,10 @@ export function chooseTarget(entity) {
   selectTarget(entity);
 }
 
-export function resolveTurn(skillObj) {
+export async function resolveTurn(skillObj) {
   const actor = combatState.activeEntity;
   const target = getSelectedTarget();
   if (!actor || !skillObj) return;
-  executeAction(skillObj, actor);
+  await executeAction(skillObj, actor);
   currentTurn.target = target?.id || null;
 }

--- a/style/combat.css
+++ b/style/combat.css
@@ -262,6 +262,16 @@
   outline-offset: -2px;
 }
 
+.tile.highlight-tile {
+  outline: 2px solid #0ff;
+  outline-offset: -2px;
+  box-shadow: 0 0 6px rgba(0, 255, 255, 0.8);
+}
+
+.clickable-target {
+  cursor: pointer;
+}
+
 @media (max-width: 600px) {
   #battle-overlay .turn-queue {
     overflow-x: auto;


### PR DESCRIPTION
## Summary
- highlight valid tiles for skills on grid
- add skill target highlighting helpers
- wait for player click on target when executing actions
- support async execution for AI and player turns
- style highlighted tiles in combat

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b79b34f8883318be5ac6d6de5735c