### PR TITLE
Improve fallback handling for runtime JSON loading

### DIFF
--- a/__tests__/dataService.test.js
+++ b/__tests__/dataService.test.js
@@ -49,3 +49,13 @@ test('returns parsed JSON on success', async () => {
     .mockResolvedValue(new Response('{"a":1}', { status: 200 }));
   await expect(loadJson('test.json')).resolves.toEqual({ a: 1 });
 });
+
+test('uses fallback on network error', async () => {
+  global.fetch = jest.fn().mockRejectedValue(new Error('fail'));
+  await expect(loadJson('path/file.json', { ok: true })).resolves.toEqual({ ok: true });
+});
+
+test('uses fallback on malformed JSON', async () => {
+  global.fetch = jest.fn().mockResolvedValue(new Response('oops', { status: 200 }));
+  await expect(loadJson('bad.json', [])).resolves.toEqual([]);
+});

--- a/scripts/dataService.js
+++ b/scripts/dataService.js
@@ -1,21 +1,35 @@
-export async function loadJson(path) {
+export async function loadJson(path, fallback) {
   let res;
   try {
     res = await fetch(path);
   } catch (err) {
-    throw new Error(`Network error while fetching ${path}: ${err.message}`);
+    const msg = `Network error while fetching ${path}: ${err.message}`;
+    if (fallback !== undefined) {
+      console.error(msg);
+      return fallback;
+    }
+    throw new Error(msg);
   }
   if (!res.ok) {
     const msg =
       res.status === 404
         ? `File not found: ${path}`
         : `${res.status} ${res.statusText} (${path})`;
+    if (fallback !== undefined) {
+      console.error(msg);
+      return fallback;
+    }
     throw new Error(msg);
   }
   const text = await res.text();
   try {
     return JSON.parse(text);
   } catch (err) {
-    throw new Error(`Malformed JSON in ${path}: ${err.message}`);
+    const msg = `Malformed JSON in ${path}: ${err.message}`;
+    if (fallback !== undefined) {
+      console.error(msg);
+      return fallback;
+    }
+    throw new Error(msg);
   }
 }

--- a/ui/info_menu.js
+++ b/ui/info_menu.js
@@ -1,11 +1,13 @@
+import { loadJson as loadJsonFile } from '../scripts/dataService.js';
+import { showError } from '../scripts/errorPrompt.js';
+
 export async function loadJson(name) {
-  try {
-    const res = await fetch(`info_data/${name}`);
-    if (!res.ok) return [];
-    return await res.json();
-  } catch {
+  const data = await loadJsonFile(`info_data/${name}`, null);
+  if (data === null) {
+    showError(`Failed to load info_data/${name}`);
     return [];
   }
+  return data;
 }
 
 function createEntry(obj, fields) {


### PR DESCRIPTION
## Summary
- add optional fallback support to `loadJson`
- surface fetch failures in the info menu
- test new fallback behaviour

## Testing
- `npm test --silent` *(fails: jest not installed)*
- `npm run lint --silent` *(fails: ESLint config dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c1161a88c8331b03fced6c3c24280