### PR TITLE
Add combat log panel and skill preview

### DIFF
--- a/scripts/combat_engine.js
+++ b/scripts/combat_engine.js
@@ -6,7 +6,10 @@ import {
 } from './combat_state.js';
 import { markActiveTile } from './grid_renderer.js';
 import { selectTarget, getSelectedTarget } from './combat_state.js';
-import { highlightSkillTargets, clearSkillTargetHighlights } from './combat_ui.js';
+import {
+  highlightSkillTargets,
+  clearSkillTargetHighlights
+} from './combat_ui.js';
 import { tickStatuses } from './status_effects.js';
 import { executeSkill } from './skill_engine.js';
 
@@ -87,10 +90,24 @@ export async function executeAction(skill, actor, targetOverride, extra = {}) {
   const targets = getTargets(targetType, actor);
   const selected = targetOverride || getSelectedTarget();
   let target = selected && targets.includes(selected) ? selected : null;
-  if (!target && actor.isPlayer && targets.length > 1 && targetType !== 'self' && targetType !== 'allEnemies' && targetType !== 'allAllies') {
+  if (
+    !target &&
+    actor.isPlayer &&
+    targets.length > 1 &&
+    targetType !== 'self' &&
+    targetType !== 'allEnemies' &&
+    targetType !== 'allAllies'
+  ) {
     target = await waitForTarget(skill, actor);
   }
   if (!target) target = targets[0];
   if (target) selectTarget(target);
   executeSkill(skill, actor, target, { actor, target, ...extra });
+  const message =
+    `${actor.name} uses ${skill.name}` + (target ? ` on ${target.name}` : '');
+  document.dispatchEvent(
+    new CustomEvent('combatEvent', {
+      detail: { type: 'skill', actor, skill, target, message }
+    })
+  );
 }

--- a/scripts/combat_renderer.js
+++ b/scripts/combat_renderer.js
@@ -1,0 +1,41 @@
+let previewEl = null;
+let cooldownFn = () => 0;
+
+function formatTarget(type) {
+  if (!type) return 'Enemy';
+  const map = {
+    self: 'Self',
+    enemy: 'Enemy',
+    allEnemies: 'All Enemies',
+    allAllies: 'All Allies',
+    ally: 'Ally'
+  };
+  return map[type] || type;
+}
+
+export function initSkillPreview(overlay, getCooldown) {
+  previewEl = overlay.querySelector('#skill-preview');
+  cooldownFn = typeof getCooldown === 'function' ? getCooldown : () => 0;
+}
+
+export function showSkillPreview(skill) {
+  if (!previewEl || !skill) return;
+  const remaining = cooldownFn(skill.id) || 0;
+  const effects = Array.isArray(skill.statuses)
+    ? skill.statuses.map((s) => s.id).join(', ')
+    : '';
+  previewEl.innerHTML = `\
+    <strong>${skill.icon ? skill.icon + ' ' : ''}${skill.name}</strong>\
+    <div class="desc">${skill.description}</div>\
+    <div class="meta">Cooldown: ${skill.cooldown || 0}${remaining ? ` (Remaining: ${remaining})` : ''}</div>\
+    <div class="meta">Target: ${formatTarget(skill.targetType)}</div>\
+    ${effects ? `<div class="meta">Effects: ${effects}</div>` : ''}\
+  `;
+  previewEl.classList.remove('hidden');
+}
+
+export function hideSkillPreview() {
+  if (previewEl) {
+    previewEl.classList.add('hidden');
+  }
+}

--- a/style/combat.css
+++ b/style/combat.css
@@ -31,6 +31,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: relative;
 }
 
 #battle-overlay .combatants {
@@ -179,7 +180,8 @@
 }
 
 #battle-overlay .actions.hidden,
-#battle-overlay .log.hidden {
+#battle-overlay .log.hidden,
+#battle-overlay .skill-preview.hidden {
   display: none;
 }
 
@@ -206,13 +208,40 @@
 
 #battle-overlay .log {
   margin-top: 10px;
-  height: 80px;
+  height: 120px;
   overflow-y: auto;
-  width: 220px;
+  width: 250px;
   font-size: 14px;
   border: 1px solid #555;
   padding: 5px;
   background: rgba(0, 0, 0, 0.3);
+}
+
+#battle-overlay #combat-log .entry.player {
+  color: #6cf;
+}
+#battle-overlay #combat-log .entry.enemy {
+  color: #f66;
+}
+#battle-overlay #combat-log .entry.system {
+  color: #ccc;
+}
+
+#battle-overlay .skill-preview {
+  position: absolute;
+  bottom: 140px;
+  left: 10px;
+  width: 260px;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 6px;
+  font-size: 14px;
+  pointer-events: none;
+}
+#battle-overlay .skill-preview.hidden {
+  display: none;
 }
 
 #battle-overlay .actions button:hover {


### PR DESCRIPTION
## Summary
- expand combat overlay with combat log and skill preview elements
- add skill preview renderer module
- extend combat UI log to colorize and cap entries
- show skill preview on hover
- dispatch combat events from engine

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7bffc4248331a3b03bb2b071fdd2