### PR TITLE
Refactor combat UI layout

### DIFF
--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -56,12 +56,18 @@ function createCombatantEl(entity, isPlayer, index) {
     wrapper.classList.add('empty');
     return wrapper;
   }
+  const portrait = document.createElement('div');
+  portrait.className = 'portrait';
   if (entity.portrait || entity.icon) {
-    const portrait = document.createElement('div');
-    portrait.className = 'portrait';
     portrait.textContent = entity.portrait || entity.icon;
-    wrapper.appendChild(portrait);
+  } else if (!isPlayer) {
+    portrait.textContent = '▲';
+    portrait.classList.add('enemy-icon');
+    portrait.dataset.tier = entity.boss ? 'boss' : entity.type || 'spawn';
+  } else {
+    portrait.textContent = '🧍';
   }
+  wrapper.appendChild(portrait);
   const name = document.createElement('div');
   name.className = 'name';
   name.textContent = entity.name || (isPlayer ? 'Player' : 'Enemy');
@@ -169,9 +175,8 @@ export function clearSkillTargetHighlights() {
 
 function getTurnLabel(unit) {
   if (!unit) return '';
-  return (
-    unit.portrait || unit.icon || (unit.isPlayer || unit.isAlly ? '🧍' : '👾')
-  );
+  if (unit.portrait || unit.icon) return unit.portrait || unit.icon;
+  return unit.isPlayer || unit.isAlly ? '🧍' : '▲';
 }
 
 export function renderTurnQueue(container, queue = [], active, index = 0) {
@@ -184,6 +189,11 @@ export function renderTurnQueue(container, queue = [], active, index = 0) {
     const box = document.createElement('div');
     box.className = 'turn-entry';
     box.textContent = getTurnLabel(unit);
+    box.title = unit.name;
+    if (!unit.isPlayer && !unit.isAlly && !unit.icon && !unit.portrait) {
+      box.classList.add('enemy-icon');
+      box.dataset.tier = unit.boss ? 'boss' : unit.type || 'spawn';
+    }
     if (unit === active && i === 0) box.classList.add('active');
     if (unit.hp <= 0 || hasStatus(unit, 'stunned')) {
       box.classList.add('skipped');

--- a/scripts/status_tracker.js
+++ b/scripts/status_tracker.js
@@ -1,0 +1,36 @@
+export function highlightActiveUnit(overlay, unit, players = [], enemies = []) {
+  if (!overlay || !unit) return;
+  overlay
+    .querySelectorAll('.combatant')
+    .forEach((el) => el.classList.remove('acting'));
+  const idx =
+    unit.isPlayer || unit.isAlly
+      ? players.indexOf(unit)
+      : enemies.indexOf(unit);
+  const selector =
+    unit.isPlayer || unit.isAlly
+      ? `.player-team .combatant[data-index="${idx}"]`
+      : `.enemy-team .combatant[data-index="${idx}"]`;
+  const el = overlay.querySelector(selector);
+  if (el) el.classList.add('acting');
+}
+
+export function syncHpBars(overlay, players = [], enemies = []) {
+  if (!overlay) return;
+  players.forEach((p, i) => {
+    const el = overlay.querySelector(
+      `.player-team .combatant[data-index="${i}"] .hp`
+    );
+    if (el && p && p.maxHp) {
+      el.style.width = `${(p.hp / p.maxHp) * 100}%`;
+    }
+  });
+  enemies.forEach((e, i) => {
+    const el = overlay.querySelector(
+      `.enemy-team .combatant[data-index="${i}"] .hp`
+    );
+    if (el && e && e.maxHp) {
+      el.style.width = `${(e.hp / e.maxHp) * 100}%`;
+    }
+  });
+}

--- a/style/combat.css
+++ b/style/combat.css
@@ -35,10 +35,11 @@
 }
 
 #battle-overlay .combatants {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   width: 100%;
   justify-content: center;
-  align-items: flex-start;
+  align-items: start;
   gap: 12px;
   margin-bottom: 20px;
 }
@@ -53,7 +54,8 @@
 }
 
 #battle-overlay .combatants #combat-log {
-  flex: 0 0 260px;
+  width: 260px;
+  justify-self: center;
 }
 
 #battle-overlay .combatant {
@@ -71,6 +73,19 @@
 #battle-overlay .combatant .portrait {
   font-size: 48px;
   margin-bottom: 5px;
+}
+
+#battle-overlay .enemy-icon[data-tier='spawn'] {
+  color: #e74c3c;
+}
+#battle-overlay .enemy-icon[data-tier='advanced'] {
+  color: #b22222;
+}
+#battle-overlay .enemy-icon[data-tier='elite'] {
+  color: #721414;
+}
+#battle-overlay .enemy-icon[data-tier='boss'] {
+  color: #4b0000;
 }
 
 #battle-overlay .combatant .desc {
@@ -156,15 +171,17 @@
 
 #battle-overlay .actions {
   margin-top: 20px;
-  text-align: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
 #battle-overlay .action-tabs {
-  margin-bottom: 10px;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   gap: 6px;
-  flex-wrap: wrap;
 }
 
 #battle-overlay .action-tabs button {
@@ -194,6 +211,14 @@
   justify-content: center;
   gap: 8px;
   margin-bottom: 6px;
+  flex: 1 1 auto;
+}
+#battle-overlay .tab-panels {
+  display: flex;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
+  justify-content: center;
+  gap: 8px;
 }
 
 #battle-overlay .hidden {
@@ -320,6 +345,18 @@
   justify-content: center;
   background: rgba(0, 0, 0, 0.5);
 }
+#battle-overlay .turn-entry.enemy-icon[data-tier='spawn'] {
+  color: #e74c3c;
+}
+#battle-overlay .turn-entry.enemy-icon[data-tier='advanced'] {
+  color: #b22222;
+}
+#battle-overlay .turn-entry.enemy-icon[data-tier='elite'] {
+  color: #721414;
+}
+#battle-overlay .turn-entry.enemy-icon[data-tier='boss'] {
+  color: #4b0000;
+}
 
 #battle-overlay .turn-entry.active {
   border-color: gold;
@@ -352,7 +389,6 @@
   box-shadow: 0 0 6px rgba(0, 255, 255, 0.8);
 }
 
-
 @media (max-width: 600px) {
   #battle-overlay .turn-queue {
     overflow-x: auto;
@@ -362,8 +398,13 @@
     padding: 2px 6px;
   }
   #battle-overlay .combatants {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
+    justify-items: center;
+  }
+  #battle-overlay .actions {
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
   }
 }
 


### PR DESCRIPTION
## Summary
- style combat grid with CSS grid
- color enemy icons by tier and use triangle icons
- show icon colors in speed log
- track active unit with new `status_tracker` helper
- adjust responsive layout and action panel

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684d852d8cb48331bd53e6b3ca5cbda3