### PR TITLE
Fix player memory export

### DIFF
--- a/scripts/player_memory.js
+++ b/scripts/player_memory.js
@@ -114,6 +114,9 @@ export function discoverLore(id) {
   discover('lore', id);
 }
 
+// Provide an alias for legacy imports
+export const recordLore = discoverLore;
+
 export function discoverMap(id) {
   discover('maps', id);
 }


### PR DESCRIPTION
## Summary
- expose `recordLore` alias in `player_memory.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c21430450833191963fcd61fd4289