### PR TITLE
Extend combat with ally skill commands and auto mode

### DIFF
--- a/scripts/ai_logic.js
+++ b/scripts/ai_logic.js
@@ -1,0 +1,16 @@
+export function chooseBestSkill(skills = [], ally, isOnCooldown = () => false) {
+  if (!Array.isArray(skills) || skills.length === 0) return null;
+  const usable = skills.filter((s) => !isOnCooldown(s));
+  if (usable.length === 0) return null;
+  function getType(skill) {
+    if (skill.aiType) return skill.aiType;
+    const id = skill.id?.toLowerCase() || '';
+    const name = skill.name?.toLowerCase() || '';
+    if (id.includes('heal') || name.includes('heal')) return 'healing';
+    if (skill.category === 'defensive') return 'buff';
+    return 'attack';
+  }
+  const order = { healing: 0, buff: 1, attack: 2 };
+  usable.sort((a, b) => (order[getType(a)] || 3) - (order[getType(b)] || 3));
+  return usable[0];
+}

--- a/scripts/combat_engine.js
+++ b/scripts/combat_engine.js
@@ -12,6 +12,8 @@ import {
 } from './combat_ui.js';
 import { tickStatuses } from './status_effects.js';
 import { executeSkill } from './skill_engine.js';
+import { getSkill } from './skills.js';
+import { getEnemySkill } from './enemy_skills.js';
 
 export function initTurnOrder() {
   generateTurnQueue();
@@ -86,6 +88,12 @@ function waitForTarget(skill, actor) {
 }
 
 export async function executeAction(skill, actor, targetOverride, extra = {}) {
+  if (!skill && actor?.selectedSkillId) {
+    skill = actor.isPlayer
+      ? getSkill(actor.selectedSkillId)
+      : getEnemySkill(actor.selectedSkillId);
+  }
+  if (!skill) return;
   const targetType = skill.targetType || 'enemy';
   const targets = getTargets(targetType, actor);
   const selected = targetOverride || getSelectedTarget();

--- a/scripts/combat_state.js
+++ b/scripts/combat_state.js
@@ -5,13 +5,20 @@ export const combatState = {
   turnQueue: [],
   turnIndex: 0,
   activeEntity: null,
-  selectedTarget: null
+  selectedTarget: null,
+  autoBattle: false
 };
 
 export function initCombatState(player, enemy) {
   combatState.round = 1;
   combatState.players = Array.isArray(player) ? player : [player];
   combatState.enemies = Array.isArray(enemy) ? enemy : [enemy];
+  combatState.players.forEach((p) => {
+    p.selectedSkillId = null;
+  });
+  combatState.enemies.forEach((e) => {
+    e.selectedSkillId = null;
+  });
   combatState.turnQueue = [];
   combatState.turnIndex = 0;
   combatState.activeEntity = null;
@@ -56,4 +63,12 @@ export function livingPlayers() {
 
 export function livingEnemies() {
   return combatState.enemies.filter((e) => e.hp > 0);
+}
+
+export function setAutoBattle(value) {
+  combatState.autoBattle = Boolean(value);
+}
+
+export function isAutoBattle() {
+  return combatState.autoBattle;
 }

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -2,6 +2,7 @@ import { getStatusEffect } from './status_effects.js';
 import { getStatusList } from './statusManager.js';
 import { attachTooltip } from '../ui/skillsPanel.js';
 import { highlightTiles, clearHighlightedTiles } from './grid_renderer.js';
+import { combatState } from './combat_state.js';
 
 export function renderCombatants(root, players = [], enemies = [], onSelect) {
   if (!root) return;
@@ -354,4 +355,21 @@ function onCombatEvent(e) {
     const label = actor.isPlayer ? 'player' : 'enemy';
     appendLog(e.detail.message, label);
   }
+}
+
+export function selectSkillForAlly(overlay, ally, skills, onSelect) {
+  return new Promise((resolve) => {
+    if (!overlay || !ally || !Array.isArray(skills)) return resolve(null);
+    const index = combatState.players ? combatState.players.indexOf(ally) : 0;
+    highlightActing(overlay, true, index);
+    const off = overlay.querySelector('.offensive-skill-buttons');
+    const def = overlay.querySelector('.defensive-skill-buttons');
+    const buttons = renderSkillList(off, skills, (skill) => {
+      ally.selectedSkillId = skill.id;
+      if (typeof onSelect === 'function') onSelect(skill);
+      resolve(skill);
+    });
+    renderSkillList(def, [], () => {});
+    setupTabs(overlay);
+  });
 }

--- a/scripts/settings_menu.js
+++ b/scripts/settings_menu.js
@@ -1,0 +1,14 @@
+import { setAutoBattle, isAutoBattle } from './combat_state.js';
+
+export function initSettingsMenu() {
+  const btn = document.getElementById('auto-battle-toggle-settings');
+  if (!btn) return;
+  function update() {
+    btn.textContent = isAutoBattle() ? 'Auto-Battle ON' : 'Auto-Battle OFF';
+  }
+  btn.addEventListener('click', () => {
+    setAutoBattle(!isAutoBattle());
+    update();
+  });
+  update();
+}


### PR DESCRIPTION
## Summary
- track selected skills and auto-battle flag in combat state
- add AI helper to pick best skill
- enable auto-battle toggle in combat UI
- store selected skill when using skills
- execute actor.selectedSkillId if provided
- expose helper to pick ally skills
- stub settings menu hook

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b7f45bfa08331b829fe366c9e9419