### PR TITLE
Add dynamic combat turn queue

### DIFF
--- a/scripts/combat_engine.js
+++ b/scripts/combat_engine.js
@@ -1,9 +1,5 @@
-import {
-  combatState,
-  generateTurnQueue,
-  livingPlayers,
-  livingEnemies
-} from './combat_state.js';
+import { combatState, livingPlayers, livingEnemies } from './combat_state.js';
+import { startRound, nextTurn as queueNextTurn } from './turn_manager.js';
 import { markActiveTile } from './grid_renderer.js';
 import { selectTarget, getSelectedTarget } from './combat_state.js';
 import {
@@ -29,7 +25,7 @@ function getCombatantEl(entity) {
 }
 
 export function initTurnOrder() {
-  generateTurnQueue();
+  startRound();
   combatState.turnIndex = 0;
   combatState.activeEntity = combatState.turnQueue[0] || null;
   markActiveTile(combatState.activeEntity);
@@ -43,14 +39,8 @@ export function nextTurn() {
   if (combatState.activeEntity) {
     tickStatuses(combatState.activeEntity);
   }
-  combatState.turnIndex += 1;
-  if (combatState.turnIndex >= combatState.turnQueue.length) {
-    generateTurnQueue();
-    combatState.turnIndex = 0;
-    combatState.round += 1;
-  }
-  combatState.activeEntity =
-    combatState.turnQueue[combatState.turnIndex] || null;
+  queueNextTurn();
+  combatState.activeEntity = combatState.turnQueue[combatState.turnIndex] || null;
   markActiveTile(combatState.activeEntity);
   document.dispatchEvent(
     new CustomEvent('turnStarted', { detail: combatState.activeEntity })

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -1,5 +1,5 @@
 import { getStatusEffect } from './status_effects.js';
-import { getStatusList } from './statusManager.js';
+import { getStatusList, hasStatus } from './statusManager.js';
 import { attachTooltip } from '../ui/skillsPanel.js';
 import { highlightTiles, clearHighlightedTiles } from './grid_renderer.js';
 import { combatState } from './combat_state.js';
@@ -158,9 +158,7 @@ export function clearSkillTargetHighlights() {
 
 function getTurnLabel(unit) {
   if (!unit) return '';
-  if (unit.isPlayer) return `🧍 ${unit.name || 'Player'}`;
-  if (unit.isAlly) return unit.icon || unit.name || 'Ally';
-  return `${unit.name || 'Enemy'} ${unit.portrait || '👾'}`;
+  return unit.portrait || unit.icon || (unit.isPlayer || unit.isAlly ? '🧍' : '👾');
 }
 
 export function renderTurnQueue(container, queue = [], active, index = 0) {
@@ -168,12 +166,15 @@ export function renderTurnQueue(container, queue = [], active, index = 0) {
   container.innerHTML = '';
   if (!Array.isArray(queue) || queue.length === 0) return;
   const len = queue.length;
-  for (let i = 0; i < Math.min(len, 5); i++) {
+  for (let i = 0; i < len; i++) {
     const unit = queue[(index + i) % len];
     const box = document.createElement('div');
-    box.className = 'turn-box';
+    box.className = 'turn-entry';
     box.textContent = getTurnLabel(unit);
-    if (unit === active) box.classList.add('active');
+    if (unit === active && i === 0) box.classList.add('active');
+    if (unit.hp <= 0 || hasStatus(unit, 'stunned')) {
+      box.classList.add('skipped');
+    }
     container.appendChild(box);
   }
 }

--- a/scripts/turn_manager.js
+++ b/scripts/turn_manager.js
@@ -1,0 +1,31 @@
+import { combatState } from './combat_state.js';
+
+function getSpeed(unit) {
+  return unit?.stats?.spd ?? unit?.stats?.speed ?? 0;
+}
+
+export function startRound() {
+  const activeUnits = [...combatState.players, ...combatState.enemies].filter(
+    (u) => u && u.hp > 0
+  );
+  activeUnits.sort((a, b) => {
+    const diff = getSpeed(b) - getSpeed(a);
+    if (diff !== 0) return diff;
+    if (a.isPlayer && !b.isPlayer) return -1;
+    if (!a.isPlayer && b.isPlayer) return 1;
+    return Math.random() < 0.5 ? -1 : 1;
+  });
+  combatState.turnQueue = activeUnits.slice();
+  combatState.turnIndex = 0;
+  combatState.activeEntity = combatState.turnQueue[0] || null;
+}
+
+export function nextTurn() {
+  combatState.turnIndex += 1;
+  if (combatState.turnIndex >= combatState.turnQueue.length) {
+    startRound();
+    combatState.round += 1;
+  }
+  combatState.activeEntity = combatState.turnQueue[combatState.turnIndex] || null;
+  return combatState.activeEntity;
+}

--- a/style/combat.css
+++ b/style/combat.css
@@ -268,22 +268,41 @@
 
 #battle-overlay .turn-queue {
   display: flex;
-  gap: 6px;
-  margin-bottom: 10px;
-  flex-wrap: nowrap;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 8px;
 }
 
-#battle-overlay .turn-queue .turn-box {
-  padding: 4px 8px;
-  border: 1px solid #555;
-  border-radius: 4px;
+#battle-overlay .turn-entry {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  border: 2px solid #888;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: rgba(0, 0, 0, 0.5);
-  white-space: nowrap;
 }
 
-#battle-overlay .turn-queue .turn-box.active {
-  outline: 2px solid #ff0;
-  outline-offset: 2px;
+#battle-overlay .turn-entry.active {
+  border-color: gold;
+  animation: pulse 1s infinite;
+}
+
+#battle-overlay .turn-entry.skipped {
+  opacity: 0.5;
+  text-decoration: line-through;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
 }
 
 .tile.active-turn {
@@ -302,7 +321,7 @@
   #battle-overlay .turn-queue {
     overflow-x: auto;
   }
-  #battle-overlay .turn-queue .turn-box {
+  #battle-overlay .turn-queue .turn-entry {
     font-size: 12px;
     padding: 2px 6px;
   }


### PR DESCRIPTION
## Summary
- render turn queue as small portraits and highlight active unit
- compute order based on SPD each round
- manage turn queue in new `turn_manager` module
- style the new turn queue elements

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b865657b48331aee34cf571f481f8