### PR TITLE
Add core mechanic tests

### DIFF
--- a/__tests__/combatResolution.test.js
+++ b/__tests__/combatResolution.test.js
@@ -1,0 +1,32 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let calculateDamage, applyDamage;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ calculateDamage, applyDamage } = await import('../scripts/logic.js'));
+});
+
+test('calculateDamage handles defense and negative defense multiplier', () => {
+  const normalTarget = { stats: { defense: 3 } };
+  expect(calculateDamage(null, normalTarget, 8)).toBe(5);
+  const negativeTarget = { stats: { defense: -2 } };
+  expect(calculateDamage(null, negativeTarget, 5)).toBe(6);
+});
+
+test('applyDamage reduces hp and absorb correctly', () => {
+  const target = { hp: 10, stats: { defense: 2 }, absorb: 3 };
+  const dmg = applyDamage(target, 8);
+  expect(dmg).toBe(3);
+  expect(target.hp).toBe(7);
+  expect(target.absorb).toBe(0);
+});
+
+test('applyDamage triggers resolve leaving 1 hp', () => {
+  const target = { hp: 4, stats: { defense: 0 }, hasResolve: true };
+  const dmg = applyDamage(target, 10);
+  expect(dmg).toBe(3);
+  expect(target.hp).toBe(1);
+  expect(target.hasResolve).toBe(false);
+});

--- a/__tests__/itemEffects.test.js
+++ b/__tests__/itemEffects.test.js
@@ -1,0 +1,44 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../scripts/inventory.js', () => ({
+  consumeItem: jest.fn()
+}));
+
+let useHealthPotion, useDefensePotion, useArcaneSpark, consumeItem;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ useHealthPotion, useDefensePotion, useArcaneSpark } = await import('../scripts/item_logic.js'));
+  ({ consumeItem } = await import('../scripts/inventory.js'));
+  consumeItem.mockReset();
+});
+
+test('useHealthPotion consumes item and heals', () => {
+  consumeItem.mockReturnValue(true);
+  const result = useHealthPotion();
+  expect(consumeItem).toHaveBeenCalledWith('health_potion', 1);
+  expect(result).toEqual({ heal: 20 });
+});
+
+test('useDefensePotion consumes item and buffs defense', () => {
+  consumeItem.mockReturnValue(true);
+  const result = useDefensePotion();
+  expect(consumeItem).toHaveBeenCalledWith('defense_potion_I', 1);
+  expect(result).toEqual({ defense: 1 });
+});
+
+test('useArcaneSpark deals damage when item available', () => {
+  consumeItem.mockReturnValue(true);
+  const result = useArcaneSpark();
+  expect(consumeItem).toHaveBeenCalledWith('arcane_spark', 1);
+  expect(result).toEqual({ damage: 6 });
+});
+
+
+test('item functions return null when item missing', () => {
+  consumeItem.mockReturnValue(false);
+  expect(useHealthPotion()).toBeNull();
+  expect(useDefensePotion()).toBeNull();
+  expect(useArcaneSpark()).toBeNull();
+});

--- a/__tests__/saveLoad.test.js
+++ b/__tests__/saveLoad.test.js
@@ -1,0 +1,80 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../scripts/game_state.js', () => ({
+  serializeGameState: jest.fn(() => ({ g: 1 })),
+  deserializeGameState: jest.fn(),
+  validateLoadedInventory: jest.fn(),
+  gameState: { currentMap: 'map01' }
+}));
+
+jest.unstable_mockModule('../scripts/inventory_state.js', () => ({
+  serializeInventory: jest.fn(() => ({ items: [] })),
+  inventoryState: { loadFromObject: jest.fn() }
+}));
+
+jest.unstable_mockModule('../scripts/quest_state.js', () => ({
+  serializeQuestState: jest.fn(() => ({ q: 1 })),
+  deserializeQuestState: jest.fn()
+}));
+
+jest.unstable_mockModule('../scripts/player.js', () => ({
+  serializePlayer: jest.fn(() => ({ lvl: 1 })),
+  deserializePlayer: jest.fn(),
+  player: {}
+}));
+
+jest.unstable_mockModule('../ui/inventory_menu.js', () => ({
+  refreshInventoryDisplay: jest.fn()
+}));
+
+jest.unstable_mockModule('../scripts/inventory.js', () => ({
+  inventory: []
+}));
+
+let saveGame, loadGame;
+let game, invState, qState, playerMod;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ saveGame, loadGame } = await import('../scripts/save_load.js'));
+  game = await import('../scripts/game_state.js');
+  invState = await import('../scripts/inventory_state.js');
+  qState = await import('../scripts/quest_state.js');
+  playerMod = await import('../scripts/player.js');
+});
+
+test('saveGame writes data to localStorage', () => {
+  jest.spyOn(Date, 'now').mockReturnValue(1000);
+  saveGame(2);
+  const raw = localStorage.getItem('game_save_slot_2');
+  const data = JSON.parse(raw);
+  expect(data.timestamp).toBe(1000);
+  expect(data.mapName).toBe('map01');
+  expect(data.game).toEqual({ g: 1 });
+  expect(data.inventory).toEqual({ items: [] });
+  expect(data.quests).toEqual({ q: 1 });
+  expect(data.player).toEqual({ lvl: 1 });
+  Date.now.mockRestore();
+});
+
+test('loadGame reads data and populates modules', () => {
+  const obj = {
+    timestamp: 1000,
+    mapName: 'map01',
+    itemCount: 0,
+    game: { g: 2 },
+    inventory: { items: [{ id: 'x', quantity: 2 }] },
+    quests: { q: 2 },
+    player: { lvl: 2 }
+  };
+  localStorage.setItem('game_save_slot_1', JSON.stringify(obj));
+
+  const result = loadGame(1);
+  expect(result).toBe(true);
+  expect(game.deserializeGameState).toHaveBeenCalledWith({ g: 2 });
+  expect(invState.inventoryState.loadFromObject).toHaveBeenCalledWith({ items: [{ id: 'x', quantity: 2 }] });
+  expect(game.validateLoadedInventory).toHaveBeenCalledWith([{ id: 'x', quantity: 2 }]);
+  expect(qState.deserializeQuestState).toHaveBeenCalledWith({ q: 2 });
+  expect(playerMod.deserializePlayer).toHaveBeenCalledWith({ lvl: 2 });
+});


### PR DESCRIPTION
## Summary
- add combat resolution tests
- add item effect tests for consumables
- cover save/load behavior with a new test suite

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0172640c8331afc33c473e2b6cda