### PR TITLE
Implement manual targeting for multi-unit battles

### DIFF
--- a/scripts/combat_engine.js
+++ b/scripts/combat_engine.js
@@ -196,3 +196,22 @@ export async function executeAction(skill, actor, targetOverride, extra = {}) {
     })
   );
 }
+
+export async function startPlayerTurn(unit) {
+  if (!unit) return;
+  const overlay = document.getElementById('battle-overlay');
+  if (!overlay) return;
+  const skillIds = unit.learnedSkills || unit.skills || [];
+  const skills = skillIds
+    .map((id) => (unit.isPlayer ? getSkill(id) : getEnemySkill(id)))
+    .filter(Boolean);
+  const { chooseSkillAndTarget } = await import('./combat_ui.js');
+  const res = await chooseSkillAndTarget(overlay, unit, skills);
+  if (!res || !res.skill) return;
+  await executeAction(res.skill, unit, res.target || null);
+  proceedToNextTurn();
+}
+
+export function proceedToNextTurn() {
+  return nextTurn();
+}

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -433,3 +433,37 @@ export function showSkillsForCurrentAlly(overlay, players, skillMap) {
     );
   });
 }
+
+export function chooseTargetForSkill(skill, actor) {
+  return new Promise((resolve) => {
+    const overlay = document.getElementById('battle-overlay');
+    if (!overlay) return resolve(null);
+    const handler = (entity) => {
+      document.removeEventListener('keydown', esc);
+      clearSkillTargetHighlights();
+      resolve(entity);
+    };
+    const esc = (e) => {
+      if (e.key === 'Escape') {
+        document.removeEventListener('keydown', esc);
+        clearSkillTargetHighlights();
+        resolve(null);
+      }
+    };
+    document.addEventListener('keydown', esc);
+    highlightSkillTargets(
+      skill,
+      actor,
+      combatState.players,
+      combatState.enemies,
+      handler
+    );
+  });
+}
+
+export async function chooseSkillAndTarget(overlay, unit, skillList) {
+  const skill = await selectSkillForAlly(overlay, unit, skillList);
+  if (!skill) return null;
+  const target = await chooseTargetForSkill(skill, unit);
+  return { skill, target };
+}

--- a/scripts/input_handler.js
+++ b/scripts/input_handler.js
@@ -1,0 +1,38 @@
+export const inputHandler = {
+  onSkill: null,
+  onTarget: null,
+  onAlly: null,
+  init() {
+    document.addEventListener('click', (e) => {
+      const skillBtn = e.target.closest('[data-skill-id]');
+      if (skillBtn && this.onSkill) {
+        this.onSkill(skillBtn.dataset.skillId, skillBtn, e);
+        return;
+      }
+      const combatant = e.target.closest('.combatant.selectable');
+      if (combatant && this.onTarget) {
+        const index = Number(combatant.dataset.index);
+        const isPlayer = combatant.closest('.player-team') !== null;
+        this.onTarget({ index, isPlayer, element: combatant }, e);
+        return;
+      }
+      const ally = e.target.closest('.ally-portrait');
+      if (ally && this.onAlly) {
+        const parent = ally.parentElement;
+        const index = Array.prototype.indexOf.call(parent.children, ally);
+        this.onAlly(index, ally, e);
+      }
+    });
+  },
+  setSkillHandler(fn) {
+    this.onSkill = fn;
+  },
+  setTargetHandler(fn) {
+    this.onTarget = fn;
+  },
+  setAllyHandler(fn) {
+    this.onAlly = fn;
+  }
+};
+
+export default inputHandler;

--- a/scripts/player_party.js
+++ b/scripts/player_party.js
@@ -1,0 +1,27 @@
+export const playerParty = {
+  members: [],
+  activeIndex: 0
+};
+
+export function initParty(list = []) {
+  playerParty.members = Array.isArray(list) ? list : [list];
+  playerParty.activeIndex = 0;
+}
+
+export function getActiveMember() {
+  return playerParty.members[playerParty.activeIndex] || null;
+}
+
+export function setActiveIndex(idx) {
+  if (typeof idx === 'number' && idx >= 0 && idx < playerParty.members.length) {
+    playerParty.activeIndex = idx;
+  }
+}
+
+export function nextMember() {
+  if (playerParty.members.length === 0) return null;
+  playerParty.activeIndex = (playerParty.activeIndex + 1) % playerParty.members.length;
+  return getActiveMember();
+}
+
+export default playerParty;

--- a/scripts/turn_manager.js
+++ b/scripts/turn_manager.js
@@ -29,3 +29,7 @@ export function nextTurn() {
   combatState.activeEntity = combatState.turnQueue[combatState.turnIndex] || null;
   return combatState.activeEntity;
 }
+
+export function proceedToNextTurn() {
+  return nextTurn();
+}


### PR DESCRIPTION
## Summary
- add `startPlayerTurn` helper in `combat_engine` to drive skill and target selection
- expose `proceedToNextTurn` from `turn_manager`
- extend combat UI with target selection helpers
- track party members and active ally
- centralize battle input handling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b87bbf2b083318205f475547bfa2f