### PR TITLE
Add setup script for node modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ npm install
 ```
 Run this command before using `npm run lint` or `npm test`.
 
+Alternatively run the helper script which prefers cached packages when
+available:
+
+```bash
+./scripts/setup_dev.sh
+```
+
 ### Available commands
 
 - `npm run lint` – check code with ESLint

--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# setup_dev.sh - install Node.js dependencies
+
+# Use npm ci when node_modules exists, otherwise npm install
+
+set -e
+
+if [ -d node_modules ]; then
+    echo "node_modules already exists, running 'npm ci --prefer-offline' to refresh"
+    npm ci --prefer-offline --no-audit
+else
+    echo "Installing dependencies via 'npm install'"
+    npm install --prefer-offline --no-audit
+fi
+

--- a/versions/v0.7.3/README.md
+++ b/versions/v0.7.3/README.md
@@ -61,6 +61,13 @@ npm install
 ```
 Run this command before using `npm run lint` or `npm test`.
 
+Alternatively run the helper script which prefers cached packages when
+available:
+
+```bash
+./scripts/setup_dev.sh
+```
+
 ### Available commands
 
 - `npm run lint` – check code with ESLint


### PR DESCRIPTION
## Summary
- add `scripts/setup_dev.sh` for installing npm dependencies
- document the setup script in main and historical READMEs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684bfcdd92b883319290b9b0114c2dd3