### PR TITLE
Add ally switching and combat inspect panel

### DIFF
--- a/scripts/combat_inspect.js
+++ b/scripts/combat_inspect.js
@@ -1,0 +1,51 @@
+import { getAllCombatants } from './combat_state.js';
+import { getStatusEffect } from './status_effects.js';
+import { getStatusList } from './statusManager.js';
+
+export function createInspectPanel() {
+  const panel = document.createElement('div');
+  panel.className = 'inspect-panel collapsed';
+  const toggle = document.createElement('button');
+  toggle.className = 'inspect-toggle';
+  toggle.textContent = '📊 Inspect';
+  panel.appendChild(toggle);
+  const list = document.createElement('div');
+  list.className = 'inspect-list';
+  panel.appendChild(list);
+  toggle.addEventListener('click', () => {
+    panel.classList.toggle('collapsed');
+  });
+
+  function renderEntry(unit) {
+    const wrap = document.createElement('div');
+    wrap.className = 'inspect-entry';
+    const stats = document.createElement('div');
+    const atk = unit.stats?.attack ?? unit.atk ?? 0;
+    const def = unit.stats?.defense ?? unit.def ?? 0;
+    const spd = unit.stats?.speed ?? 0;
+    const hp = `${unit.hp}/${unit.maxHp ?? unit.hp}`;
+    stats.textContent = `${unit.name}: HP ${hp} | ATK ${atk} | DEF ${def} | SPD ${spd}`;
+    wrap.appendChild(stats);
+    const statusWrap = document.createElement('div');
+    statusWrap.className = 'statuses';
+    getStatusList(unit).forEach((s) => {
+      const defn = getStatusEffect(s.id);
+      const span = document.createElement('span');
+      span.className = 'effect';
+      span.title = defn?.description || s.id;
+      const icon = defn?.icon ? `${defn.icon} ` : '';
+      span.textContent = `${icon}${s.remaining}t`;
+      statusWrap.appendChild(span);
+    });
+    wrap.appendChild(statusWrap);
+    return wrap;
+  }
+
+  function update() {
+    list.innerHTML = '';
+    const units = getAllCombatants();
+    units.forEach((u) => list.appendChild(renderEntry(u)));
+  }
+
+  return { panel, update };
+}

--- a/scripts/combat_state.js
+++ b/scripts/combat_state.js
@@ -6,7 +6,9 @@ export const combatState = {
   turnIndex: 0,
   activeEntity: null,
   selectedTarget: null,
-  autoBattle: false
+  autoBattle: false,
+  currentAllyIndex: 0,
+  selectedSkillId: null
 };
 
 export function initCombatState(player, enemy) {
@@ -23,6 +25,8 @@ export function initCombatState(player, enemy) {
   combatState.turnIndex = 0;
   combatState.activeEntity = null;
   combatState.selectedTarget = null;
+  combatState.currentAllyIndex = 0;
+  combatState.selectedSkillId = null;
 }
 
 export function generateTurnQueue() {
@@ -63,6 +67,10 @@ export function livingPlayers() {
 
 export function livingEnemies() {
   return combatState.enemies.filter((e) => e.hp > 0);
+}
+
+export function getAllCombatants() {
+  return [...combatState.players, ...combatState.enemies];
 }
 
 export function setAutoBattle(value) {

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -373,3 +373,34 @@ export function selectSkillForAlly(overlay, ally, skills, onSelect) {
     setupTabs(overlay);
   });
 }
+
+export function renderAllySwitch(overlay, players, onSwitch) {
+  if (!overlay) return;
+  const container = overlay.querySelector('.ally-switch');
+  if (!container) return;
+  container.innerHTML = '';
+  players.forEach((p, idx) => {
+    const div = document.createElement('div');
+    div.className = 'ally-portrait';
+    div.textContent = p.portrait || '🧍';
+    if (idx === combatState.currentAllyIndex) div.classList.add('active');
+    if (!p.selectedSkillId) div.classList.add('pending');
+    div.addEventListener('click', () => {
+      if (combatState.currentAllyIndex !== idx) {
+        combatState.currentAllyIndex = idx;
+        onSwitch?.(idx);
+      }
+    });
+    container.appendChild(div);
+  });
+}
+
+export function showSkillsForCurrentAlly(overlay, players, skillMap) {
+  const idx = combatState.currentAllyIndex || 0;
+  const ally = players[idx];
+  if (!ally) return;
+  const skills = skillMap(ally);
+  selectSkillForAlly(overlay, ally, skills, () => {
+    renderAllySwitch(overlay, players, (i) => showSkillsForCurrentAlly(overlay, players, skillMap));
+  });
+}

--- a/style/combat.css
+++ b/style/combat.css
@@ -310,3 +310,70 @@
     padding: 2px 6px;
   }
 }
+
+#battle-overlay .ally-switch {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+#battle-overlay .ally-portrait {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+#battle-overlay .ally-portrait.active {
+  border-color: #ff0;
+}
+
+#battle-overlay .ally-portrait.pending {
+  box-shadow: 0 0 4px #0ff;
+}
+
+#battle-overlay .inspect-panel {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.7);
+  border: 1px solid #555;
+  padding: 6px;
+  color: #fff;
+  width: 160px;
+  font-size: 12px;
+  max-height: 90%;
+  overflow-y: auto;
+}
+
+#battle-overlay .inspect-panel.collapsed .inspect-list {
+  display: none;
+}
+
+#battle-overlay .inspect-toggle {
+  margin-bottom: 4px;
+  width: 100%;
+}
+
+#battle-overlay .inspect-entry {
+  margin-bottom: 4px;
+}
+
+#battle-overlay .inspect-entry .statuses {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+}
+
+@media (max-width: 600px) {
+  #battle-overlay .inspect-panel {
+    width: 140px;
+    font-size: 10px;
+  }
+}


### PR DESCRIPTION
## Summary
- track `currentAllyIndex` and `selectedSkillId` in combat state
- provide utility `getAllCombatants`
- allow ally portrait switching in combat UI
- add inspect panel component to view combatant stats
- style ally switch bar and inspect panel

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b816cf87483319f269f3c48acd2c9