### PR TITLE
Refine combat UI for portrait mode

### DIFF
--- a/combat_view.html
+++ b/combat_view.html
@@ -1,24 +1,24 @@
 <!doctype html>
 <div class="combat-screen">
-  <div class="turn-queue spd-log"></div>
+  <div class="turn-queue spd-log spd-bar"></div>
   <div class="combatants">
     <div class="player-team">
-      <div class="combatant empty"></div>
-      <div class="combatant empty"></div>
-      <div class="combatant empty"></div>
+      <div class="combatant combat-box empty"></div>
+      <div class="combatant combat-box empty"></div>
+      <div class="combatant combat-box empty"></div>
     </div>
-    <div id="combat-log" class="log"></div>
+    <div id="combat-log" class="log combat-log"></div>
     <div class="enemy-team">
-      <div class="combatant empty"></div>
-      <div class="combatant empty"></div>
-      <div class="combatant empty"></div>
+      <div class="combatant combat-box empty"></div>
+      <div class="combatant combat-box empty"></div>
+      <div class="combatant combat-box empty"></div>
     </div>
   </div>
   <div class="actions">
     <div class="action-tabs">
-      <button class="offensive-tab" data-i18n="combat.category.offensive"></button>
-      <button class="defensive-tab" data-i18n="combat.category.defensive"></button>
-      <button class="items-tab" data-i18n="combat.category.items"></button>
+      <button class="offensive-tab combat-skill-category" data-i18n="combat.category.offensive"></button>
+      <button class="defensive-tab combat-skill-category" data-i18n="combat.category.defensive"></button>
+      <button class="items-tab combat-skill-category" data-i18n="combat.category.items"></button>
     </div>
     <div class="tab-panels">
       <div class="offensive-skill-buttons tab-panel"></div>

--- a/scripts/combat_renderer.js
+++ b/scripts/combat_renderer.js
@@ -40,3 +40,16 @@ export function hideSkillPreview() {
     previewEl.classList.add('hidden');
   }
 }
+
+export function initPortraitLayout(overlay) {
+  if (!overlay) return;
+  const mq = window.matchMedia(
+    '(max-width: 768px) and (orientation: portrait)'
+  );
+  const update = () => {
+    if (mq.matches) overlay.classList.add('portrait');
+    else overlay.classList.remove('portrait');
+  };
+  mq.addEventListener('change', update);
+  update();
+}

