### PR TITLE
Fix JSON imports for browser modules

### DIFF
--- a/info_data/classes.js
+++ b/info_data/classes.js
@@ -1,0 +1,22 @@
+export default 
+[
+  {
+    "id": "warrior",
+    "name": "Warrior",
+    "description": "Trained fighter with improved attack power.",
+    "bonuses": { "attack": 3 }
+  },
+  {
+    "id": "guardian",
+    "name": "Guardian",
+    "description": "Defensive specialist with extra protection.",
+    "bonuses": { "defense": 3 }
+  },
+  {
+    "id": "alchemist",
+    "name": "Alchemist",
+    "description": "Expert with concoctions; potions are more effective.",
+    "bonuses": { "itemHealBonus": 1 }
+  }
+]
+;

--- a/info_data/echo_info_list.js
+++ b/info_data/echo_info_list.js
@@ -1,0 +1,34 @@
+export default 
+[
+  {
+    "id": "fogbound_intro",
+    "name": "Fogbound Whisper",
+    "description": "Fog remembers what we forget. But not all of it returns whole."
+  },
+  {
+    "id": "fogbound_fragment",
+    "name": "Fogbound Fragment",
+    "description": "Echo of a self unsure it ever existed."
+  },
+  {
+    "id": "shadow",
+    "name": "Shadow Self",
+    "description": "A reflection of the path you did not take."
+  },
+  {
+    "id": "flame",
+    "name": "Flame Self",
+    "description": "The fire you might have kindled."
+  },
+  {
+    "id": "peace",
+    "name": "Peaceful Self",
+    "description": "The tranquility you could have chosen."
+  },
+  {
+    "id": "memory",
+    "name": "Unlived Memory",
+    "description": "Fragments of possibilities unmade."
+  }
+]
+;

--- a/info_data/npc_info.js
+++ b/info_data/npc_info.js
@@ -1,0 +1,99 @@
+export default 
+[
+  {
+    "id": "eryndor",
+    "name": "Eryndor",
+    "description": "Last of the Lorebound, keeper of forgotten tales."
+  },
+  {
+    "id": "first_memory",
+    "name": "Memory Echo",
+    "description": "A lingering vision of your earliest recollections."
+  },
+  {
+    "id": "lioran",
+    "name": "Lioran",
+    "description": "A fugitive scholar hiding among the ruins."
+  },
+  {
+    "id": "coren",
+    "name": "Coren",
+    "description": "A wary scout who still answers to his commander."
+  },
+  {
+    "id": "goblin_quest_giver",
+    "name": "Goblin Trader",
+    "description": "Trades goblin gear for mysterious rewards."
+  },
+  {
+    "id": "arvalin",
+    "name": "Arvalin",
+    "description": "A scholar fascinated by cursed artifacts."
+  },
+  {
+    "id": "grindle",
+    "name": "Grindle",
+    "description": "A gruff craftsman skilled in forging."
+  },
+  {
+    "id": "vaelin",
+    "name": "Vaelin",
+    "description": "Scout turned philosopher wandering the Verge."
+  },
+  {
+    "id": "forge_npc",
+    "name": "Forge Master",
+    "description": "Offers upgrades and rerolls for equipment."
+  },
+  {
+    "id": "shade_sage",
+    "name": "Shade Sage",
+    "description": "A mysterious figure lingering in the hub."
+  },
+  {
+    "id": "fork_guide",
+    "name": "Pathseer",
+    "description": "Guides travelers through the forked pass."
+  },
+  {
+    "id": "watcher",
+    "name": "Watcher",
+    "description": "A silent guardian hidden in the shadows."
+  },
+  {
+    "id": "flamebound",
+    "name": "Flamebound",
+    "description": "A warrior devoted to the fires within the earth."
+  },
+  {
+    "id": "arbiter",
+    "name": "Arbiter",
+    "description": "Keeper of balance between shadow and flame."
+  },
+  {
+    "id": "vaultkeeper",
+    "name": "Vaultkeeper",
+    "description": "Guardian of the rotating vault."
+  },
+  {
+    "id": "korell",
+    "name": "Korell",
+    "description": "Hermit-technician who unlocks Fusion Crafting."
+  },
+  {
+    "id": "caelen",
+    "name": "Caelen",
+    "description": "World-weary trader intrigued by magic artifacts."
+  },
+  {
+    "id": "krealer",
+    "name": "Krealer",
+    "description": "A cryptic entity guarding forbidden knowledge."
+  },
+  {
+    "id": "kaelor_the_weaver",
+    "name": "Kaelor the Weaver",
+    "description": "Pragmatic trader who exchanges fragments for a key."
+  }
+]
+;

--- a/scripts/classes_info.js
+++ b/scripts/classes_info.js
@@ -1,4 +1,4 @@
-import classes from '../info_data/classes.json' assert { type: 'json' };
+import classes from '../info_data/classes.js';
 
 export function getClassInfo(id) {
   return classes.find((c) => c.id === id);

--- a/scripts/echo_info.js
+++ b/scripts/echo_info.js
@@ -1,4 +1,4 @@
-import echoInfoList from '../info_data/echo_info_list.json' assert { type: 'json' };
+import echoInfoList from '../info_data/echo_info_list.js';
 
 export function getAllEchoes() {
   return echoInfoList;

--- a/scripts/npc_info.js
+++ b/scripts/npc_info.js
@@ -1,4 +1,4 @@
-import npcInfoList from '../info_data/npc_info.json' assert { type: 'json' };
+import npcInfoList from '../info_data/npc_info.js';
 
 export function getAllNpcs() {
   return npcInfoList;


### PR DESCRIPTION
## Summary
- replace JSON module imports with JS files exporting the data
- adjust imports in info scripts to use the new JS modules

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1cf750d48331b6e1431a5cbe3d83