### PR TITLE
Fix strike skill damage

### DIFF
--- a/__tests__/strike_damage.test.js
+++ b/__tests__/strike_damage.test.js
@@ -1,0 +1,28 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let getSkill, applyDamage;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ getSkill } = await import('../scripts/skills.js'));
+  ({ applyDamage } = await import('../scripts/logic.js'));
+});
+
+test('strike applies damage equal to attack minus defense', () => {
+  const strike = getSkill('strike');
+  const player = { name: 'Hero', stats: { attack: 10 }, tempAttack: 0 };
+  const enemy = { name: 'Dummy', hp: 20, stats: { defense: 3 } };
+  const logs = [];
+  const log = (msg) => logs.push(msg);
+
+  strike.effect({
+    caster: player,
+    target: enemy,
+    damageTarget: (t, amt) => applyDamage(t, amt),
+    log
+  });
+
+  expect(enemy.hp).toBe(13);
+  expect(logs[0]).toMatch(/Hero.*strikes.*7 damage/i);
+});

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -15,11 +15,27 @@ const skillDefs = {
     cooldown: 0,
     source: 'starter',
     // Basic attack scaled by player ATK
-    effect({ user, target, log }) {
-      if (target) {
-        const dmg = user?.stats?.attack || 0;
-        const applied = applyDamage(target, dmg);
-        log(`${user.name} strikes ${target.name} for ${applied} damage!`);
+    effect(args) {
+      const {
+        caster,
+        target,
+        damageTarget,
+        damageEnemy,
+        player,
+        enemy,
+        log
+      } = args;
+
+      if (damageTarget && caster && target) {
+        const atk = caster.stats?.attack || 0;
+        const dmg = atk + (caster.tempAttack || 0);
+        const applied = damageTarget(target, dmg);
+        log(`${caster.name} strikes for ${applied} damage!`);
+      } else if (typeof damageEnemy === 'function') {
+        const applied = damageEnemy(0);
+        const actorName = player?.name || caster?.name || 'Player';
+        const enemyName = enemy?.name || target?.name || 'Enemy';
+        log(`${actorName} strikes ${enemyName} for ${applied} damage!`);
       }
     }
   },


### PR DESCRIPTION
## Summary
- update Strike skill to use new damageTarget or fallback to damageEnemy
- add strike_damage.test.js to verify strike calculates damage using target defense

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b922434808331a5c31727233faec3