### PR TITLE
Add localized Snealer dialogue

### DIFF
--- a/scripts/dialogue/npcs/snealer.js
+++ b/scripts/dialogue/npcs/snealer.js
@@ -1,51 +1,31 @@
+import { t } from '../../i18n.js';
+
 export default [
   {
-    text: 'Psst... not all treasures are in chests, you know.',
+    text: 'snealer.dialogue.1.text',
     options: [
-      { label: 'What do you mean?', goto: 1 },
-      { label: 'You look suspicious.', goto: 2 },
-      { label: "I'll be going.", goto: null }
+      { label: t('snealer.dialogue.1.ask_fortune'), goto: 1 },
+      { label: t('snealer.dialogue.1.ask_answers'), goto: 2 },
+      { label: t('snealer.dialogue.1.leave'), goto: null }
     ]
   },
   {
-    text: 'Some secrets lie where footsteps vanish...',
+    text: 'snealer.dialogue.2.text',
     options: [
-      { label: 'Where should I look?', goto: 3 },
-      { label: 'Sounds like nonsense.', goto: null }
+      { label: t('snealer.dialogue.2.refuse'), goto: null },
+      { label: t('snealer.dialogue.2.intrigued'), goto: 3 }
     ]
   },
   {
-    text: "Suspicious? Me? I'm just a humble observer of the unseen.",
+    text: 'snealer.dialogue.3.text',
     options: [
-      { label: 'Observer of what exactly?', goto: 4 },
-      { label: 'Still sounds suspicious.', goto: null }
+      { label: t('snealer.dialogue.3.ponder'), goto: null }
     ]
   },
   {
-    text: "If you can answer this: What walks without a sound, and lives only when no one's around?",
+    text: 'snealer.dialogue.4.text',
     options: [
-      { label: 'A shadow?', goto: 5 },
-      { label: 'A ghost?', goto: 6 },
-      { label: 'No idea.', goto: null }
+      { label: t('snealer.dialogue.4.nod'), goto: null }
     ]
-  },
-  {
-    text: 'The sort of things that disappear when light hits them...',
-    options: [{ label: 'Interesting.', goto: null }]
-  },
-  {
-    text: "Sharp. I wasn't sure you had it in you.",
-    options: [
-      { label: 'What is this token?', goto: 7, give: 'shadow_token' },
-      { label: 'Thanks.', goto: null, give: 'shadow_token' }
-    ]
-  },
-  {
-    text: "Heh. Close, but shadows don't haunt.",
-    options: [{ label: 'Fair point.', goto: null }]
-  },
-  {
-    text: 'It might open a path for those who prefer to stay unseen...',
-    options: [{ label: "I'll keep that in mind.", goto: null }]
   }
 ];

