### PR TITLE
Refactor dialog modules

### DIFF
--- a/__tests__/combatUiHelpers.test.js
+++ b/__tests__/combatUiHelpers.test.js
@@ -1,0 +1,8 @@
+/** @jest-environment jsdom */
+import { updateHpBar } from '../scripts/combat_ui_helpers.js';
+
+test('updateHpBar sets style width correctly', () => {
+  const bar = document.createElement('div');
+  updateHpBar(bar, 25, 100);
+  expect(bar.style.width).toBe('25%');
+});

--- a/__tests__/dialogueFlags.test.js
+++ b/__tests__/dialogueFlags.test.js
@@ -1,0 +1,47 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../scripts/dialogue/memory.js', () => ({
+  setMemory: jest.fn()
+}));
+
+jest.unstable_mockModule('../scripts/dialogueSystem.js', () => ({
+  showDialogue: jest.fn()
+}));
+
+jest.unstable_mockModule('../scripts/ending_manager.js', () => ({
+  recordEnding: jest.fn()
+}));
+
+jest.unstable_mockModule('../scripts/player_memory.js', () => ({
+  getEchoConversationCount: jest.fn(() => 0),
+  recordLore: jest.fn()
+}));
+
+jest.unstable_mockModule('../scripts/relic_state.js', () => ({
+  getOwnedRelics: jest.fn(() => [])
+}));
+
+let flags, memoryMod, dialogueSys, endingMgr;
+
+beforeEach(async () => {
+  jest.resetModules();
+  flags = await import('../scripts/dialogue/flags.js');
+  memoryMod = await import('../scripts/dialogue/memory.js');
+  dialogueSys = await import('../scripts/dialogueSystem.js');
+  endingMgr = await import('../scripts/ending_manager.js');
+});
+
+test('flagMetLioran calls setMemory', () => {
+  flags.flagMetLioran();
+  expect(memoryMod.setMemory).toHaveBeenCalledWith('met_lioran');
+});
+
+test('echoAbsoluteDefeat records ending and shows dialogue', () => {
+  flags.echoAbsoluteDefeat();
+  expect(endingMgr.recordEnding).toHaveBeenCalledWith(
+    'defeat',
+    'Consumed by the Absolute'
+  );
+  expect(dialogueSys.showDialogue).toHaveBeenCalled();
+});

--- a/__tests__/krealerDialogues.test.js
+++ b/__tests__/krealerDialogues.test.js
@@ -1,0 +1,5 @@
+import { krealer1Dialogue } from '../scripts/dialogue/krealer_dialogues.js';
+
+test('krealer1Dialogue first line matches expectation', () => {
+  expect(krealer1Dialogue[0].text).toMatch('Doubt is a weapon');
+});

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -67,12 +67,9 @@ import { getStatusEffect } from './status_effects.js';
 import { initEnemyState } from './enemy.js';
 import { combatState, initCombatState } from './combat_state.js';
 import { initTurnOrder, nextTurn } from './combat_engine.js';
+import { updateHpBar } from './combat_ui_helpers.js';
 
 let overlay = null;
