### PR TITLE
Fix syntax error from JSON import assertions

### DIFF
--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -1,4 +1,9 @@
-/* Internationalization utilities */
+/* Internationalization utilities
+ *
+ * Locale files are plain JavaScript modules rather than JSON imports.
+ * This avoids the need for `assert { type: "json" }` which some
+ * browsers do not yet support and previously caused a syntax error.
+ */
 
 import en from './locales/en.js';
 import nl from './locales/nl.js';


### PR DESCRIPTION
## Summary
- clarify that locale modules use JS not JSON to avoid unsupported import assertions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684cc18540fc8331a71d350a4ad052e0