### PR TITLE
Fix rollback module to avoid browser errors

### DIFF
--- a/scripts/rollback.js
+++ b/scripts/rollback.js
@@ -1,7 +1,15 @@
-export function rollbackTo(version) {
-  const fs = require('fs-extra');
-  const path = require('path');
+export async function rollbackTo(version) {
+  // Guard against executing in a browser environment
+  if (typeof window !== 'undefined') {
+    console.warn('Rollback is not supported in the browser.');
+    return;
+  }
 
+  const fsExtra = await import('fs-extra');
+  const path = await import('path');
+
+  const fs = fsExtra.default || fsExtra;
+  const __dirname = path.dirname(new URL(import.meta.url).pathname);
   const base = path.resolve(__dirname, '../');
   const versionPath = path.resolve(__dirname, `../versions/${version}`);
 


### PR DESCRIPTION
## Summary
- guard rollback module so it doesn't run in the browser
- load Node modules dynamically when executed in Node

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `@eslint/js` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b94bb378083319137dcc0469fed01