-
-function updateHpBar(bar, current, max) {
-  bar.style.width = `${(current / max) * 100}%`;
-}
 
 /**
  * Starts a basic turn-based combat encounter.

--- a/scripts/combat_ui_helpers.js
+++ b/scripts/combat_ui_helpers.js
@@ -1,0 +1,3 @@
+export function updateHpBar(bar, current, max) {
+  bar.style.width = `${(current / max) * 100}%`;
+}

--- a/scripts/dialogue/flags.js
+++ b/scripts/dialogue/flags.js
@@ -1,0 +1,65 @@
+import { getOwnedRelics } from '../relic_state.js';
+import { getEchoConversationCount, recordLore } from '../player_memory.js';
+import { recordEnding } from '../ending_manager.js';
+import { showDialogue } from '../dialogueSystem.js';
+import { setMemory } from './memory.js';
+
+export function echoAbsoluteIntro() {
+  const echoes = getEchoConversationCount();
+  const relics = getOwnedRelics().length;
+  const line = `All ${echoes} echoes and ${relics} relics converge into one form.`;
+  showDialogue(line);
+}
+
+export function echoAbsoluteVictory() {
+  showDialogue('The Absolute fades, leaving clarity behind.', () => {
+    recordLore('pattern_end');
+    recordEnding('victory', 'Echo Absolute defeated');
+  });
+}
+
+export function echoAbsoluteDefeat() {
+  showDialogue('Memories scatter as darkness takes hold.', () => {
+    recordEnding('defeat', 'Consumed by the Absolute');
+  });
+}
+
+export function flagMetFirstMemory() {
+  setMemory('met_first_memory');
+}
+
+export function flagEryndorSkillGiven() {
+  setMemory('eryndor_skill_given');
+}
+
+export function flagMetLioran() {
+  setMemory('met_lioran');
+}
+
+export function flagObtainedArcaneSpark() {
+  setMemory('obtained_arcane_spark');
+}
+
+export function flagRiftLurkerDefeated() {
+  setMemory('rift_lurker_defeated');
+}
+
+export function flagTradedForPrismKey() {
+  setMemory('traded_for_prism_key');
+}
+
+export function flagTradedWithKaelor() {
+  setMemory('traded_with_kaelor');
+}
+
+export function flagManipulatedByVerrel() {
+  setMemory('manipulated_by_verrel');
+}
+
+export function vicarDoorMessageNorth() {
+  showDialogue('A holy seal binds this passage.');
+}
+
+export function vicarDoorMessageExit() {
+  showDialogue('You may only proceed with proof of dominion.');
+}

--- a/scripts/dialogue/krealer_dialogues.js
+++ b/scripts/dialogue/krealer_dialogues.js
@@ -1,0 +1,449 @@
+import { setKrealerFlag } from '../player_memory.js';
+
+export const krealer1Dialogue = [
+  {
+    text: 'Doubt is a weapon. Who truly commands your thoughts?',
+    options: [
+      { label: 'Voices of authority', goto: 1 },
+      { label: 'Only my conscience', goto: 2 }
+    ]
+  },
+  {
+    text: 'Authority requires trust. What will you sacrifice for certainty?',
+    options: [
+      {
+        label: 'My freedom',
+        goto: null,
+        memoryFlag: 'k1_freedom',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer1');
+          setKrealerFlag('k1_freedom');
+        }
+      },
+      {
+        label: 'Nothing. I question everything.',
+        goto: null,
+        memoryFlag: 'k1_question_all',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer1');
+          setKrealerFlag('k1_question_all');
+        }
+      }
+    ]
+  },
+  {
+    text: 'If conscience guides you, how do you silence fear?',
+    options: [
+      {
+        label: 'I embrace it',
+        goto: null,
+        memoryFlag: 'k1_embrace_fear',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer1');
+          setKrealerFlag('k1_embrace_fear');
+        }
+      },
+      {
+        label: 'I bury it deep',
+        goto: null,
+        memoryFlag: 'k1_bury_fear',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer1');
+          setKrealerFlag('k1_bury_fear');
+        }
+      }
+    ]
+  }
+];
+
+export const krealer2Dialogue = [
+  {
+    text: 'Trust is a mask you offer willingly. Whose face lies beneath?',
+    options: [
+      { label: 'Someone I hope to believe in', goto: 1 },
+      { label: 'A stranger shaped by need', goto: 2 }
+    ]
+  },
+  {
+    text: 'Hope invites vulnerability. Do you guard or reveal your weakness?',
+    options: [
+      {
+        label: 'Reveal to grow',
+        goto: null,
+        memoryFlag: 'k2_reveal',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer2');
+          setKrealerFlag('k2_reveal');
+        }
+      },
+      {
+        label: 'Guard it fiercely',
+        goto: null,
+        memoryFlag: 'k2_guard',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer2');
+          setKrealerFlag('k2_guard');
+        }
+      }
+    ]
+  },
+  {
+    text: 'Need can manipulate. Will you discard the mask?',
+    options: [
+      {
+        label: "Yes, even if I'm exposed",
+        goto: null,
+        memoryFlag: 'k2_unmask',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer2');
+          setKrealerFlag('k2_unmask');
+        }
+      },
+      {
+        label: 'No, deception keeps me safe',
+        goto: null,
+        memoryFlag: 'k2_keepmask',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer2');
+          setKrealerFlag('k2_keepmask');
+        }
+      }
+    ]
+  }
+];
+
+export const krealer3Dialogue = [
+  {
+    text: 'Feeling or thinking— which do you bury deepest?',
+    options: [
+      { label: 'Feelings fade first', goto: 1 },
+      { label: 'Thoughts must be hidden', goto: 2 }
+    ]
+  },
+  {
+    text: 'What emotion would you erase to survive?',
+    options: [
+      {
+        label: 'Compassion',
+        goto: null,
+        memoryFlag: 'k3_erase_compassion',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer3');
+          setKrealerFlag('k3_erase_compassion');
+        }
+      },
+      {
+        label: 'Anger',
+        goto: null,
+        memoryFlag: 'k3_erase_anger',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer3');
+          setKrealerFlag('k3_erase_anger');
+        }
+      }
+    ]
+  },
+  {
+    text: 'Hidden thoughts breed secrets. Which truth do you fear?',
+    options: [
+      {
+        label: 'My own weakness',
+        goto: null,
+        memoryFlag: 'k3_fear_weakness',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer3');
+          setKrealerFlag('k3_fear_weakness');
+        }
+      },
+      {
+        label: 'Others discovering me',
+        goto: null,
+        memoryFlag: 'k3_fear_discovery',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer3');
+          setKrealerFlag('k3_fear_discovery');
+        }
+      }
+    ]
+  }
+];
+
+export const krealer4Dialogue = [
+  {
+    text: 'Every step is watched. Do you see yourself reflected?',
+    options: [
+      { label: 'Yes, mirrors surround me', goto: 1 },
+      { label: 'No, only shadows', goto: 2 }
+    ]
+  },
+  {
+    text: 'Which reflection feels most true?',
+    options: [
+      {
+        label: 'The obedient persona',
+        goto: null,
+        memoryFlag: 'k4_obedient',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer4');
+          setKrealerFlag('k4_obedient');
+        }
+      },
+      {
+        label: 'The hidden self',
+        goto: null,
+        memoryFlag: 'k4_hidden',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer4');
+          setKrealerFlag('k4_hidden');
+        }
+      }
+    ]
+  },
+  {
+    text: 'In shadows, do you seek silence or revelation?',
+    options: [
+      {
+        label: 'Silence brings safety',
+        goto: null,
+        memoryFlag: 'k4_silence_pref',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer4');
+          setKrealerFlag('k4_silence_pref');
+        }
+      },
+      {
+        label: 'Revelation despite risk',
+        goto: null,
+        memoryFlag: 'k4_reveal_pref',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer4');
+          setKrealerFlag('k4_reveal_pref');
+        }
+      }
+    ]
+  }
+];
+
+export const krealer5Dialogue = [
+  {
+    text: 'Predict your rival and the game is won before it begins.',
+    options: [
+      { label: 'Study them relentlessly', goto: 1 },
+      { label: 'Let intuition guide me', goto: 2 }
+    ]
+  },
+  {
+    text: 'Knowledge is power. What knowledge do you crave?',
+    options: [
+      {
+        label: 'Their fears',
+        goto: null,
+        memoryFlag: 'k5_seek_fears',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer5');
+          setKrealerFlag('k5_seek_fears');
+        }
+      },
+      {
+        label: 'Their dreams',
+        goto: null,
+        memoryFlag: 'k5_seek_dreams',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer5');
+          setKrealerFlag('k5_seek_dreams');
+        }
+      }
+    ]
+  },
+  {
+    text: 'Intuition whispers softly. Do you listen or command it?',
+    options: [
+      {
+        label: 'I listen closely',
+        goto: null,
+        memoryFlag: 'k5_listen',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer5');
+          setKrealerFlag('k5_listen');
+        }
+      },
+      {
+        label: 'I bend it to my will',
+        goto: null,
+        memoryFlag: 'k5_command',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer5');
+          setKrealerFlag('k5_command');
+        }
+      }
+    ]
+  }
+];
+
+export const krealer6Dialogue = [
+  {
+    text: 'Memories fade. Which one would you erase first?',
+    options: [
+      { label: 'My deepest regret', goto: 1 },
+      { label: 'None—they define me', goto: 2 }
+    ]
+  },
+  {
+    text: 'What fills the void left behind?',
+    options: [
+      {
+        label: 'Hope for a fresh start',
+        goto: null,
+        memoryFlag: 'k6_fresh_start',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer6');
+          setKrealerFlag('k6_fresh_start');
+        }
+      },
+      {
+        label: 'Nothing. I welcome emptiness',
+        goto: null,
+        memoryFlag: 'k6_welcome_empty',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer6');
+          setKrealerFlag('k6_welcome_empty');
+        }
+      }
+    ]
+  },
+  {
+    text: 'If none vanish, how do you bear their weight?',
+    options: [
+      {
+        label: 'By sharing them',
+        goto: null,
+        memoryFlag: 'k6_share_weight',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer6');
+          setKrealerFlag('k6_share_weight');
+        }
+      },
+      {
+        label: 'By locking them away',
+        goto: null,
+        memoryFlag: 'k6_lock_away',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer6');
+          setKrealerFlag('k6_lock_away');
+        }
+      }
+    ]
+  }
+];
+
+export const krealer7Dialogue = [
+  {
+    text: 'Consequences blur when apathy reigns. Does choice matter to you?',
+    options: [
+      { label: 'Yes, every choice echoes', goto: 1 },
+      { label: 'Not when outcomes are the same', goto: 2 }
+    ]
+  },
+  {
+    text: 'Which echo lingers in you now?',
+    options: [
+      {
+        label: 'Regret',
+        goto: null,
+        memoryFlag: 'k7_echo_regret',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer7');
+          setKrealerFlag('k7_echo_regret');
+        }
+      },
+      {
+        label: 'Pride',
+        goto: null,
+        memoryFlag: 'k7_echo_pride',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer7');
+          setKrealerFlag('k7_echo_pride');
+        }
+      }
+    ]
+  },
+  {
+    text: 'If outcomes match, will you choose for others or yourself?',
+    options: [
+      {
+        label: 'For others',
+        goto: null,
+        memoryFlag: 'k7_choose_others',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer7');
+          setKrealerFlag('k7_choose_others');
+        }
+      },
+      {
+        label: 'For myself',
+        goto: null,
+        memoryFlag: 'k7_choose_self',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer7');
+          setKrealerFlag('k7_choose_self');
+        }
+      }
+    ]
+  }
+];
+
+export const krealer8Dialogue = [
+  {
+    text: 'You are the story you build. Which parts are real?',
+    options: [
+      { label: 'The victories I remember', goto: 1 },
+      { label: 'The failures I hide', goto: 2 }
+    ]
+  },
+  {
+    text: 'Do victories define you or distract you?',
+    options: [
+      {
+        label: 'They define me',
+        goto: null,
+        memoryFlag: 'k8_victory_define',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer8');
+          setKrealerFlag('k8_victory_define');
+        }
+      },
+      {
+        label: 'They distract me',
+        goto: null,
+        memoryFlag: 'k8_victory_distract',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer8');
+          setKrealerFlag('k8_victory_distract');
+        }
+      }
+    ]
+  },
+  {
+    text: 'Does hiding failure give strength or fragility?',
+    options: [
+      {
+        label: 'Strength to continue',
+        goto: null,
+        memoryFlag: 'k8_failure_strength',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer8');
+          setKrealerFlag('k8_failure_strength');
+        }
+      },
+      {
+        label: 'Fragility behind a mask',
+        goto: null,
+        memoryFlag: 'k8_failure_fragile',
+        onChoose: () => {
+          setKrealerFlag('flag_krealer8');
+          setKrealerFlag('k8_failure_fragile');
+        }
+      }
+    ]
+  }
+];

--- a/scripts/dialogue/memory.js
+++ b/scripts/dialogue/memory.js
@@ -1,0 +1,42 @@
+import { discover, setKrealerFlag } from '../player_memory.js';
+
+export const dialogueMemory = new Set();
+export const dialogueBranches = {};
+
+const state = {
+  activeDialogue: null
+};
+
+export const dialogueState = state;
+
+export function getActiveDialogue() {
+  return state.activeDialogue;
+}
+
+export function setMemory(flag) {
+  dialogueMemory.add(flag);
+  if (flag && flag.startsWith('flag_krealer')) setKrealerFlag(flag);
+  document.dispatchEvent(new CustomEvent('memoryFlagSet', { detail: flag }));
+}
+
+export function hasMemory(flag) {
+  return dialogueMemory.has(flag);
+}
+
+export function setBranchChoice(id, choice) {
+  if (!id) return;
+  dialogueBranches[id] = choice;
+}
+
+export function getBranchChoice(id) {
+  return dialogueBranches[id];
+}
+
+export function startSession(dialogue, npcId) {
+  state.activeDialogue = dialogue;
+  if (npcId) discover('npcs', npcId);
+}
+
+export function endSession() {
+  state.activeDialogue = null;
+}

--- a/scripts/dialogue_state.js
+++ b/scripts/dialogue_state.js
@@ -21,49 +21,44 @@ import { chooseClass as selectClass } from './class_state.js';
 import { player } from './player.js';
 import { clearCorruption } from './corruption_state.js';
 import { unlockRelicSlot, unlockPortal15 } from './player_state.js';
+import {
+  dialogueMemory,
+  dialogueBranches,
+  dialogueState,
+  getActiveDialogue,
+  setMemory,
+  hasMemory,
+  setBranchChoice,
+  getBranchChoice,
+  startSession,
+  endSession
+} from './dialogue/memory.js';
+import {
+  krealer1Dialogue,
+  krealer2Dialogue,
+  krealer3Dialogue,
+  krealer4Dialogue,
+  krealer5Dialogue,
+  krealer6Dialogue,
+  krealer7Dialogue,
+  krealer8Dialogue
+} from './dialogue/krealer_dialogues.js';
+import {
+  echoAbsoluteIntro,
+  echoAbsoluteVictory,
+  echoAbsoluteDefeat,
+  flagMetFirstMemory,
+  flagEryndorSkillGiven,
+  flagMetLioran,
+  flagObtainedArcaneSpark,
+  flagRiftLurkerDefeated,
+  flagTradedForPrismKey,
+  flagTradedWithKaelor,
+  flagManipulatedByVerrel,
+  vicarDoorMessageNorth,
+  vicarDoorMessageExit
+} from './dialogue/flags.js';
 
-export const dialogueMemory = new Set();
-
-// Record branching choices so later conversations can reference them.
-export const dialogueBranches = {};
-
-const state = {
-  activeDialogue: null
-};
-
-export function getActiveDialogue() {
-  return state.activeDialogue;
-}
-
-export function setMemory(flag) {
-  dialogueMemory.add(flag);
-  if (flag && flag.startsWith('flag_krealer')) setKrealerFlag(flag);
-  document.dispatchEvent(new CustomEvent('memoryFlagSet', { detail: flag }));
-}
-
-export function hasMemory(flag) {
-  return dialogueMemory.has(flag);
-}
-
-export function setBranchChoice(id, choice) {
-  if (!id) return;
-  dialogueBranches[id] = choice;
-}
-
-export function getBranchChoice(id) {
-  return dialogueBranches[id];
-}
-
-export function startSession(dialogue, npcId) {
-  state.activeDialogue = dialogue;
-  if (npcId) discover('npcs', npcId);
-}
-
-export function endSession() {
-  state.activeDialogue = null;
-}
-
-export const dialogueState = state;
 
 export async function triggerUpgrade(id) {
   if (id) await upgradeItem(id);
@@ -277,510 +272,37 @@ export async function krealerDialogue() {
   });
 }
 
-export const krealer1Dialogue = [
-  {
-    text: 'Doubt is a weapon. Who truly commands your thoughts?',
-    options: [
-      { label: 'Voices of authority', goto: 1 },
-      { label: 'Only my conscience', goto: 2 }
-    ]
-  },
-  {
-    text: 'Authority requires trust. What will you sacrifice for certainty?',
-    options: [
-      {
-        label: 'My freedom',
-        goto: null,
-        memoryFlag: 'k1_freedom',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer1');
-          setKrealerFlag('k1_freedom');
-        }
-      },
-      {
-        label: 'Nothing. I question everything.',
-        goto: null,
-        memoryFlag: 'k1_question_all',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer1');
-          setKrealerFlag('k1_question_all');
-        }
-      }
-    ]
-  },
-  {
-    text: 'If conscience guides you, how do you silence fear?',
-    options: [
-      {
-        label: 'I embrace it',
-        goto: null,
-        memoryFlag: 'k1_embrace_fear',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer1');
-          setKrealerFlag('k1_embrace_fear');
-        }
-      },
-      {
-        label: 'I bury it deep',
-        goto: null,
-        memoryFlag: 'k1_bury_fear',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer1');
-          setKrealerFlag('k1_bury_fear');
-        }
-      }
-    ]
-  }
-];
 
-export const krealer2Dialogue = [
-  {
-    text: 'Trust is a mask you offer willingly. Whose face lies beneath?',
-    options: [
-      { label: 'Someone I hope to believe in', goto: 1 },
-      { label: 'A stranger shaped by need', goto: 2 }
-    ]
-  },
-  {
-    text: 'Hope invites vulnerability. Do you guard or reveal your weakness?',
-    options: [
-      {
-        label: 'Reveal to grow',
-        goto: null,
-        memoryFlag: 'k2_reveal',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer2');
-          setKrealerFlag('k2_reveal');
-        }
-      },
-      {
-        label: 'Guard it fiercely',
-        goto: null,
-        memoryFlag: 'k2_guard',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer2');
-          setKrealerFlag('k2_guard');
-        }
-      }
-    ]
-  },
-  {
-    text: 'Need can manipulate. Will you discard the mask?',
-    options: [
-      {
-        label: "Yes, even if I'm exposed",
-        goto: null,
-        memoryFlag: 'k2_unmask',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer2');
-          setKrealerFlag('k2_unmask');
-        }
-      },
-      {
-        label: 'No, deception keeps me safe',
-        goto: null,
-        memoryFlag: 'k2_keepmask',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer2');
-          setKrealerFlag('k2_keepmask');
-        }
-      }
-    ]
-  }
-];
-
-export const krealer3Dialogue = [
-  {
-    text: 'Feeling or thinking— which do you bury deepest?',
-    options: [
-      { label: 'Feelings fade first', goto: 1 },
-      { label: 'Thoughts must be hidden', goto: 2 }
-    ]
-  },
-  {
-    text: 'What emotion would you erase to survive?',
-    options: [
-      {
-        label: 'Compassion',
-        goto: null,
-        memoryFlag: 'k3_erase_compassion',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer3');
-          setKrealerFlag('k3_erase_compassion');
-        }
-      },
-      {
-        label: 'Anger',
-        goto: null,
-        memoryFlag: 'k3_erase_anger',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer3');
-          setKrealerFlag('k3_erase_anger');
-        }
-      }
-    ]
-  },
-  {
-    text: 'Hidden thoughts breed secrets. Which truth do you fear?',
-    options: [
-      {
-        label: 'My own weakness',
-        goto: null,
-        memoryFlag: 'k3_fear_weakness',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer3');
-          setKrealerFlag('k3_fear_weakness');
-        }
-      },
-      {
-        label: 'Others discovering me',
-        goto: null,
-        memoryFlag: 'k3_fear_discovery',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer3');
-          setKrealerFlag('k3_fear_discovery');
-        }
-      }
-    ]
-  }
-];
-
-export const krealer4Dialogue = [
-  {
-    text: 'Every step is watched. Do you see yourself reflected?',
-    options: [
-      { label: 'Yes, mirrors surround me', goto: 1 },
-      { label: 'No, only shadows', goto: 2 }
-    ]
-  },
-  {
-    text: 'Which reflection feels most true?',
-    options: [
-      {
-        label: 'The obedient persona',
-        goto: null,
-        memoryFlag: 'k4_obedient',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer4');
-          setKrealerFlag('k4_obedient');
-        }
-      },
-      {
-        label: 'The hidden self',
-        goto: null,
-        memoryFlag: 'k4_hidden',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer4');
-          setKrealerFlag('k4_hidden');
-        }
-      }
-    ]
-  },
-  {
-    text: 'In shadows, do you seek silence or revelation?',
-    options: [
-      {
-        label: 'Silence brings safety',
-        goto: null,
-        memoryFlag: 'k4_silence_pref',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer4');
-          setKrealerFlag('k4_silence_pref');
-        }
-      },
-      {
-        label: 'Revelation despite risk',
-        goto: null,
-        memoryFlag: 'k4_reveal_pref',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer4');
-          setKrealerFlag('k4_reveal_pref');
-        }
-      }
-    ]
-  }
-];
-
-export const krealer5Dialogue = [
-  {
-    text: 'Predict your rival and the game is won before it begins.',
-    options: [
-      { label: 'Study them relentlessly', goto: 1 },
-      { label: 'Let intuition guide me', goto: 2 }
-    ]
-  },
-  {
-    text: 'Knowledge is power. What knowledge do you crave?',
-    options: [
-      {
-        label: 'Their fears',
-        goto: null,
-        memoryFlag: 'k5_seek_fears',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer5');
-          setKrealerFlag('k5_seek_fears');
-        }
-      },
-      {
-        label: 'Their dreams',
-        goto: null,
-        memoryFlag: 'k5_seek_dreams',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer5');
-          setKrealerFlag('k5_seek_dreams');
-        }
-      }
-    ]
-  },
-  {
-    text: 'Intuition whispers softly. Do you listen or command it?',
-    options: [
-      {
-        label: 'I listen closely',
-        goto: null,
-        memoryFlag: 'k5_listen',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer5');
-          setKrealerFlag('k5_listen');
-        }
-      },
-      {
-        label: 'I bend it to my will',
-        goto: null,
-        memoryFlag: 'k5_command',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer5');
-          setKrealerFlag('k5_command');
-        }
-      }
-    ]
-  }
-];
-
-export const krealer6Dialogue = [
-  {
-    text: 'Memories fade. Which one would you erase first?',
-    options: [
-      { label: 'My deepest regret', goto: 1 },
-      { label: 'None—they define me', goto: 2 }
-    ]
-  },
-  {
-    text: 'What fills the void left behind?',
-    options: [
-      {
-        label: 'Hope for a fresh start',
-        goto: null,
-        memoryFlag: 'k6_fresh_start',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer6');
-          setKrealerFlag('k6_fresh_start');
-        }
-      },
-      {
-        label: 'Nothing. I welcome emptiness',
-        goto: null,
-        memoryFlag: 'k6_welcome_empty',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer6');
-          setKrealerFlag('k6_welcome_empty');
-        }
-      }
-    ]
-  },
-  {
-    text: 'If none vanish, how do you bear their weight?',
-    options: [
-      {
-        label: 'By sharing them',
-        goto: null,
-        memoryFlag: 'k6_share_weight',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer6');
-          setKrealerFlag('k6_share_weight');
-        }
-      },
-      {
-        label: 'By locking them away',
-        goto: null,
-        memoryFlag: 'k6_lock_away',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer6');
-          setKrealerFlag('k6_lock_away');
-        }
-      }
-    ]
-  }
-];
-
-export const krealer7Dialogue = [
-  {
-    text: 'Consequences blur when apathy reigns. Does choice matter to you?',
-    options: [
-      { label: 'Yes, every choice echoes', goto: 1 },
-      { label: 'Not when outcomes are the same', goto: 2 }
-    ]
-  },
-  {
-    text: 'Which echo lingers in you now?',
-    options: [
-      {
-        label: 'Regret',
-        goto: null,
-        memoryFlag: 'k7_echo_regret',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer7');
-          setKrealerFlag('k7_echo_regret');
-        }
-      },
-      {
-        label: 'Pride',
-        goto: null,
-        memoryFlag: 'k7_echo_pride',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer7');
-          setKrealerFlag('k7_echo_pride');
-        }
-      }
-    ]
-  },
-  {
-    text: 'If outcomes match, will you choose for others or yourself?',
-    options: [
-      {
-        label: 'For others',
-        goto: null,
-        memoryFlag: 'k7_choose_others',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer7');
-          setKrealerFlag('k7_choose_others');
-        }
-      },
-      {
-        label: 'For myself',
-        goto: null,
-        memoryFlag: 'k7_choose_self',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer7');
-          setKrealerFlag('k7_choose_self');
-        }
-      }
-    ]
-  }
-];
-
-export const krealer8Dialogue = [
-  {
-    text: 'You are the story you build. Which parts are real?',
-    options: [
-      { label: 'The victories I remember', goto: 1 },
-      { label: 'The failures I hide', goto: 2 }
-    ]
-  },
-  {
-    text: 'Do victories define you or distract you?',
-    options: [
-      {
-        label: 'They define me',
-        goto: null,
-        memoryFlag: 'k8_victory_define',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer8');
-          setKrealerFlag('k8_victory_define');
-        }
-      },
-      {
-        label: 'They distract me',
-        goto: null,
-        memoryFlag: 'k8_victory_distract',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer8');
-          setKrealerFlag('k8_victory_distract');
-        }
-      }
-    ]
-  },
-  {
-    text: 'Does hiding failure give strength or fragility?',
-    options: [
-      {
-        label: 'Strength to continue',
-        goto: null,
-        memoryFlag: 'k8_failure_strength',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer8');
-          setKrealerFlag('k8_failure_strength');
-        }
-      },
-      {
-        label: 'Fragility behind a mask',
-        goto: null,
-        memoryFlag: 'k8_failure_fragile',
-        onChoose: () => {
-          setKrealerFlag('flag_krealer8');
-          setKrealerFlag('k8_failure_fragile');
-        }
-      }
-    ]
-  }
-];
-
-export function echoAbsoluteIntro() {
-  const echoes = getEchoConversationCount();
-  const relics = getOwnedRelics().length;
-  const line = `All ${echoes} echoes and ${relics} relics converge into one form.`;
-  showDialogue(line);
-}
-
-export function echoAbsoluteVictory() {
-  showDialogue('The Absolute fades, leaving clarity behind.', () => {
-    discoverLore('pattern_end');
-    recordEnding('victory', 'Echo Absolute defeated');
-  });
-}
-
-export function echoAbsoluteDefeat() {
-  showDialogue('Memories scatter as darkness takes hold.', () => {
-    recordEnding('defeat', 'Consumed by the Absolute');
-  });
-}
-
-export function flagMetFirstMemory() {
-  setMemory('met_first_memory');
-}
-
-export function flagEryndorSkillGiven() {
-  setMemory('eryndor_skill_given');
-}
-
-export function flagMetLioran() {
-  setMemory('met_lioran');
-}
-
-export function flagObtainedArcaneSpark() {
-  setMemory('obtained_arcane_spark');
-}
-
-export function flagRiftLurkerDefeated() {
-  setMemory('rift_lurker_defeated');
-}
-
-export function flagTradedForPrismKey() {
-  setMemory('traded_for_prism_key');
-}
-
-export function flagTradedWithKaelor() {
-  setMemory('traded_with_kaelor');
-}
-
-export function flagManipulatedByVerrel() {
-  setMemory('manipulated_by_verrel');
-}
-
-export function vicarDoorMessageNorth() {
-  showDialogue('A holy seal binds this passage.');
-}
-
-export function vicarDoorMessageExit() {
-  showDialogue('You may only proceed with proof of dominion.');
-}
+export {
+  dialogueMemory,
+  dialogueBranches,
+  dialogueState,
+  getActiveDialogue,
+  setMemory,
+  hasMemory,
+  setBranchChoice,
+  getBranchChoice,
+  startSession,
+  endSession,
+  krealer1Dialogue,
+  krealer2Dialogue,
+  krealer3Dialogue,
+  krealer4Dialogue,
+  krealer5Dialogue,
+  krealer6Dialogue,
+  krealer7Dialogue,
+  krealer8Dialogue,
+  echoAbsoluteIntro,
+  echoAbsoluteVictory,
+  echoAbsoluteDefeat,
+  flagMetFirstMemory,
+  flagEryndorSkillGiven,
+  flagMetLioran,
+  flagObtainedArcaneSpark,
+  flagRiftLurkerDefeated,
+  flagTradedForPrismKey,
+  flagTradedWithKaelor,
+  flagManipulatedByVerrel,
+  vicarDoorMessageNorth,
+  vicarDoorMessageExit
+};


### PR DESCRIPTION
## Summary
- modularize combat UI helper
- extract dialogue memory management and flag helpers
- split Krealer dialogues into own module
- export helpers from `dialogue_state.js`
- add unit tests for new modules

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c0b1b57108331bdc50b606eca4df6