### PR TITLE
Adjust mobile combat layout

### DIFF
--- a/scripts/combat_renderer.js
+++ b/scripts/combat_renderer.js
@@ -53,3 +53,15 @@ export function initPortraitLayout(overlay) {
   mq.addEventListener('change', update);
   update();
 }
+
+export function injectMiniHpBars(container) {
+  if (!container) return;
+  container.querySelectorAll('.combatant').forEach((el) => {
+    if (!el.querySelector('.hp-bar')) {
+      const bar = document.createElement('div');
+      bar.className = 'hp-bar';
+      bar.innerHTML = '<div class="hp"></div>';
+      el.appendChild(bar);
+    }
+  });
+}

--- a/ui/combat/combat_layout.css
+++ b/ui/combat/combat_layout.css
@@ -1,0 +1,81 @@
+.combat-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.combatants {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  width: 100%;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.player-team,
+.enemy-team {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.combat-box {
+  width: 48px;
+  height: 48px;
+  background: #222;
+  border: 1px solid #555;
+  border-radius: 6px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  margin: 4px 0;
+}
+
+.combat-box .hp-bar {
+  position: absolute;
+  bottom: -6px;
+  left: 2px;
+  right: 2px;
+  height: 4px;
+  background: #444;
+}
+
+.combat-box .hp-bar .hp {
+  background: #e74c3c;
+  height: 100%;
+  width: 100%;
+}
+
+.log-box {
+  width: 90%;
+  height: 100px;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.6);
+  border: 1px solid #fff;
+  margin: auto;
+}
+
+@media (max-width: 768px) {
+  .combat-box {
+    width: 48px;
+    height: 48px;
+    font-size: 12px;
+  }
+
+  .action-tabs button {
+    width: 80px;
+    font-size: 14px;
+    margin: 4px auto;
+  }
+
+  .tab-panels {
+    width: 60%;
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}

--- a/ui/combat/combat_layout.js
+++ b/ui/combat/combat_layout.js
@@ -1,0 +1,52 @@
+export function createCombatLayout() {
+  const root = document.createElement('div');
+  root.className = 'combat-screen';
+
+  const queue = document.createElement('div');
+  queue.className = 'turn-queue spd-log spd-bar';
+  root.appendChild(queue);
+
+  const combatants = document.createElement('div');
+  combatants.className = 'combatants';
+
+  const playerCol = document.createElement('div');
+  playerCol.className = 'player-team';
+  for (let i = 0; i < 3; i++) {
+    const box = document.createElement('div');
+    box.className = 'combatant combat-box empty';
+    playerCol.appendChild(box);
+  }
+
+  const logBox = document.createElement('div');
+  logBox.id = 'combat-log';
+  logBox.className = 'log-box log combat-log';
+
+  const enemyCol = document.createElement('div');
+  enemyCol.className = 'enemy-team';
+  for (let i = 0; i < 3; i++) {
+    const box = document.createElement('div');
+    box.className = 'combatant combat-box empty';
+    enemyCol.appendChild(box);
+  }
+
+  combatants.appendChild(playerCol);
+  combatants.appendChild(logBox);
+  combatants.appendChild(enemyCol);
+  root.appendChild(combatants);
+
+  const actions = document.createElement('div');
+  actions.className = 'actions';
+  actions.innerHTML = `
+    <div class="action-tabs">
+      <button class="offensive-tab combat-skill-category">Offensive</button>
+      <button class="defensive-tab combat-skill-category">Defensive</button>
+      <button class="items-tab combat-skill-category">Items</button>
+    </div>
+    <div class="tab-panels">
+      <div class="offensive-skill-buttons tab-panel"></div>
+      <div class="defensive-skill-buttons tab-panel hidden"></div>
+      <div class="item-buttons tab-panel hidden"></div>
+    </div>`;
+  root.appendChild(actions);
+  return root;
+}

--- a/ui/combat_log.js
+++ b/ui/combat_log.js
@@ -1,5 +1,11 @@
 import { appendLog } from '../scripts/combat_ui.js';
 
-export function combatLog(message) {
-  appendLog(message);
+let logRoot = null;
+
+export function initCombatLog(root) {
+  logRoot = root;
+}
+
+export function combatLog(message, type = 'system') {
+  if (logRoot) appendLog(message, type);
 }


### PR DESCRIPTION
## Summary
- add dynamic combat layout builder
- style combat screen for smaller viewports
- ensure combat boxes include mini HP bars
- route combat log output through a central log element

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8fe657f48331bdb1bd169e0a69a2