### PR TITLE
Implement localized chest interactions

### DIFF
--- a/data/maps/map01.json
+++ b/data/maps/map01.json
@@ -147,7 +147,9 @@
       "G",
       "G",
       {
-        "type": "C"
+        "type": "C",
+        "item": "rusty_key",
+        "opened": false
       },
       "G",
       "G",
@@ -246,7 +248,9 @@
       "G",
       "G",
       {
-        "type": "C"
+        "type": "C",
+        "item": "defense_potion_I",
+        "opened": false
       },
       "G",
       "F",
@@ -414,7 +418,9 @@
       "G",
       "G",
       {
-        "type": "C"
+        "type": "C",
+        "item": "old_coin",
+        "opened": false
       },
       "G",
       "G",

--- a/data/maps/map07_maze01.json
+++ b/data/maps/map07_maze01.json
@@ -179,7 +179,8 @@
       "F",
       {
         "type": "C",
-        "item": "maze_key_1"
+        "item": "maze_key_1",
+        "opened": false
       },
       "F",
       "G",

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -31,13 +31,16 @@ export function getLanguage() {
   return currentLang;
 }
 
-export function t(key) {
-  const value = translations[currentLang]?.[key] ?? translations.en?.[key];
-  if (!value) {
+export function t(key, vars = {}) {
+  const template = translations[currentLang]?.[key] ?? translations.en?.[key];
+  if (!template) {
     console.warn('[Translation Missing]:', key);
     return '[Missing Translation]';
   }
-  return value;
+  if (typeof template === 'string') {
+    return template.replace(/\{(\w+)\}/g, (_, k) => vars[k] ?? `{${k}}`);
+  }
+  return template;
 }
 
 export function applyTranslations() {

--- a/scripts/locales/ar.js
+++ b/scripts/locales/ar.js
@@ -70,5 +70,7 @@ export default {
   "snealer.dialogue.3.ponder": "سأجازف.",
   "snealer.dialogue.4.text": "حكيم. عد إلي بشيء نادر، شيء يسقطه من يكرهون النور.",
   "snealer.dialogue.4.nod": "حسنًا.",
-  "message.water_restore": "الماء البارد يجددك. تم استعادة نقاط الصحة بالكامل."
+  "message.water_restore": "الماء البارد يجددك. تم استعادة نقاط الصحة بالكامل.",
+  "message.chest_found": "وجدت {itemName} في الصندوق!",
+  "message.chest_empty": "الصندوق فارغ."
 }

--- a/scripts/locales/en.js
+++ b/scripts/locales/en.js
@@ -77,5 +77,7 @@ export default {
   "snealer.dialogue.3.ponder": "I'll risk it.",
   "snealer.dialogue.4.text": "Wise. Return with something rare, something dropped by those who hate the light.",
   "snealer.dialogue.4.nod": "Got it.",
-  "message.water_restore": "The cool water rejuvenates you. HP fully restored."
+  "message.water_restore": "The cool water rejuvenates you. HP fully restored.",
+  "message.chest_found": "You found {itemName} in the chest!",
+  "message.chest_empty": "The chest is empty."
 }

--- a/scripts/locales/ja.js
+++ b/scripts/locales/ja.js
@@ -70,5 +70,7 @@ export default {
   "snealer.dialogue.3.ponder": "やってみよう。",
   "snealer.dialogue.4.text": "賢いな。光を嫌う者たちが落とす珍品を持って戻れ。",
   "snealer.dialogue.4.nod": "了解。",
-  "message.water_restore": "冷たい水があなたを癒す。HPが全回復した。"
+  "message.water_restore": "冷たい水があなたを癒す。HPが全回復した。",
+  "message.chest_found": "宝箱の中に{itemName}を見つけた！",
+  "message.chest_empty": "宝箱は空っぽだ。"
 }

--- a/scripts/locales/nl.js
+++ b/scripts/locales/nl.js
@@ -77,5 +77,7 @@ export default {
   "snealer.dialogue.3.ponder": "Ik waag het.",
   "snealer.dialogue.4.text": "Wijs. Kom terug met iets zeldzaams, iets wat wordt achtergelaten door zij die het licht haten.",
   "snealer.dialogue.4.nod": "Begrepen.",
-  "message.water_restore": "Het koele water verjongt je. HP volledig hersteld."
+  "message.water_restore": "Het koele water verjongt je. HP volledig hersteld.",
+  "message.chest_found": "Je vond {itemName} in de kist!",
+  "message.chest_empty": "De kist is leeg."
 }

--- a/scripts/locales/ru.js
+++ b/scripts/locales/ru.js
@@ -70,5 +70,7 @@ export default {
   "snealer.dialogue.3.ponder": "Рискну.",
   "snealer.dialogue.4.text": "Мудро. Вернись с редкостью, добытой у тех, кто боится света.",
   "snealer.dialogue.4.nod": "Понял.",
-  "message.water_restore": "Прохладная вода освежает. HP полностью восстановлено."
+  "message.water_restore": "Прохладная вода освежает. HP полностью восстановлено.",
+  "message.chest_found": "Вы нашли {itemName} в сундуке!",
+  "message.chest_empty": "Сундук пуст."
 }

--- a/scripts/router.js
+++ b/scripts/router.js
@@ -50,6 +50,7 @@ export async function loadMap(filename, spawnPoint) {
     const [cx, cy] = coord.split(',').map(Number);
     if (grid[cy] && grid[cy][cx]) {
       grid[cy][cx].type = 'c';
+      grid[cy][cx].opened = true;
     }
   }
   currentMap = name;

--- a/scripts/tile_type.js
+++ b/scripts/tile_type.js
@@ -168,15 +168,14 @@ export async function onInteractEffect(
         }
         const result = await openChest(chestId, player);
         if (result) {
-          if (result.message) {
-            showDialogue(result.message);
-          }
           if (Array.isArray(result.items)) {
             result.items.forEach((it) => {
-              if (it) showDialogue(`You obtained ${it.name}!`);
+              if (it) showDialogue(t('message.chest_found', { itemName: it.name }));
             });
           } else if (result.item) {
-            showDialogue(`You obtained ${result.item.name}!`);
+            showDialogue(t('message.chest_found', { itemName: result.item.name }));
+          } else {
+            showDialogue(t('message.chest_empty'));
           }
           const idx = y * cols + x;
           const tileEl = container.children[idx];
@@ -185,7 +184,10 @@ export async function onInteractEffect(
             tileEl.classList.add('chest-opened', 'tile-c', 'blocked');
           }
           tile.type = 'c';
+          tile.opened = true;
         }
+      } else {
+        showDialogue(t('message.chest_empty'));
       }
       break;
     }


### PR DESCRIPTION
## Summary
- add new translation keys for chest messages
- support variable replacement in `t()`
- track opened chests on grid load
- localize chest interaction messages
- update map chest data with items and opened flag

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684ccda8c1208331940a6ed9f0497763