### PR TITLE
Improve accessibility for overlay close buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     </div>
     <div id="inventory-overlay" class="inventory-overlay">
       <div class="inventory-content">
-        <button class="close-btn">&times;</button>
+        <button class="close-btn" aria-label="Close">&times;</button>
         <h2>Inventory</h2>
         <div id="player-stats"></div>
         <div class="inventory-categories">
@@ -49,7 +49,7 @@
     </div>
     <div id="menu-overlay" class="menu-overlay">
       <div class="menu-content">
-        <button class="close-btn">&times;</button>
+        <button class="close-btn" aria-label="Close">&times;</button>
         <div class="menu-buttons">
           <div class="tab guide-tab">Guide</div>
           <div class="tab info-tab">Info</div>
@@ -63,14 +63,14 @@
     </div>
     <div id="quest-log-overlay" class="quest-overlay">
       <div class="quest-content">
-        <button class="close-btn">&times;</button>
+        <button class="close-btn" aria-label="Close">&times;</button>
         <h2>Active Quests</h2>
         <div id="quest-log"></div>
       </div>
     </div>
     <div id="status-overlay" class="status-overlay">
       <div class="status-content">
-        <button class="close-btn">&times;</button>
+        <button class="close-btn" aria-label="Close">&times;</button>
         <h2>Player Status</h2>
         <div id="status-info"></div>
         <h3>Passive Skills</h3>
@@ -79,7 +79,7 @@
     </div>
     <div id="info-overlay" class="info-overlay">
       <div id="info-menu">
-        <button class="close-btn">&times;</button>
+        <button class="close-btn" aria-label="Close">&times;</button>
         <nav class="info-nav">
           <div class="info-nav-btn active" data-target="enemies">Enemies</div>
           <div class="info-nav-btn" data-target="items">Items</div>
@@ -114,7 +114,7 @@
     </div>
     <div id="null-summary-overlay" class="null-summary-overlay">
       <div class="null-summary-content">
-        <button class="close-btn">&times;</button>
+        <button class="close-btn" aria-label="Close">&times;</button>
         <h2>Null Factor Summary</h2>
         <div id="null-summary-message"></div>
         <div id="null-summary-list"></div>
@@ -122,7 +122,7 @@
     </div>
     <div id="settings-overlay" class="settings-overlay">
       <div class="settings-content">
-        <button class="close-btn">&times;</button>
+        <button class="close-btn" aria-label="Close">&times;</button>
         <h2>Settings</h2>
         <label class="setting-row">
           <input type="checkbox" id="coords-toggle" /> Grid Coordinates
@@ -196,14 +196,14 @@
     </div>
     <div id="save-load-overlay" class="save-load-overlay">
       <div class="save-load-content">
-        <button class="close-btn">&times;</button>
+        <button class="close-btn" aria-label="Close">&times;</button>
         <h2 id="save-load-title">Save Game</h2>
         <div id="slots-container"></div>
       </div>
     </div>
     <div id="howto-overlay" class="howto-overlay">
       <div class="howto-content">
-        <button class="close-btn">&times;</button>
+        <button class="close-btn" aria-label="Close">&times;</button>
         <h2>How to Play</h2>
         <div class="howto-scroll">
           <p><strong>Movement:</strong> Tap or click a ground tile to move. (Ground tiles are light green squares.)</p>


### PR DESCRIPTION
## Summary
- add `aria-label="Close"` to overlay close buttons for better accessibility

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684c07dd73d08331bb3842ef4a73fbe2