### PR TITLE
Improve combat UI

### DIFF
--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -283,6 +283,8 @@ export function renderSkillList(container, skills, onClick) {
   const map = {};
   skills.forEach((skill) => {
     const btn = document.createElement('button');
+    btn.className = 'skill-btn';
+    btn.dataset.id = skill.id;
     const effects = [];
     if (Array.isArray(skill.statuses)) {
       skill.statuses.forEach((s) => {
@@ -303,7 +305,7 @@ export function renderSkillList(container, skills, onClick) {
       .filter(Boolean)
       .join(' ');
     const icon = skill.icon ? `${skill.icon} ` : '';
-    btn.innerHTML = `<strong>${icon}${skill.name}</strong><div class="desc">${descParts}</div>`;
+    btn.innerHTML = `<strong>${icon}${skill.name}</strong><div class="desc">${descParts}</div><div class="cooldown-overlay hidden"></div>`;
     btn.addEventListener('click', () => onClick(skill));
     attachSkillTooltip(btn, skill);
     container.appendChild(btn);
@@ -323,12 +325,23 @@ export function setSkillDisabledState(
     const def = skillLookup[id];
     const offensive = def?.category === 'offensive';
     const exempt = def?.silenceExempt;
-    if ((isSilenced && offensive && !exempt) || cooldowns[id] > 0) {
+    const cd = cooldowns[id] || 0;
+    const overlay = btn.querySelector('.cooldown-overlay');
+    if ((isSilenced && offensive && !exempt) || cd > 0) {
       btn.classList.add('disabled');
       btn.disabled = true;
     } else {
       btn.classList.remove('disabled');
       btn.disabled = false;
+    }
+    if (overlay) {
+      if (cd > 0) {
+        overlay.textContent = cd;
+        overlay.classList.remove('hidden');
+      } else {
+        overlay.textContent = '';
+        overlay.classList.add('hidden');
+      }
     }
   });
 }

--- a/scripts/locales/ar.js
+++ b/scripts/locales/ar.js
@@ -171,5 +171,6 @@ export default {
   'combat.category.items': 'Items',
   'combat.auto.toggle': 'Toggle Auto-Battle',
   'combat.auto.on': 'Auto-Battle ON',
-  'combat.auto.off': 'Auto-Battle OFF'
+  'combat.auto.off': 'Auto-Battle OFF',
+  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.'
 };

--- a/scripts/locales/en.js
+++ b/scripts/locales/en.js
@@ -179,5 +179,6 @@ export default {
   'combat.category.items': 'Items',
   'combat.auto.toggle': 'Toggle Auto-Battle',
   'combat.auto.on': 'Auto-Battle ON',
-  'combat.auto.off': 'Auto-Battle OFF'
+  'combat.auto.off': 'Auto-Battle OFF',
+  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.'
 };

--- a/scripts/locales/ja.js
+++ b/scripts/locales/ja.js
@@ -171,5 +171,6 @@ export default {
   'combat.category.items': 'Items',
   'combat.auto.toggle': 'Toggle Auto-Battle',
   'combat.auto.on': 'Auto-Battle ON',
-  'combat.auto.off': 'Auto-Battle OFF'
+  'combat.auto.off': 'Auto-Battle OFF',
+  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.'
 };

--- a/scripts/locales/nl.js
+++ b/scripts/locales/nl.js
@@ -180,5 +180,6 @@ export default {
   'combat.category.items': 'Items',
   'combat.auto.toggle': 'Toggle Auto-Battle',
   'combat.auto.on': 'Auto-Battle ON',
-  'combat.auto.off': 'Auto-Battle OFF'
+  'combat.auto.off': 'Auto-Battle OFF',
+  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.'
 };

--- a/scripts/locales/ru.js
+++ b/scripts/locales/ru.js
@@ -173,5 +173,6 @@ export default {
   'combat.category.items': 'Items',
   'combat.auto.toggle': 'Toggle Auto-Battle',
   'combat.auto.on': 'Auto-Battle ON',
-  'combat.auto.off': 'Auto-Battle OFF'
+  'combat.auto.off': 'Auto-Battle OFF',
+  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.'
 };

--- a/style/combat.css
+++ b/style/combat.css
@@ -214,11 +214,26 @@
   background: #444;
   color: #fff;
   border: 1px solid #222;
+  position: relative;
 }
 
 #battle-overlay .actions button.disabled {
   opacity: 0.5;
   pointer-events: none;
+}
+
+#battle-overlay .cooldown-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+}
+
+#battle-overlay .cooldown-overlay.hidden {
+  display: none;
 }
 
 #battle-overlay .tab-panel button .desc {

--- a/ui/skills_panel.js
+++ b/ui/skills_panel.js
@@ -1,8 +1,11 @@
 import { showItemTooltip, hideItemTooltip } from '../scripts/utils.js';
+import { t } from '../scripts/i18n.js';
 
 export function attachTooltip(button, skill) {
   if (!button || !skill) return;
-  const parts = [skill.description];
+  const descKey = `combat.skill.${skill.id}.description`;
+  const baseDesc = t(descKey);
+  const parts = [baseDesc !== '[Missing Translation]' ? baseDesc : skill.description];
   if (typeof skill.cost === 'number' && skill.cost > 0) {
     parts.push(`Cost: ${skill.cost}`);
   }


### PR DESCRIPTION
## Summary
- add missing translation for Strike description
- support localized tooltips for skills
- display cooldown overlays on skill buttons
- style cooldown overlays in combat view

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684d0080f7588331b8c0988d3cbda52c