### PR TITLE
Redesigned combat UI layout

### DIFF
--- a/combat_view.html
+++ b/combat_view.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<div class="combat-screen">
+  <div class="turn-queue spd-log"></div>
+  <div class="combatants">
+    <div class="player-team">
+      <div class="combatant empty"></div>
+      <div class="combatant empty"></div>
+      <div class="combatant empty"></div>
+    </div>
+    <div id="combat-log" class="log"></div>
+    <div class="enemy-team">
+      <div class="combatant empty"></div>
+      <div class="combatant empty"></div>
+      <div class="combatant empty"></div>
+    </div>
+  </div>
+  <div class="actions">
+    <div class="action-tabs">
+      <button class="offensive-tab" data-i18n="combat.category.offensive"></button>
+      <button class="defensive-tab" data-i18n="combat.category.defensive"></button>
+      <button class="items-tab" data-i18n="combat.category.items"></button>
+    </div>
+    <div class="tab-panels">
+      <div class="offensive-skill-buttons tab-panel"></div>
+      <div class="defensive-skill-buttons tab-panel hidden"></div>
+      <div class="item-buttons tab-panel hidden"></div>
+    </div>
+  </div>
+</div>

--- a/scripts/combat_system.js
+++ b/scripts/combat_system.js
@@ -38,6 +38,7 @@ import {
   updateStatusUI,
   renderSkillList,
   renderTurnQueue,
+  renderCombatants,
   setSkillDisabledState,
   initLogPanel,
   showVictoryMessage,
@@ -90,30 +91,21 @@ export async function startCombat(enemy, player) {
   overlay.classList.add('battle-transition');
   overlay.innerHTML = `
     <div class="combat-screen">
-      <div class="turn-queue"></div>
+      <div class="turn-queue spd-log"></div>
       <div class="combatants">
-        <div class="combatant player">
-          <div class="name">Hero</div>
-          <div class="hp-bar"><div class="hp"></div></div>
-          <div class="statuses status-effects player-statuses"></div>
-        </div>
-        <div class="combatant enemy intro-anim">
-          <div class="portrait">${enemy.portrait || '👾'}</div>
-          <div class="name">${enemy.name}</div>
-          <div class="desc">${enemy.description || ''}</div>
-          <div class="hp-bar"><div class="hp"></div></div>
-          <div class="statuses status-effects enemy-statuses"></div>
-        </div>
+        <div class="player-team"></div>
+        <div id="combat-log" class="log hidden"></div>
+        <div class="enemy-team"></div>
       </div>
       <div class="intro-text">${
         enemy.intro || 'A shadowy beast snarls and prepares to strike!'
       }</div>
       <div class="actions hidden">
-        <button id="auto-battle-toggle" class="auto-battle-btn">Toggle Auto-Battle</button>
+        <button id="auto-battle-toggle" class="auto-battle-btn" data-i18n="combat.auto.toggle">${t('combat.auto.toggle')}</button>
         <div class="action-tabs">
-          <button class="offensive-tab selected">Offensive</button>
-          <button class="defensive-tab">Defensive</button>
-          <button class="items-tab">Items</button>
+          <button class="offensive-tab selected" data-i18n="combat.category.offensive">${t('combat.category.offensive')}</button>
+          <button class="defensive-tab" data-i18n="combat.category.defensive">${t('combat.category.defensive')}</button>
+          <button class="items-tab" data-i18n="combat.category.items">${t('combat.category.items')}</button>
         </div>
         <div class="tab-panels">
           <div class="offensive-skill-buttons tab-panel"></div>
@@ -122,17 +114,25 @@ export async function startCombat(enemy, player) {
         </div>
       </div>
       <div id="skill-preview" class="skill-preview hidden"></div>
-      <div id="combat-log" class="log hidden"></div>
     </div>`;
 
   document.body.appendChild(overlay);
+  renderCombatants(
+    overlay.querySelector('.combatants'),
+    Array.isArray(player) ? player : [player],
+    Array.isArray(enemy) ? enemy : [enemy]
+  );
   resetBossPhase(enemy.id);
   if (enemy.id === 'echo_absolute') setPhase(1);
   document.dispatchEvent(new CustomEvent('combatStarted'));
   requestAnimationFrame(() => overlay.classList.add('active'));
 
-  const playerBar = overlay.querySelector('.player .hp');
-  const enemyBar = overlay.querySelector('.enemy .hp');
+  const playerBar = overlay.querySelector(
+    '.player-team .combatant[data-index="0"] .hp'
+  );
+  const enemyBar = overlay.querySelector(
+    '.enemy-team .combatant[data-index="0"] .hp'
+  );
 
   const statsBonus = getTotalStats();
   const playerMax = (player.maxHp ?? 100) + (statsBonus.maxHp || 0);
@@ -165,13 +165,13 @@ export async function startCombat(enemy, player) {
 
   if (autoBtn) {
     autoBtn.textContent = combatState.autoBattle
-      ? 'Auto-Battle ON'
-      : 'Auto-Battle OFF';
+      ? t('combat.auto.on')
+      : t('combat.auto.off');
     autoBtn.addEventListener('click', () => {
       combatState.autoBattle = !combatState.autoBattle;
       autoBtn.textContent = combatState.autoBattle
-        ? 'Auto-Battle ON'
-        : 'Auto-Battle OFF';
+        ? t('combat.auto.on')
+        : t('combat.auto.off');
     });
   }
 

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -20,18 +20,20 @@ export function renderCombatants(root, players = [], enemies = [], onSelect) {
   const enemySide = document.createElement('div');
   enemySide.className = 'enemy-team';
 
-  players.forEach((p, idx) => {
-    const el = createCombatantEl(p, true, idx);
+  for (let i = 0; i < 3; i++) {
+    const p = players[i] || null;
+    const el = createCombatantEl(p, true, i);
     playerSide.appendChild(el);
-  });
-  enemies.forEach((e, idx) => {
-    const el = createCombatantEl(e, false, idx);
-    if (typeof onSelect === 'function') {
+  }
+  for (let i = 0; i < 3; i++) {
+    const e = enemies[i] || null;
+    const el = createCombatantEl(e, false, i);
+    if (e && typeof onSelect === 'function') {
       el.classList.add('selectable');
-      el.addEventListener('click', () => onSelect(e, idx, el));
+      el.addEventListener('click', () => onSelect(e, i, el));
     }
     enemySide.appendChild(el);
-  });
+  }
 
   container.appendChild(playerSide);
   container.appendChild(enemySide);
@@ -50,10 +52,14 @@ function createCombatantEl(entity, isPlayer, index) {
   const wrapper = document.createElement('div');
   wrapper.className = `combatant ${isPlayer ? 'player' : 'enemy'}`;
   wrapper.dataset.index = index;
-  if (entity.portrait) {
+  if (!entity) {
+    wrapper.classList.add('empty');
+    return wrapper;
+  }
+  if (entity.portrait || entity.icon) {
     const portrait = document.createElement('div');
     portrait.className = 'portrait';
-    portrait.textContent = entity.portrait;
+    portrait.textContent = entity.portrait || entity.icon;
     wrapper.appendChild(portrait);
   }
   const name = document.createElement('div');
@@ -80,6 +86,7 @@ export function highlightActing(root, isPlayer, index) {
     isPlayer ? '.player-team .combatant' : '.enemy-team .combatant'
   );
   group.forEach((el) => {
+    if (el.classList.contains('empty')) return;
     const match = Number(el.dataset.index) === index;
     if (match) el.classList.add('acting');
     else el.classList.remove('acting');
@@ -92,6 +99,7 @@ export function highlightTarget(root, isPlayer, index) {
     isPlayer ? '.player-team .combatant' : '.enemy-team .combatant'
   );
   group.forEach((el) => {
+    if (el.classList.contains('empty')) return;
     const match = Number(el.dataset.index) === index;
     if (match) el.classList.add('targeted');
     else el.classList.remove('targeted');

--- a/scripts/locales/ar.js
+++ b/scripts/locales/ar.js
@@ -165,5 +165,11 @@ export default {
   'combat.silenced': 'حالة الصمت تمنعك من الفعل!',
   'combat.paralyzed': '{enemy} مشلول ولا يستطيع التحرك!',
   'combat.confused': '{enemy} مرتبك ومتردد!',
-  'combat.unstable': '{enemy} غير مستقر ويتمايل!'
+  'combat.unstable': '{enemy} غير مستقر ويتمايل!',
+  'combat.category.offensive': 'Offensive',
+  'combat.category.defensive': 'Defensive',
+  'combat.category.items': 'Items',
+  'combat.auto.toggle': 'Toggle Auto-Battle',
+  'combat.auto.on': 'Auto-Battle ON',
+  'combat.auto.off': 'Auto-Battle OFF'
 };

--- a/scripts/locales/en.js
+++ b/scripts/locales/en.js
@@ -173,4 +173,11 @@ export default {
   'combat.paralyzed': '{enemy} is paralyzed and cannot act!',
   'combat.confused': '{enemy} looks confused and hesitates!',
   'combat.unstable': '{enemy} staggers in instability!'
+  ,
+  'combat.category.offensive': 'Offensive',
+  'combat.category.defensive': 'Defensive',
+  'combat.category.items': 'Items',
+  'combat.auto.toggle': 'Toggle Auto-Battle',
+  'combat.auto.on': 'Auto-Battle ON',
+  'combat.auto.off': 'Auto-Battle OFF'
 };

--- a/scripts/locales/ja.js
+++ b/scripts/locales/ja.js
@@ -165,5 +165,11 @@ export default {
   'combat.silenced': '沈黙状態で行動できない！',
   'combat.paralyzed': '{enemy}は麻痺して動けない！',
   'combat.confused': '{enemy}は混乱している！',
-  'combat.unstable': '{enemy}は不安定に揺らいでいる！'
+  'combat.unstable': '{enemy}は不安定に揺らいでいる！',
+  'combat.category.offensive': 'Offensive',
+  'combat.category.defensive': 'Defensive',
+  'combat.category.items': 'Items',
+  'combat.auto.toggle': 'Toggle Auto-Battle',
+  'combat.auto.on': 'Auto-Battle ON',
+  'combat.auto.off': 'Auto-Battle OFF'
 };

--- a/scripts/locales/nl.js
+++ b/scripts/locales/nl.js
@@ -174,4 +174,11 @@ export default {
   'combat.paralyzed': '{enemy} is verlamd en kan niet handelen!',
   'combat.confused': '{enemy} is verward en aarzelt!',
   'combat.unstable': '{enemy} wankelt onstabiel!'
+  ,
+  'combat.category.offensive': 'Offensive',
+  'combat.category.defensive': 'Defensive',
+  'combat.category.items': 'Items',
+  'combat.auto.toggle': 'Toggle Auto-Battle',
+  'combat.auto.on': 'Auto-Battle ON',
+  'combat.auto.off': 'Auto-Battle OFF'
 };

--- a/scripts/locales/ru.js
+++ b/scripts/locales/ru.js
@@ -167,5 +167,11 @@ export default {
   'combat.silenced': 'Немота не даёт действовать!',
   'combat.paralyzed': '{enemy} парализован и не может ходить!',
   'combat.confused': '{enemy} в замешательстве!',
-  'combat.unstable': '{enemy} пошатнулся в нестабильности!'
+  'combat.unstable': '{enemy} пошатнулся в нестабильности!',
+  'combat.category.offensive': 'Offensive',
+  'combat.category.defensive': 'Defensive',
+  'combat.category.items': 'Items',
+  'combat.auto.toggle': 'Toggle Auto-Battle',
+  'combat.auto.on': 'Auto-Battle ON',
+  'combat.auto.off': 'Auto-Battle OFF'
 };

--- a/style/combat.css
+++ b/style/combat.css
@@ -36,15 +36,36 @@
 
 #battle-overlay .combatants {
   display: flex;
-  width: 80%;
-  justify-content: space-between;
-  align-items: center;
+  width: 100%;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 12px;
   margin-bottom: 20px;
+}
+
+#battle-overlay .player-team,
+#battle-overlay .enemy-team {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 120px;
+  align-items: center;
+}
+
+#battle-overlay .combatants #combat-log {
+  flex: 0 0 260px;
 }
 
 #battle-overlay .combatant {
   margin: 10px;
   text-align: center;
+}
+
+#battle-overlay .combatant.empty {
+  opacity: 0.3;
+  border: 1px dashed #666;
+  width: 100px;
+  height: 100px;
 }
 
 #battle-overlay .combatant .portrait {
@@ -324,6 +345,10 @@
   #battle-overlay .turn-queue .turn-entry {
     font-size: 12px;
     padding: 2px 6px;
+  }
+  #battle-overlay .combatants {
+    flex-direction: column;
+    align-items: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- overhaul combat screen HTML layout
- add translation strings for combat categories and auto-battle labels
- render placeholder combatant tiles for up to three units per side
- update auto-battle toggle text handling
- style updates for new layout
- include design reference file `combat_view.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf8b02124833182f7e6db14bd4e1d