### PR TITLE
Fix module import error in classes_info

### DIFF
--- a/__tests__/classes_info.test.js
+++ b/__tests__/classes_info.test.js
@@ -1,0 +1,19 @@
+/** @jest-environment jsdom */
+
+let getClassInfo, getAllClasses;
+
+beforeEach(async () => {
+  ({ getClassInfo, getAllClasses } = await import('../scripts/classes_info.js'));
+});
+
+test('getClassInfo returns correct class data', () => {
+  const warrior = getClassInfo('warrior');
+  expect(warrior).toBeDefined();
+  expect(warrior.name).toBe('Warrior');
+});
+
+test('getAllClasses returns array of classes', () => {
+  const classes = getAllClasses();
+  expect(Array.isArray(classes)).toBe(true);
+  expect(classes.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- add regression test for classes_info module

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1e76b400833198685f90dd7236d2