### PR TITLE
Fix Eryndor dialogue loader path

### DIFF
--- a/scripts/npc_dialogues/eryndor_dialogue_loader.js
+++ b/scripts/npc_dialogues/eryndor_dialogue_loader.js
@@ -4,10 +4,10 @@ export async function loadEryndorDialogue() {
   const lang = getLanguage().toLowerCase();
   const fallback = 'en';
   try {
-    const module = await import(`../npc-dialogues/eryndor_${lang}_dialogue.js`);
+    const module = await import(`../../npc-dialogues/eryndor_${lang}_dialogue.js`);
     return module.eryndorDialogue || module.default;
   } catch (err) {
-    const fallbackModule = await import(`../npc-dialogues/eryndor_${fallback}_dialogue.js`);
+    const fallbackModule = await import(`../../npc-dialogues/eryndor_${fallback}_dialogue.js`);
     return fallbackModule.eryndorDialogue || fallbackModule.default;
   }
 }


### PR DESCRIPTION
## Summary
- fix path in `loadEryndorDialogue` so it loads from the root `npc-dialogues` directory

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ce37e1aa8833187eeefec7c1677e8