### PR TITLE
Add 3v3 mobile combat UI layout

### DIFF
--- a/combat/action_panel.js
+++ b/combat/action_panel.js
@@ -1,0 +1,21 @@
+export function renderCategory(container, skills = [], onClick) {
+  if (!container) return;
+  container.innerHTML = '';
+  skills.forEach((skill) => {
+    const btn = document.createElement('button');
+    btn.className = 'skill-btn';
+    btn.textContent = skill.name;
+    btn.addEventListener('click', () => onClick?.(skill));
+    container.appendChild(btn);
+  });
+}
+
+export function switchCategory(root, name) {
+  const panels = root.querySelectorAll('.tab-panel');
+  panels.forEach((p) => p.classList.add('hidden'));
+  const tab = root.querySelector(`.${name}-skill-buttons`);
+  if (tab) tab.classList.remove('hidden');
+  root
+    .querySelectorAll('.combat-skill-category')
+    .forEach((b) => b.classList.toggle('selected', b.classList.contains(`${name}-tab`)));
+}

--- a/combat/combat_log.js
+++ b/combat/combat_log.js
@@ -1,0 +1,14 @@
+let container = null;
+
+export function initLog(el) {
+  container = el;
+  if (container) container.innerHTML = '';
+}
+
+export function append(message) {
+  if (!container) return;
+  const div = document.createElement('div');
+  div.textContent = message;
+  container.appendChild(div);
+  container.scrollTop = container.scrollHeight;
+}

--- a/combat/combat_renderer.js
+++ b/combat/combat_renderer.js
@@ -1,0 +1,28 @@
+export function injectMiniBars(container, actors = []) {
+  if (!container) return;
+  const boxes = container.querySelectorAll('.combat-box');
+  boxes.forEach((box, idx) => {
+    const actor = actors[idx];
+    box.classList.toggle('empty', !actor);
+    let icon = box.querySelector('.icon');
+    if (!icon) {
+      icon = document.createElement('div');
+      icon.className = 'icon';
+      box.appendChild(icon);
+    }
+    icon.textContent = actor ? actor.portrait || actor.icon || (actor.isPlayer ? '🧑' : '👾') : '';
+    let hp = box.querySelector('.hp');
+    if (!hp) {
+      const bar = document.createElement('div');
+      bar.className = 'hp-bar';
+      bar.innerHTML = '<div class="hp"></div>';
+      box.appendChild(bar);
+      hp = bar.firstElementChild;
+    }
+    if (actor && actor.maxHp) {
+      hp.style.width = `${(actor.hp / actor.maxHp) * 100}%`;
+    } else {
+      hp.style.width = '0%';
+    }
+  });
+}

--- a/ui/combat/combat_layout.css
+++ b/ui/combat/combat_layout.css
@@ -5,6 +5,11 @@
   width: 100%;
 }
 
+.turn-queue {
+  margin-bottom: 6px;
+  text-align: center;
+}
+
 .combatants {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
@@ -22,8 +27,8 @@
 }
 
 .combat-box {
-  width: 48px;
-  height: 48px;
+  width: 60px;
+  height: 60px;
   background: #222;
   border: 1px solid #555;
   border-radius: 6px;
@@ -40,7 +45,7 @@
   bottom: -6px;
   left: 2px;
   right: 2px;
-  height: 4px;
+  height: 6px;
   background: #444;
 }
 
@@ -52,11 +57,35 @@
 
 .log-box {
   width: 90%;
-  height: 100px;
+  height: 90px;
   overflow-y: auto;
   background: rgba(0, 0, 0, 0.6);
   border: 1px solid #fff;
   margin: auto;
+}
+
+.actions {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+}
+
+.action-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tab-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.tab-panel button {
+  width: 100%;
 }
 
 @media (max-width: 768px) {
@@ -64,6 +93,10 @@
     width: 48px;
     height: 48px;
     font-size: 12px;
+  }
+
+  .log-box {
+    height: 80px;
   }
 
   .action-tabs button {

--- a/ui/combat/combat_layout.js
+++ b/ui/combat/combat_layout.js
@@ -14,6 +14,13 @@ export function createCombatLayout() {
   for (let i = 0; i < 3; i++) {
     const box = document.createElement('div');
     box.className = 'combatant combat-box empty';
+    const icon = document.createElement('div');
+    icon.className = 'icon';
+    box.appendChild(icon);
+    const hp = document.createElement('div');
+    hp.className = 'hp-bar';
+    hp.innerHTML = '<div class="hp"></div>';
+    box.appendChild(hp);
     playerCol.appendChild(box);
   }
 
@@ -26,6 +33,13 @@ export function createCombatLayout() {
   for (let i = 0; i < 3; i++) {
     const box = document.createElement('div');
     box.className = 'combatant combat-box empty';
+    const icon = document.createElement('div');
+    icon.className = 'icon';
+    box.appendChild(icon);
+    const hp = document.createElement('div');
+    hp.className = 'hp-bar';
+    hp.innerHTML = '<div class="hp"></div>';
+    box.appendChild(hp);
     enemyCol.appendChild(box);
   }
 


### PR DESCRIPTION
## Summary
- restructure combat layout DOM creation to include icon and HP bar slots
- style combat elements for portrait 3v3 layout
- add helper modules for combat rendering, combat log and action panel

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9ca4d24483319f0762917a8b9d54