### PR TITLE
Add localized water restore message

### DIFF
--- a/scripts/locales/ar.js
+++ b/scripts/locales/ar.js
@@ -69,5 +69,6 @@ export default {
   "snealer.dialogue.3.text": "الحقيقة شفرة. قد تجرح نفسك بها، أيها المتجول.",
   "snealer.dialogue.3.ponder": "سأجازف.",
   "snealer.dialogue.4.text": "حكيم. عد إلي بشيء نادر، شيء يسقطه من يكرهون النور.",
-  "snealer.dialogue.4.nod": "حسنًا."
+  "snealer.dialogue.4.nod": "حسنًا.",
+  "message.water_restore": "الماء البارد يجددك. تم استعادة نقاط الصحة بالكامل."
 }

--- a/scripts/locales/en.js
+++ b/scripts/locales/en.js
@@ -76,5 +76,6 @@ export default {
   "snealer.dialogue.3.text": "Truth is a blade. You might cut yourself on it, wanderer.",
   "snealer.dialogue.3.ponder": "I'll risk it.",
   "snealer.dialogue.4.text": "Wise. Return with something rare, something dropped by those who hate the light.",
-  "snealer.dialogue.4.nod": "Got it."
+  "snealer.dialogue.4.nod": "Got it.",
+  "message.water_restore": "The cool water rejuvenates you. HP fully restored."
 }

--- a/scripts/locales/ja.js
+++ b/scripts/locales/ja.js
@@ -69,5 +69,6 @@ export default {
   "snealer.dialogue.3.text": "真実は刃だ。触れれば切れるぞ、旅人。",
   "snealer.dialogue.3.ponder": "やってみよう。",
   "snealer.dialogue.4.text": "賢いな。光を嫌う者たちが落とす珍品を持って戻れ。",
-  "snealer.dialogue.4.nod": "了解。"
+  "snealer.dialogue.4.nod": "了解。",
+  "message.water_restore": "冷たい水があなたを癒す。HPが全回復した。"
 }

--- a/scripts/locales/nl.js
+++ b/scripts/locales/nl.js
@@ -76,5 +76,6 @@ export default {
   "snealer.dialogue.3.text": "De waarheid is een mes. Je kunt jezelf eraan snijden, zwerver.",
   "snealer.dialogue.3.ponder": "Ik waag het.",
   "snealer.dialogue.4.text": "Wijs. Kom terug met iets zeldzaams, iets wat wordt achtergelaten door zij die het licht haten.",
-  "snealer.dialogue.4.nod": "Begrepen."
+  "snealer.dialogue.4.nod": "Begrepen.",
+  "message.water_restore": "Het koele water verjongt je. HP volledig hersteld."
 }

--- a/scripts/locales/ru.js
+++ b/scripts/locales/ru.js
@@ -69,5 +69,6 @@ export default {
   "snealer.dialogue.3.text": "Правда — это лезвие. Можешь порезаться, странник.",
   "snealer.dialogue.3.ponder": "Рискну.",
   "snealer.dialogue.4.text": "Мудро. Вернись с редкостью, добытой у тех, кто боится света.",
-  "snealer.dialogue.4.nod": "Понял."
+  "snealer.dialogue.4.nod": "Понял.",
+  "message.water_restore": "Прохладная вода освежает. HP полностью восстановлено."
 }

--- a/scripts/tile_type.js
+++ b/scripts/tile_type.js
@@ -34,6 +34,7 @@ export function isInteractable(symbol) {
 }
 
 import { showDialogue } from './dialogue_system.js';
+import { t } from './i18n.js';
 import { healFull, healToFull } from './player.js';
 import { applyDamage } from './logic.js';
 import { triggerDarkTrap, triggerFireTrap } from './trap_logic.js';
@@ -58,7 +59,7 @@ export async function onStepEffect(symbol, player, x, y) {
   } else if (symbol === 'W') {
     healToFull();
     if (!gameState.settings?.notifySkip) {
-      showDialogue('The cool water rejuvenates you. HP fully restored.');
+      showDialogue(t('message.water_restore'));
     }
     if (tileEl) {
       tileEl.classList.add('ripple');
@@ -191,7 +192,7 @@ export async function onInteractEffect(
     case 'W': {
       healToFull();
       if (!gameState.settings?.notifySkip) {
-        showDialogue('The cool water rejuvenates you. HP fully restored.');
+        showDialogue(t('message.water_restore'));
       }
       const index = y * cols + x;
       const tileEl = container.children[index];


### PR DESCRIPTION
## Summary
- localize water restore message in locales
- display localized message when using water tiles

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684cc89ed73483319f99355d3e2036bd