### PR TITLE
Improve menu stats display

### DIFF
--- a/scripts/leveling.js
+++ b/scripts/leveling.js
@@ -1,0 +1,8 @@
+export function getXpThreshold(level) {
+  let threshold = 10;
+  const lvl = Math.max(1, Math.floor(level));
+  for (let i = 1; i < lvl; i++) {
+    threshold = Math.floor(threshold * 1.5);
+  }
+  return threshold;
+}

--- a/scripts/player_state.js
+++ b/scripts/player_state.js
@@ -1,3 +1,5 @@
+import { player, getTotalStats } from './player.js';
+
 const STORAGE_KEY = 'gridquest.player_state';
 
 const state = {
@@ -65,3 +67,13 @@ export function isPortal15Unlocked() {
 }
 
 export const playerState = state;
+
+export function getPlayerState() {
+  return {
+    hp: player.hp,
+    maxHp: player.maxHp,
+    stats: getTotalStats(),
+    level: player.level,
+    xp: player.xp
+  };
+}

--- a/style/layout.css
+++ b/style/layout.css
@@ -415,6 +415,11 @@ body {
   font-weight: bold;
 }
 
+.menu-stats p {
+  margin: 4px 0;
+  font-family: monospace;
+}
+
 /* Quest Log UI */
 .quest-overlay {
   position: fixed;

--- a/ui/main_menu.js
+++ b/ui/main_menu.js
@@ -1,5 +1,6 @@
-import { player, getTotalStats } from '../scripts/player.js';
 import { hasCodeFile } from '../scripts/inventory.js';
+import { getPlayerState } from '../scripts/player_state.js';
+import { getXpThreshold } from '../scripts/leveling.js';
 import { toggleQuestLog } from '../scripts/quest_log.js';
 import { toggleInfoMenu } from './info_menu.js';
 import { toggleStatusPanel } from '../scripts/menu/status.js';
@@ -9,20 +10,23 @@ import { confirmRestart } from '../scripts/restart.js';
 export function updateMenuStats() {
   const el = document.getElementById('menu-stats');
   if (!el) return;
-  const stats = getTotalStats();
-  const def = stats.defense || 0;
-  const tooltip =
-    'Negative defense increases damage taken by 10% per point.';
-  const defHtml = def < 0
-    ? `<span class="negative" title="${tooltip}">${def}</span>`
-    : `<span title="${tooltip}">${def}</span>`;
+  const { hp, maxHp, stats, level, xp } = getPlayerState();
+  const { attack, defense, speed } = stats;
+  const tooltip = 'Negative defense increases damage taken by 10% per point.';
+  const defHtml =
+    defense < 0
+      ? `<span class="negative" title="${tooltip}">${defense}</span>`
+      : `<span title="${tooltip}">${defense}</span>`;
+  const xpCap = getXpThreshold(level);
   el.innerHTML = `
-    <div>Level: ${player.level}</div>
-    <div>XP: ${player.xp} / ${player.xpToNextLevel}</div>
-    <div>HP: ${player.hp} / ${player.maxHp}</div>
-    <div>ATK: ${stats.attack || 0}</div>
-    <div>DEF: ${defHtml}</div>
-  `;
+    <div class="menu-stats">
+      <p><strong>Level:</strong> ${level}</p>
+      <p><strong>XP:</strong> ${xp} / ${xpCap}</p>
+      <p><strong>HP:</strong> ${hp} / ${maxHp}</p>
+      <p><strong>ATK:</strong> ${attack}</p>
+      <p><strong>DEF:</strong> ${defHtml}</p>
+      <p><strong>SPD:</strong> ${speed}</p>
+    </div>`;
 }
 
 function updateNullButton() {


### PR DESCRIPTION
## Summary
- add helper to compute XP thresholds
- expose a getPlayerState helper
- show full player stats in the menu panel
- tweak menu stat CSS

## Testing
- `npx prettier --write ui/main_menu.js scripts/player_state.js scripts/leveling.js style/layout.css`
- `npx eslint ui/main_menu.js scripts/player_state.js scripts/leveling.js` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c24d6bba08331a66f5ad91e932f86