### PR TITLE
Revamp leveling & simplify skill system

### DIFF
--- a/__tests__/chestPersistence.test.js
+++ b/__tests__/chestPersistence.test.js
@@ -20,10 +20,6 @@ jest.unstable_mockModule('../scripts/player.js', () => ({
   loseHpNonLethal: jest.fn()
 }));
 
-jest.unstable_mockModule('../scripts/skills.js', () => ({
-  unlockSkillsFromItem: jest.fn(() => []),
-  unlockSkillsFromRelic: jest.fn(() => [])
-}));
 
 let openChest,
   isChestOpened,

--- a/__tests__/mazeKeyChest.test.js
+++ b/__tests__/mazeKeyChest.test.js
@@ -20,10 +20,6 @@ jest.unstable_mockModule('../scripts/player.js', () => ({
   loseHpNonLethal: jest.fn()
 }));
 
-jest.unstable_mockModule('../scripts/skills.js', () => ({
-  unlockSkillsFromItem: jest.fn(() => []),
-  unlockSkillsFromRelic: jest.fn(() => [])
-}));
 
 let openChest,
   getItemCount,

--- a/data/items.json
+++ b/data/items.json
@@ -387,14 +387,6 @@
     "icon": "🔥",
     "category": "combat"
   },
-  "ember_prayer_scroll": {
-    "name": "Scroll: Ember Prayer",
-    "description": "Using it teaches the Ember Prayer skill.",
-    "type": "quest",
-    "stackLimit": 1,
-    "icon": "📜",
-    "category": "lore"
-  },
   "prism_fragment": {
     "name": "Prism Fragment",
     "description": "A shimmering piece of condensed prism memory.",

--- a/info/items.js
+++ b/info/items.js
@@ -46,8 +46,6 @@ export const itemDescriptions = {
   crystal_seed: 'Crystal Seed \u2013 essential for future item upgrades.',
   mana_scroll: 'Mana Scroll \u2013 completely refreshes all skill cooldowns.',
   mana_ember: 'Mana Ember \u2013 restores skill energy when used in combat.',
-  ember_prayer_scroll:
-    'Ember Prayer Scroll \u2013 consume to learn the Ember Prayer skill.',
   prism_key:
     'Prism Key \u2013 obtained from Caelen in map06, unlocks the path to the next area.',
   maze_key_1: 'Maze Key 1 \u2013 opens the western maze in the Gatepoint Room.',

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -4,7 +4,6 @@ import { updateInventoryUI } from './inventory_ui.js';
 import { giveRelic, setMemory } from './dialogue_state.js';
 import { getItemData, loadItems } from './item_loader.js';
 import { loseHpNonLethal } from './player.js';
-import { unlockSkillsFromItem, unlockSkillsFromRelic } from './skills.js';
 
 const chestContents = {
   'map01:10,5': {
@@ -122,10 +121,6 @@ const chestContents = {
     item: 'ritual_oil',
     message: 'You find a vial of ritual oil.'
   },
-  'map09_floor01:16,10': {
-    item: 'aegis_invocation_scroll',
-    message: 'You discover a sacred scroll hidden within.'
-  },
   'map09_floor01:15,13': {
     item: 'polished_shard',
     message: 'You uncover a gleaming polished shard.'
@@ -138,10 +133,6 @@ const chestContents = {
     item: 'mana_ember',
     quantity: 1,
     message: 'The chest radiates lingering warmth.'
-  },
-  'map09_floor02:10,14': {
-    item: 'ember_prayer_scroll',
-    message: 'Inside rests a sealed scroll etched in ember.'
   },
   'map09_floor03:4,3': {
     item: 'xp_scroll',
@@ -174,7 +165,6 @@ export async function openChest(id, player) {
   }
   let item = null;
   let items = null;
-  let unlockedSkills = [];
   if (Array.isArray(config.items)) {
     items = [];
     for (const itm of config.items) {
@@ -182,7 +172,6 @@ export async function openChest(id, player) {
       if (data) {
         await giveItem(itm, 1);
         items.push(data);
-        unlockedSkills.push(...unlockSkillsFromItem(itm));
       }
     }
     updateInventoryUI();
@@ -192,17 +181,15 @@ export async function openChest(id, player) {
       const qty = config.quantity || 1;
       await giveItem(config.item, qty);
       updateInventoryUI();
-      unlockedSkills = unlockSkillsFromItem(config.item);
     }
   }
   if (config.relic) {
     giveRelic(config.relic);
-    unlockedSkills.push(...unlockSkillsFromRelic(config.relic));
   }
   if (config.hpLoss && player) {
     loseHpNonLethal(config.hpLoss);
   }
-  return { item, items, message: config.message || null, unlockedSkills };
+  return { item, items, message: config.message || null };
 }
 
 export function setOpenedChests(list) {

--- a/scripts/dialogueSystem.js
+++ b/scripts/dialogueSystem.js
@@ -1,7 +1,7 @@
 import { addItem, removeItem, inventory } from './inventory.js';
 import { updateInventoryUI } from './inventory_ui.js';
 import { loadItems, getItemData } from './item_loader.js';
-import { unlockSkillsFromItem, getAllSkills } from './skills.js';
+import { getAllSkills } from './skills.js';
 import {
   dialogueMemory,
   setMemory,
@@ -239,13 +239,6 @@ export async function startDialogueTree(dialogue, index = 0) {
         if (item) {
           addItem({ ...item, id: opt.give });
           updateInventoryUI();
-          const unlocked = unlockSkillsFromItem(opt.give);
-          unlocked.forEach((id) => {
-            const skill = getAllSkills()[id];
-            if (skill) {
-              showDialogue(`You've learned a new skill: ${skill.name}!`);
-            }
-          });
         }
       }
       if (opt.triggerUpgrade) {

--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -17,9 +17,7 @@ import {
   useManaGem,
   useStaminaDust,
   useReflectPotion,
-  useManaScroll,
-  useAegisInvocationScroll,
-  useEmberPrayerScroll
+  useManaScroll
 } from './item_logic.js';
 import { getItemBonuses } from './item_stats.js';
 import {
@@ -273,12 +271,6 @@ function handleInventoryItemUse(id) {
       return;
     }
     const res = useManaScroll();
-    if (res) used = true;
-  } else if (id === 'aegis_invocation_scroll') {
-    const res = useAegisInvocationScroll();
-    if (res) used = true;
-  } else if (id === 'ember_prayer_scroll') {
-    const res = useEmberPrayerScroll();
     if (res) used = true;
   } else if (typeof data.use === 'function') {
     if (data.inventoryOnly && gameState.inCombat) {

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -548,17 +548,6 @@ export const itemData = {
     stackLimit: 1,
     icon: '💍'
   },
-  aegis_invocation_scroll: {
-    id: 'aegis_invocation_scroll',
-    name: 'Aegis Invocation Scroll',
-    description: 'Using it teaches the Aegis Invocation skill.',
-    type: 'quest',
-    tags: ['lore'],
-    category: 'lore',
-    consumable: true,
-    stackLimit: 1,
-    icon: '📜'
-  },
   ritual_oil: {
     id: 'ritual_oil',
     name: 'Ritual Oil',
@@ -615,17 +604,6 @@ export const itemData = {
     stackLimit: 5,
     icon: '🔥',
     useInCombat: true
-  },
-  ember_prayer_scroll: {
-    id: 'ember_prayer_scroll',
-    name: 'Ember Prayer Scroll',
-    description: 'Using it teaches the Ember Prayer skill.',
-    type: 'quest',
-    tags: ['lore'],
-    category: 'lore',
-    consumable: true,
-    stackLimit: 1,
-    icon: '📜'
   },
   volcanic_slag: {
     id: 'volcanic_slag',

--- a/scripts/item_logic.js
+++ b/scripts/item_logic.js
@@ -66,18 +66,3 @@ export function useManaScroll() {
   return null;
 }
 
-export function useAegisInvocationScroll() {
-  if (consumeItem('aegis_invocation_scroll', 1)) {
-    import('./player.js').then((m) => m.grantSkill('aegisInvocation'));
-    return { learned: true };
-  }
-  return null;
-}
-
-export function useEmberPrayerScroll() {
-  if (consumeItem('ember_prayer_scroll', 1)) {
-    import('./player.js').then((m) => m.grantSkill('emberPrayer'));
-    return { learned: true };
-  }
-  return null;
-}

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -9,7 +9,7 @@ import { unlockPassivesForLevel, getPassive } from './passive_skills.js';
 import { getItemBonuses } from './item_stats.js';
 import { getRelicBonuses } from './relic_state.js';
 import { getClassBonuses, getChosenClass } from './class_state.js';
-import { unlockSkill, getAllSkills } from './skills.js';
+import { getAllSkills } from './skills.js';
 import {
   addItem,
   removeItem as removeInvItem,
@@ -60,23 +60,27 @@ export const player = {
 
 export function calculateStatsFromLevel(level) {
   const lvl = level;
-  const milestoneHp = Math.floor(lvl / 5) * 2 + Math.floor(lvl / 10) * 2;
-  const maxHp = 100 + lvl * 2 + milestoneHp;
+  const bonusHp =
+    (lvl - 1) * 2 +
+    Math.floor(lvl / 5) * 2 +
+    Math.floor(lvl / 10) * 2 +
+    Math.floor(lvl / 15) * 2;
+  const maxHp = 100 + bonusHp;
   const attack = 15 + Math.floor(lvl / 5);
-  const defense = Math.floor(lvl / 10);
-  const speed = 6;
+  const defense = Math.floor(lvl / 10) + Math.floor(lvl / 15);
+  const speed = 6 + Math.floor(lvl / 15);
   return { maxHp, defense, attack, speed };
 }
 
 export function updateStatsFromLevel() {
-  const { maxHp, defense, attack } = calculateStatsFromLevel(player.level);
+  const { maxHp, defense, attack, speed } = calculateStatsFromLevel(player.level);
   player.maxHp = maxHp;
   player.atk = attack;
   player.def = defense;
   if (!player.stats) player.stats = { attack: 0, defense: 0, speed: 6 };
   player.stats.defense = 0;
   player.stats.attack = 0;
-  if (typeof player.stats.speed !== 'number') player.stats.speed = 6;
+  player.stats.speed = speed;
   if (player.hp > player.maxHp) player.hp = player.maxHp;
 }
 
@@ -326,7 +330,8 @@ export function getTotalStats() {
 }
 
 export function grantSkill(id) {
-  if (unlockSkill(id)) {
+  if (!player.learnedSkills.includes(id)) {
+    player.learnedSkills.push(id);
     const skill = getAllSkills()[id];
     if (skill) {
       showDialogue(`You've learned a new skill: ${skill.name}!`);

--- a/scripts/restart.js
+++ b/scripts/restart.js
@@ -10,8 +10,6 @@ export function restartGame() {
     'gridquest.lore_flags',
     'gridquest.class',
     'gridquest.passives',
-    'gridquest.enemySkillSources',
-    'gridquest.skills',
     'gridquest.save'
   ];
   keys.forEach((k) => localStorage.removeItem(k));

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -67,7 +67,6 @@ const skillDefs = {
     category: 'defensive',
     cost: 0,
     cooldown: 0,
-    unlockCondition: { chest: 'map01:11,3' },
     effect({ activateShieldBlock, log }) {
       activateShieldBlock();
       log('A sturdy wall of force surrounds you.');
@@ -83,7 +82,6 @@ const skillDefs = {
     category: 'offensive',
     cost: 0,
     cooldown: 0,
-    unlockCondition: { enemy: 'E' },
     effect({ user, target, log }) {
       if (target) {
         const dmg = 10 + (user?.stats?.attack || 0);
@@ -102,7 +100,6 @@ const skillDefs = {
     category: 'offensive',
     cost: 0,
     cooldown: 0,
-    unlockCondition: { enemy: 'B' },
     effect({ user, target, log }) {
       if (target) {
         const dmg = 20 + (user?.stats?.attack || 0);
@@ -121,7 +118,6 @@ const skillDefs = {
     category: 'offensive',
     cost: 0,
     cooldown: 0,
-    unlockCondition: { enemy: 'S' },
     effect({ user, target, log }) {
       if (target) {
         const dmg = 18 + (user?.stats?.attack || 0);
@@ -140,7 +136,6 @@ const skillDefs = {
     category: 'offensive',
     cost: 0,
     cooldown: 0,
-    unlockCondition: { item: 'ancient_scroll' },
     effect({ user, target, log }) {
       if (target) {
         const dmg = 12 + (user?.stats?.attack || 0);
@@ -193,7 +188,6 @@ const skillDefs = {
     cost: 0,
     cooldown: 7,
     source: 'map09_floor01_chest',
-    unlockCondition: { item: 'aegis_invocation_scroll' },
     effect({ applyStatus, removeNegativeStatus, player, log }) {
       applyStatus(player, 'aegis_barrier', Infinity);
       const removed = removeNegativeStatus(player);
@@ -217,7 +211,6 @@ const skillDefs = {
     cost: 0,
     cooldown: 4,
     source: 'map09_floor02_chest',
-    unlockCondition: { item: 'ember_prayer_scroll' },
     effect({ healPlayer, applyStatus, enemy, player, log }) {
       const amount = Math.floor(player.maxHp * 0.2);
       healPlayer(amount);
@@ -305,99 +298,17 @@ const skillDefs = {
 };
 
 let player = null;
-const enemySkillSources = new Set();
-
-function loadEnemySkillSources() {
-  const json = localStorage.getItem('gridquest.enemySkillSources');
-  if (!json) return [];
-  try {
-    const arr = JSON.parse(json);
-    if (Array.isArray(arr)) return arr;
-    return [];
-  } catch {
-    return [];
-  }
-}
-
-function saveEnemySkillSources(list) {
-  localStorage.setItem('gridquest.enemySkillSources', JSON.stringify(list));
-}
-
-function loadLearnedSkills() {
-  const json = localStorage.getItem('gridquest.skills');
-  if (!json) return [];
-  try {
-    const arr = JSON.parse(json);
-    if (Array.isArray(arr)) return arr;
-    return [];
-  } catch {
-    return [];
-  }
-}
-
-function saveLearnedSkills(list) {
-  localStorage.setItem('gridquest.skills', JSON.stringify(list));
-}
 
 export function initSkillSystem(playerObj) {
   player = playerObj;
   if (!Array.isArray(player.learnedSkills)) {
-    player.learnedSkills = loadLearnedSkills();
+    player.learnedSkills = [];
   }
-  const enemyList = loadEnemySkillSources();
-  enemyList.forEach((id) => enemySkillSources.add(id));
-  // Ensure starting skills are present
   ['strike', 'guard', 'heal'].forEach((id) => {
     if (!player.learnedSkills.includes(id)) {
       player.learnedSkills.push(id);
     }
   });
-  saveLearnedSkills(player.learnedSkills);
-}
-
-export function unlockSkill(id) {
-  if (!player) return false;
-  if (!player.learnedSkills.includes(id)) {
-    player.learnedSkills.push(id);
-    saveLearnedSkills(player.learnedSkills);
-    return true;
-  }
-  return false;
-}
-
-export function isEnemySourceUsed(id) {
-  return enemySkillSources.has(id);
-}
-
-export function markEnemySource(id) {
-  if (!enemySkillSources.has(id)) {
-    enemySkillSources.add(id);
-    saveEnemySkillSources(Array.from(enemySkillSources));
-  }
-}
-
-export function unlockSkillsFromItem(itemId) {
-  const unlocked = [];
-  for (const [id, skill] of Object.entries(skillDefs)) {
-    if (skill.unlockCondition?.item === itemId) {
-      if (unlockSkill(id)) {
-        unlocked.push(id);
-      }
-    }
-  }
-  return unlocked;
-}
-
-export function unlockSkillsFromRelic(relicId) {
-  const unlocked = [];
-  for (const [id, skill] of Object.entries(skillDefs)) {
-    if (skill.unlockCondition?.relic === relicId) {
-      if (unlockSkill(id)) {
-        unlocked.push(id);
-      }
-    }
-  }
-  return unlocked;
 }
 
 export function hasSkill(id) {

--- a/scripts/tile_type.js
+++ b/scripts/tile_type.js
@@ -71,7 +71,7 @@ import { hasItem, removeItem, useKey } from './inventory.js';
 import { updateInventoryUI } from './inventory_ui.js';
 import { getEnemyData } from './enemy.js';
 import { startCombat } from './combatSystem.js';
-import { getAllSkills, unlockSkill } from './skills.js';
+import { getAllSkills } from './skills.js';
 import * as router from './router.js';
 import { transitionToMap } from './transition.js';
 import { enterDoor } from './player.js';
@@ -175,14 +175,6 @@ export async function onInteractEffect(
           } else if (result.item) {
             showDialogue(`You obtained ${result.item.name}!`);
           }
-          if (Array.isArray(result.unlockedSkills)) {
-            result.unlockedSkills.forEach((id) => {
-              const skill = getAllSkills()[id];
-              if (skill) {
-                showDialogue(`You've learned a new skill: ${skill.name}!`);
-              }
-            });
-          }
           const idx = y * cols + x;
           const tileEl = container.children[idx];
           if (tileEl) {
@@ -190,13 +182,6 @@ export async function onInteractEffect(
             tileEl.classList.add('chest-opened', 'tile-c', 'blocked');
           }
           tile.type = 'c';
-          for (const [id, skill] of Object.entries(getAllSkills())) {
-            if (skill.unlockCondition?.chest === chestId) {
-              if (unlockSkill(id)) {
-                showDialogue(`You've learned a new skill: ${skill.name}!`);
-              }
-            }
-          }
         }
       }
       break;


### PR DESCRIPTION
## Summary
- update player level progression to give HP, ATK, DEF and SPD at milestones
- simplify skill system by removing unlock mechanics
- drop skill-granting scrolls and related item logic
- clean up chest and dialogue handling for removed unlocks
- adjust inventory UI and tests for new behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8d4f7fa08331b1341b666b0c1be3