### PR TITLE
Fix enemy turn ordering

### DIFF
--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -185,6 +185,7 @@ export async function startCombat(enemy, player) {
   initCombatState(player, enemy);
   const firstActor = initTurnOrder();
   let playerTurn = firstActor?.isPlayer ?? true;
+  if (!playerTurn) setTimeout(enemyTurn, animDelay);
   player = combatState.players[0];
   enemy = combatState.enemies[0];
   const queueEl = overlay.querySelector('.turn-queue');

--- a/scripts/turn_manager.js
+++ b/scripts/turn_manager.js
@@ -9,11 +9,7 @@ export function startRound() {
     (u) => u && u.hp > 0
   );
   activeUnits.sort((a, b) => {
-    const diff = getSpeed(b) - getSpeed(a);
-    if (diff !== 0) return diff;
-    if (a.isPlayer && !b.isPlayer) return -1;
-    if (!a.isPlayer && b.isPlayer) return 1;
-    return Math.random() < 0.5 ? -1 : 1;
+    return getSpeed(b) - getSpeed(a);
   });
   combatState.turnQueue = activeUnits.slice();
   combatState.turnIndex = 0;


### PR DESCRIPTION
## Summary
- ensure speed sorting is based only on speed
- auto-start enemy turn when they act first

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b908933d483318dcc8bbf3f911bca