### PR TITLE
Improve mobile combat layout

### DIFF
--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -50,7 +50,9 @@ function formatStats(entity) {
 
 function createCombatantEl(entity, isPlayer, index) {
   const wrapper = document.createElement('div');
-  wrapper.className = `combatant combat-box ${isPlayer ? 'player' : 'enemy'}`;
+  wrapper.className = `combatant combat-box actor-slot ${
+    isPlayer ? 'player' : 'enemy'
+  }`;
   wrapper.dataset.index = index;
   if (!entity) {
     wrapper.classList.add('empty');

--- a/style/combat.css
+++ b/style/combat.css
@@ -35,7 +35,16 @@
 }
 
 /* semantic helper classes */
-#battle-overlay .combat-box {
+#battle-overlay .combat-box,
+#battle-overlay .actor-slot {
+  box-sizing: border-box;
+  width: 48px;
+  height: 48px;
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
   margin: 10px;
   text-align: center;
 }
@@ -82,7 +91,6 @@
   align-items: center;
 }
 
-
 #battle-overlay .combatant {
   margin: 10px;
   text-align: center;
@@ -90,9 +98,8 @@
 
 #battle-overlay .combatant.empty {
   opacity: 0.3;
-  border: 1px dashed #666;
-  width: 100px;
-  height: 100px;
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  background: transparent;
 }
 
 #battle-overlay .combatant .portrait {
@@ -135,11 +142,12 @@
 }
 
 #battle-overlay .hp-bar {
-  width: 150px;
-  height: 20px;
+  position: absolute;
+  bottom: 0;
+  height: 4px;
+  width: 100%;
   background: #444;
-  border: 1px solid #222;
-  margin-top: 5px;
+  border-radius: 2px;
 }
 
 #battle-overlay .statuses {
@@ -294,13 +302,15 @@
 
 #battle-overlay .log {
   margin-top: 10px;
-  height: 120px;
+  max-width: 45%;
+  max-height: 100px;
   overflow-y: auto;
-  width: 250px;
   font-size: 14px;
+  font-family: monospace;
   border: 1px solid #555;
   padding: 5px;
   background: rgba(0, 0, 0, 0.3);
+  color: #fff;
 }
 
 #battle-overlay #combat-log .entry.player {
@@ -574,7 +584,7 @@
   }
 
   #battle-overlay .turn-queue {
-    width: 90%;
+    width: 100%;
     text-align: center;
     margin: 0 auto 10px;
     font-size: 0.8em;
@@ -585,7 +595,7 @@
     display: flex;
     justify-content: space-between;
     width: 100%;
-    max-width: 320px;
+    padding: 0 12px;
     margin-bottom: 10px;
   }
 
@@ -593,69 +603,57 @@
   #battle-overlay .enemy-team {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 12px;
   }
 
   #battle-overlay .combatant {
-    width: 60px;
-    height: 60px;
-    margin: 4px auto;
-    background-color: #1a1a1a;
-    border: 1px solid #444;
-    border-radius: 8px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    width: 48px;
+    height: 48px;
     font-size: 24px;
+    margin: 4px 0;
   }
 
   #battle-overlay #combat-log {
-    width: 80%;
-    height: 150px;
-    margin: 0 auto;
-    background: #111;
-    color: #eee;
+    width: 90%;
+    max-height: 100px;
     overflow-y: auto;
-    font-size: 0.85em;
-    padding: 8px;
-    border-radius: 6px;
+    margin: 8px auto;
   }
 
   #battle-overlay .actions {
     display: flex;
+    flex-direction: row;
     justify-content: space-between;
     width: 100%;
-    padding: 0 10px;
+    padding: 12px;
   }
 
   #battle-overlay .action-tabs {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
   }
 
   #battle-overlay .action-tabs button {
     width: 80px;
-    height: 40px;
-    font-size: 0.75em;
-    margin-bottom: 6px;
+    height: 32px;
+    font-size: 14px;
   }
 
   #battle-overlay .tab-panels {
+    width: 65%;
+    margin-left: auto;
+  }
+
+  #battle-overlay .tab-panel {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    width: 100%;
   }
 
   #battle-overlay .tab-panel button {
-    width: 70%;
-    height: 50px;
+    width: 100%;
     margin: 6px auto;
-    font-size: 1em;
-    background-color: #2b2b2b;
-    color: white;
-    border-radius: 6px;
     text-align: center;
   }
 }


### PR DESCRIPTION
## Summary
- adjust combat overlay styles for consistent 48px actor slots and 4px HP bars
- update mobile media query for better layout
- style combat log with monospace font and limits
- mark combatant elements with `actor-slot` class

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da11235648331899ca6ff191975f1