### PR TITLE
Add target highlighting and combat animations

### DIFF
--- a/scripts/animation_utils.js
+++ b/scripts/animation_utils.js
@@ -1,0 +1,52 @@
+import { showItemTooltip, hideItemTooltip } from './utils.js';
+
+export function highlightTargets(list = [], onClick) {
+  const targets = Array.isArray(list) ? list : [list];
+  targets.forEach((info) => {
+    const el = info.element || info;
+    if (!el) return;
+    el.classList.add('target-highlight');
+    if (onClick) {
+      el.classList.add('clickable-target');
+      el.addEventListener('click', () => onClick(info.entity || info), { once: true });
+    }
+    if (info.tooltip) {
+      const show = () => {
+        showItemTooltip(el, info.tooltip);
+      };
+      const hide = () => hideItemTooltip();
+      el.addEventListener('mouseenter', show);
+      el.addEventListener('mouseleave', hide);
+      el.addEventListener('touchstart', show, { once: true });
+    }
+  });
+}
+
+export function clearTargetHighlights(root = document) {
+  const els = root.querySelectorAll('.target-highlight');
+  els.forEach((el) => {
+    el.classList.remove('target-highlight', 'clickable-target');
+    const clone = el.cloneNode(true);
+    el.replaceWith(clone);
+  });
+}
+
+export function flashElement(el, type = 'hit') {
+  if (!el) return;
+  const cls = type === 'heal' ? 'flash-heal' : 'flash-hit';
+  el.classList.add(cls);
+  setTimeout(() => el.classList.remove(cls), 400);
+}
+
+export function floatTextOver(el, text, opts = {}) {
+  if (!el || !text) return;
+  const div = document.createElement('div');
+  div.className = 'floating-text';
+  if (opts.color) div.style.color = opts.color;
+  div.textContent = text;
+  document.body.appendChild(div);
+  const rect = el.getBoundingClientRect();
+  div.style.left = window.scrollX + rect.left + rect.width / 2 + 'px';
+  div.style.top = window.scrollY + rect.top - 10 + 'px';
+  setTimeout(() => div.remove(), 1200);
+}

--- a/style/combat.css
+++ b/style/combat.css
@@ -297,9 +297,6 @@
   box-shadow: 0 0 6px rgba(0, 255, 255, 0.8);
 }
 
-.clickable-target {
-  cursor: pointer;
-}
 
 @media (max-width: 600px) {
   #battle-overlay .turn-queue {
@@ -376,4 +373,70 @@
     width: 140px;
     font-size: 10px;
   }
+}
+
+.target-highlight {
+  outline: 2px solid var(--highlight-color, #ff5555);
+  box-shadow: 0 0 6px var(--highlight-color, #ff5555);
+  animation: targetPulse 1s infinite alternate;
+}
+
+@keyframes targetPulse {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(1.05);
+  }
+}
+
+.flash-hit {
+  animation: flashHit 0.4s;
+}
+
+.flash-heal {
+  animation: flashHeal 0.4s;
+}
+
+@keyframes flashHit {
+  from {
+    background: rgba(255, 0, 0, 0.6);
+  }
+  to {
+    background: transparent;
+  }
+}
+
+@keyframes flashHeal {
+  from {
+    background: rgba(0, 255, 0, 0.6);
+  }
+  to {
+    background: transparent;
+  }
+}
+
+.floating-text {
+  position: absolute;
+  pointer-events: none;
+  transform: translate(-50%, 0);
+  animation: floatUp 1.2s forwards;
+  font-weight: bold;
+}
+
+@keyframes floatUp {
+  from {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  to {
+    opacity: 0;
+    transform: translate(-50%, -20px);
+  }
+}
+
+.clickable-target {
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
 }


### PR DESCRIPTION
## Summary
- add new animation utils for highlighting and floating text
- show highlight indicators for valid targets when choosing skills
- flash units and float numbers after damage, healing, or status effects
- style highlights and combat feedback

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684b8473f8cc8331a1011f1ae243deb2