--- a/scripts/dialogue_system.js
+++ b/scripts/dialogue_system.js
@@ -227,7 +227,7 @@ export async function startDialogueTree(dialogue, index = 0) {
     return true;
   });
   const choices = validOptions.map((opt) => ({
-    label: opt.label,
+    label: t(opt.label),
     callback: async () => {
       if (opt.memoryFlag) setMemory(opt.memoryFlag);
       if (typeof opt.onChoose === 'function') {

--- a/scripts/locales/ar.json
+++ b/scripts/locales/ar.json
@@ -54,5 +54,18 @@
   "save.slot_empty": "فتحة فارغة",
   "save.map": "الخريطة:",
   "save.items": "العناصر:",
-  "save.saved": "تم الحفظ:"
+  "save.saved": "تم الحفظ:",
+  "snealer.name": "سنيالر",
+  "snealer.intro": "الهواء يتغير... سنيالر يبتسم بمكر.",
+  "snealer.dialogue.1.text": "آه، متجول... تبحث عن ثروة أم إجابات؟",
+  "snealer.dialogue.1.ask_fortune": "الثروة",
+  "snealer.dialogue.1.ask_answers": "الإجابات",
+  "snealer.dialogue.1.leave": "لا شيء",
+  "snealer.dialogue.2.text": "الثروات في الخراب، محمية دائمًا. لكن قل لي - ماذا ستعطيني مقابل اختصار الطريق؟",
+  "snealer.dialogue.2.refuse": "لا شيء",
+  "snealer.dialogue.2.intrigued": "يعتمد...",
+  "snealer.dialogue.3.text": "الحقيقة شفرة. قد تجرح نفسك بها، أيها المتجول.",
+  "snealer.dialogue.3.ponder": "سأجازف.",
+  "snealer.dialogue.4.text": "حكيم. عد إلي بشيء نادر، شيء يسقطه من يكرهون النور.",
+  "snealer.dialogue.4.nod": "حسنًا."
 }

--- a/scripts/locales/en.json
+++ b/scripts/locales/en.json
@@ -61,5 +61,18 @@
   "save.slot_empty": "Slot empty",
   "save.map": "Map:",
   "save.items": "Items:",
-  "save.saved": "Saved:"
+  "save.saved": "Saved:",
+  "snealer.name": "Snealer",
+  "snealer.intro": "The air shifts... Snealer grins slyly.",
+  "snealer.dialogue.1.text": "Ah, a wanderer... Looking for fortune, or answers?",
+  "snealer.dialogue.1.ask_fortune": "Fortune",
+  "snealer.dialogue.1.ask_answers": "Answers",
+  "snealer.dialogue.1.leave": "Never mind",
+  "snealer.dialogue.2.text": "Riches lie in ruins, always guarded. But tell me — what will you give for a shortcut?",
+  "snealer.dialogue.2.refuse": "Nothing",
+  "snealer.dialogue.2.intrigued": "Depends...",
+  "snealer.dialogue.3.text": "Truth is a blade. You might cut yourself on it, wanderer.",
+  "snealer.dialogue.3.ponder": "I'll risk it.",
+  "snealer.dialogue.4.text": "Wise. Return with something rare, something dropped by those who hate the light.",
+  "snealer.dialogue.4.nod": "Got it."
 }

--- a/scripts/locales/ja.json
+++ b/scripts/locales/ja.json
@@ -54,5 +54,18 @@
   "save.slot_empty": "空きスロット",
   "save.map": "マップ:",
   "save.items": "アイテム:",
-  "save.saved": "保存日時:"
+  "save.saved": "保存日時:",
+  "snealer.name": "スニーラー",
+  "snealer.intro": "空気が変わる…スニーラーがニヤリと笑う。",
+  "snealer.dialogue.1.text": "ああ、旅人か... 富を求めているのか、それとも答えを？",
+  "snealer.dialogue.1.ask_fortune": "富",
+  "snealer.dialogue.1.ask_answers": "答え",
+  "snealer.dialogue.1.leave": "やっぱいい",
+  "snealer.dialogue.2.text": "財宝は廃墟に眠る、常に守られている。だが近道を教えるとしたら、代償は？",
+  "snealer.dialogue.2.refuse": "何もない",
+  "snealer.dialogue.2.intrigued": "場合による…",
+  "snealer.dialogue.3.text": "真実は刃だ。触れれば切れるぞ、旅人。",
+  "snealer.dialogue.3.ponder": "やってみよう。",
+  "snealer.dialogue.4.text": "賢いな。光を嫌う者たちが落とす珍品を持って戻れ。",
+  "snealer.dialogue.4.nod": "了解。"
 }

--- a/scripts/locales/nl.json
+++ b/scripts/locales/nl.json
@@ -61,5 +61,18 @@
   "save.slot_empty": "Leeg slot",
   "save.map": "Kaart:",
   "save.items": "Items:",
-  "save.saved": "Opgeslagen:"
+  "save.saved": "Opgeslagen:",
+  "snealer.name": "Snealer",
+  "snealer.intro": "De lucht verandert... Snealer grijnst sluw.",
+  "snealer.dialogue.1.text": "Ah, een zwerver... Op zoek naar rijkdom of antwoorden?",
+  "snealer.dialogue.1.ask_fortune": "Rijkdom",
+  "snealer.dialogue.1.ask_answers": "Antwoorden",
+  "snealer.dialogue.1.leave": "Laat maar",
+  "snealer.dialogue.2.text": "Rijkdom ligt in ruïnes, altijd bewaakt. Maar zeg me – wat geef je voor een kortere weg?",
+  "snealer.dialogue.2.refuse": "Niets",
+  "snealer.dialogue.2.intrigued": "Hangt ervan af...",
+  "snealer.dialogue.3.text": "De waarheid is een mes. Je kunt jezelf eraan snijden, zwerver.",
+  "snealer.dialogue.3.ponder": "Ik waag het.",
+  "snealer.dialogue.4.text": "Wijs. Kom terug met iets zeldzaams, iets wat wordt achtergelaten door zij die het licht haten.",
+  "snealer.dialogue.4.nod": "Begrepen."
 }

--- a/scripts/locales/ru.json
+++ b/scripts/locales/ru.json
@@ -54,5 +54,18 @@
   "save.slot_empty": "Пустой слот",
   "save.map": "Карта:",
   "save.items": "Предметы:",
-  "save.saved": "Сохранено:"
+  "save.saved": "Сохранено:",
+  "snealer.name": "Снилер",
+  "snealer.intro": "Воздух дрожит... Снилер ухмыляется хитро.",
+  "snealer.dialogue.1.text": "Ах, странник... В поисках богатства или ответов?",
+  "snealer.dialogue.1.ask_fortune": "Богатство",
+  "snealer.dialogue.1.ask_answers": "Ответы",
+  "snealer.dialogue.1.leave": "Неважно",
+  "snealer.dialogue.2.text": "Богатства скрыты в руинах, под стражей. Но что ты отдашь за короткий путь?",
+  "snealer.dialogue.2.refuse": "Ничего",
+  "snealer.dialogue.2.intrigued": "Смотря что...",
+  "snealer.dialogue.3.text": "Правда — это лезвие. Можешь порезаться, странник.",
+  "snealer.dialogue.3.ponder": "Рискну.",
+  "snealer.dialogue.4.text": "Мудро. Вернись с редкостью, добытой у тех, кто боится света.",
+  "snealer.dialogue.4.nod": "Понял."
 }

--- a/scripts/npc/snealer.js
+++ b/scripts/npc/snealer.js
@@ -1,6 +1,6 @@
-import { startDialogueTree } from '../dialogue_system.js';
+import { startDialogueTree, showDialogue } from '../dialogue_system.js';
 import snealerDialogue from '../dialogue/npcs/snealer.js';
 
 export function interact() {
-  startDialogueTree(snealerDialogue);
+  showDialogue('snealer.intro', () => startDialogueTree(snealerDialogue));
 }


### PR DESCRIPTION
## Summary
- localize Snealer dialogue via i18n keys
- show intro line before dialogue tree
- translate dialogue choices dynamically
- provide translations for Snealer lines in EN, NL, JA, AR and RU

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c98b3f25c83319ba0953b9b3fa97f