### PR TITLE
Fix missing label translations

### DIFF
--- a/scripts/dialogue/npcs/snealer.js
+++ b/scripts/dialogue/npcs/snealer.js
@@ -1,31 +1,32 @@
-import { t } from '../../i18n.js';
+// Labels should store translation keys so that translations
+// are resolved only when the dialogue is displayed.
 
 export default [
   {
     text: 'snealer.dialogue.1.text',
     options: [
-      { label: t('snealer.dialogue.1.ask_fortune'), goto: 1 },
-      { label: t('snealer.dialogue.1.ask_answers'), goto: 2 },
-      { label: t('snealer.dialogue.1.leave'), goto: null }
+      { label: 'snealer.dialogue.1.ask_fortune', goto: 1 },
+      { label: 'snealer.dialogue.1.ask_answers', goto: 2 },
+      { label: 'snealer.dialogue.1.leave', goto: null }
     ]
   },
   {
     text: 'snealer.dialogue.2.text',
     options: [
-      { label: t('snealer.dialogue.2.refuse'), goto: null },
-      { label: t('snealer.dialogue.2.intrigued'), goto: 3 }
+      { label: 'snealer.dialogue.2.refuse', goto: null },
+      { label: 'snealer.dialogue.2.intrigued', goto: 3 }
     ]
   },
   {
     text: 'snealer.dialogue.3.text',
     options: [
-      { label: t('snealer.dialogue.3.ponder'), goto: null }
+      { label: 'snealer.dialogue.3.ponder', goto: null }
     ]
   },
   {
     text: 'snealer.dialogue.4.text',
     options: [
-      { label: t('snealer.dialogue.4.nod'), goto: null }
+      { label: 'snealer.dialogue.4.nod', goto: null }
     ]
   }
 ];

--- a/scripts/dialogue_system.js
+++ b/scripts/dialogue_system.js
@@ -201,7 +201,12 @@ export async function showDialogueWithChoices(keyOrText, choices = []) {
         key = choice.label;
       }
       const text = key ? t(key) : '[Missing Label]';
-      btn.textContent = text === '[Missing Translation]' ? '[Missing Label]' : text;
+      if (text === '[Missing Translation]') {
+        console.warn(`Missing translation key: ${key}`);
+        btn.textContent = '[Missing Label]';
+      } else {
+        btn.textContent = text;
+      }
       btn.addEventListener('click', () => choose(i));
       choicesEl.appendChild(btn);
       buttons.push(btn);

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -49,6 +49,7 @@ export function t(key) {
   if (Object.prototype.hasOwnProperty.call(enStrings, key)) {
     return enStrings[key];
   }
+  console.warn(`Missing translation key: ${key}`);
   return '[Missing Translation]';
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -61,14 +61,14 @@ import { initSettingsPanel } from './ui/settings_panel.js';
 // Inventory contents are managed in inventory.js
 
 let settings = loadSettings();
-if (hasLocale(settings.language)) {
-  setLanguage(settings.language);
-}
 
 const gridState = { cols: 0 };
 
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('game-grid');
+  if (hasLocale(settings.language)) {
+    await setLanguage(settings.language);
+  }
   // Prevent double-tap zoom on mobile devices
   document.addEventListener(
     'touchstart',


### PR DESCRIPTION
## Summary
- store translation keys in `snealer` dialogue so translations resolve when rendered
- log missing translation keys in `t()` and in dialogue choices
- wait for locale to load before starting the game

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684caf0ff1cc83319567ec2f483c19cd