--- a/scripts/combat_system.js
+++ b/scripts/combat_system.js
@@ -50,7 +50,8 @@ import { chooseBestSkill } from './ai_logic.js';
 import {
   initSkillPreview,
   showSkillPreview,
-  hideSkillPreview
+  hideSkillPreview,
+  initPortraitLayout
 } from './combat_renderer.js';
 import { clearActiveTile } from './grid_renderer.js';
 import {
@@ -91,10 +92,10 @@ export async function startCombat(enemy, player) {
   overlay.classList.add('battle-transition');
   overlay.innerHTML = `
     <div class="combat-screen">
-      <div class="turn-queue spd-log"></div>
+      <div class="turn-queue spd-log spd-bar"></div>
       <div class="combatants">
         <div class="player-team"></div>
-        <div id="combat-log" class="log hidden"></div>
+        <div id="combat-log" class="log combat-log hidden"></div>
         <div class="enemy-team"></div>
       </div>
       <div class="intro-text">${
@@ -103,9 +104,9 @@ export async function startCombat(enemy, player) {
       <div class="actions hidden">
         <button id="auto-battle-toggle" class="auto-battle-btn" data-i18n="combat.auto.toggle">${t('combat.auto.toggle')}</button>
         <div class="action-tabs">
-          <button class="offensive-tab selected" data-i18n="combat.category.offensive">${t('combat.category.offensive')}</button>
-          <button class="defensive-tab" data-i18n="combat.category.defensive">${t('combat.category.defensive')}</button>
-          <button class="items-tab" data-i18n="combat.category.items">${t('combat.category.items')}</button>
+          <button class="offensive-tab combat-skill-category selected" data-i18n="combat.category.offensive">${t('combat.category.offensive')}</button>
+          <button class="defensive-tab combat-skill-category" data-i18n="combat.category.defensive">${t('combat.category.defensive')}</button>
+          <button class="items-tab combat-skill-category" data-i18n="combat.category.items">${t('combat.category.items')}</button>
         </div>
         <div class="tab-panels">
           <div class="offensive-skill-buttons tab-panel"></div>
@@ -117,6 +118,7 @@ export async function startCombat(enemy, player) {
     </div>`;
 
   document.body.appendChild(overlay);
+  initPortraitLayout(overlay);
   renderCombatants(
     overlay.querySelector('.combatants'),
     Array.isArray(player) ? player : [player],

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -50,7 +50,7 @@ function formatStats(entity) {
 
 function createCombatantEl(entity, isPlayer, index) {
   const wrapper = document.createElement('div');
-  wrapper.className = `combatant ${isPlayer ? 'player' : 'enemy'}`;
+  wrapper.className = `combatant combat-box ${isPlayer ? 'player' : 'enemy'}`;
   wrapper.dataset.index = index;
   if (!entity) {
     wrapper.classList.add('empty');
@@ -293,7 +293,7 @@ export function renderSkillList(container, skills, onClick) {
   const map = {};
   skills.forEach((skill) => {
     const btn = document.createElement('button');
-    btn.className = 'skill-btn';
+    btn.className = 'skill-btn combat-skill-button';
     btn.dataset.id = skill.id;
     const effects = [];
     if (Array.isArray(skill.statuses)) {

--- a/scripts/responsive.js
+++ b/scripts/responsive.js
@@ -1,0 +1,13 @@
+export function isPortraitMobile() {
+  return window.innerWidth <= 768 && window.innerHeight > window.innerWidth;
+}
+
+export function onPortraitChange(cb) {
+  const mq = window.matchMedia('(max-width: 768px) and (orientation: portrait)');
+  function handler() {
+    cb(mq.matches);
+  }
+  mq.addEventListener('change', handler);
+  handler();
+  return () => mq.removeEventListener('change', handler);
+}

--- a/style/combat.css
+++ b/style/combat.css
@@ -34,6 +34,35 @@
   position: relative;
 }
 
+/* semantic helper classes */
+#battle-overlay .combat-box {
+  margin: 10px;
+  text-align: center;
+}
+
+#battle-overlay .combat-log {
+  width: 260px;
+  justify-self: center;
+}
+
+#battle-overlay .spd-bar {
+  width: 100%;
+}
+
+#battle-overlay .combat-skill-category {
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1px solid #333;
+}
+
+#battle-overlay .combat-skill-button {
+  padding: 10px;
+  border-radius: 6px;
+  background-color: #2b2b2b;
+  color: white;
+  text-align: center;
+}
+
 #battle-overlay .combatants {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
@@ -53,10 +82,6 @@
   align-items: center;
 }
 
-#battle-overlay .combatants #combat-log {
-  width: 260px;
-  justify-self: center;
-}
 
 #battle-overlay .combatant {
   margin: 10px;
@@ -549,9 +574,10 @@
   }
 
   #battle-overlay .turn-queue {
+    width: 90%;
     text-align: center;
-    margin-bottom: 6px;
-    font-size: 12px;
+    margin: 0 auto 10px;
+    font-size: 0.8em;
     color: #ccc;
   }
 
@@ -573,6 +599,7 @@
   #battle-overlay .combatant {
     width: 60px;
     height: 60px;
+    margin: 4px auto;
     background-color: #1a1a1a;
     border: 1px solid #444;
     border-radius: 8px;
@@ -583,15 +610,15 @@
   }
 
   #battle-overlay #combat-log {
-    width: 95%;
-    height: 100px;
+    width: 80%;
+    height: 150px;
+    margin: 0 auto;
     background: #111;
     color: #eee;
     overflow-y: auto;
-    font-size: 13px;
+    font-size: 0.85em;
     padding: 8px;
     border-radius: 6px;
-    margin-bottom: 12px;
   }
 
   #battle-overlay .actions {
@@ -607,19 +634,28 @@
     gap: 10px;
   }
 
+  #battle-overlay .action-tabs button {
+    width: 80px;
+    height: 40px;
+    font-size: 0.75em;
+    margin-bottom: 6px;
+  }
+
   #battle-overlay .tab-panels {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    width: 60%;
+    width: 100%;
   }
 
   #battle-overlay .tab-panel button {
+    width: 70%;
+    height: 50px;
+    margin: 6px auto;
+    font-size: 1em;
     background-color: #2b2b2b;
     color: white;
-    padding: 10px;
     border-radius: 6px;
     text-align: center;
-    font-size: 14px;
   }
 }


### PR DESCRIPTION
## Summary
- add semantic classes to combat UI elements and responsive helpers
- tweak combat markup for new classes
- add portrait layout initialization and detection helpers
- refine mobile portrait styles for combat screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8b4dbb1c8331b4cf081dfc35a906