### PR TITLE
Fix combat mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="style/layout.css" />
     <link rel="stylesheet" href="style/tile.css" />
     <link rel="stylesheet" href="style/combat.css" />
+    <link rel="stylesheet" href="style/combat_ui.css" />
     <link rel="stylesheet" href="style/inventory.css" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
   </head>

--- a/scripts/combat_state.js
+++ b/scripts/combat_state.js
@@ -23,11 +23,11 @@ export function initCombatState(player, enemy) {
   eList.forEach((e, i) => {
     if (i < 3) combatState.enemies[i] = e;
   });
-  combatState.players.forEach((p) => {
-    p.selectedSkillId = null;
+  combatState.players.forEach((p, i) => {
+    if (p) combatState.players[i].selectedSkillId = null;
   });
-  combatState.enemies.forEach((e) => {
-    e.selectedSkillId = null;
+  combatState.enemies.forEach((e, i) => {
+    if (e) combatState.enemies[i].selectedSkillId = null;
   });
   combatState.turnQueue = [];
   combatState.turnIndex = 0;

--- a/scripts/combat_system.js
+++ b/scripts/combat_system.js
@@ -92,23 +92,23 @@ export async function startCombat(enemy, player) {
   overlay.classList.add('battle-transition');
   overlay.innerHTML = `
     <div class="combat-screen">
-      <div class="turn-queue spd-log spd-bar"></div>
-      <div class="combatants">
-        <div class="player-team"></div>
+      <div class="turn-queue spd-log spd-bar speed-log"></div>
+      <div class="combatants actor-grid">
+        <div class="player-team actor-column"></div>
         <div id="combat-log" class="log combat-log hidden"></div>
-        <div class="enemy-team"></div>
+        <div class="enemy-team actor-column"></div>
       </div>
       <div class="intro-text">${
         enemy.intro || 'A shadowy beast snarls and prepares to strike!'
       }</div>
       <div class="actions hidden">
         <button id="auto-battle-toggle" class="auto-battle-btn" data-i18n="combat.auto.toggle">${t('combat.auto.toggle')}</button>
-        <div class="action-tabs">
-          <button class="offensive-tab combat-skill-category selected" data-i18n="combat.category.offensive">${t('combat.category.offensive')}</button>
-          <button class="defensive-tab combat-skill-category" data-i18n="combat.category.defensive">${t('combat.category.defensive')}</button>
-          <button class="items-tab combat-skill-category" data-i18n="combat.category.items">${t('combat.category.items')}</button>
+        <div class="action-tabs action-types">
+          <button class="offensive-tab combat-skill-category action-button selected" data-i18n="combat.category.offensive">${t('combat.category.offensive')}</button>
+          <button class="defensive-tab combat-skill-category action-button" data-i18n="combat.category.defensive">${t('combat.category.defensive')}</button>
+          <button class="items-tab combat-skill-category action-button" data-i18n="combat.category.items">${t('combat.category.items')}</button>
         </div>
-        <div class="tab-panels">
+        <div class="tab-panels skill-panel">
           <div class="offensive-skill-buttons tab-panel"></div>
           <div class="defensive-skill-buttons tab-panel hidden"></div>
           <div class="item-buttons tab-panel hidden"></div>

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -13,12 +13,12 @@ import {
 export function renderCombatants(root, players = [], enemies = [], onSelect) {
   if (!root) return;
   root.innerHTML = '';
-  const container = document.createElement('div');
-  container.className = 'combatants';
+  const container = root;
+  container.classList.add('actor-grid');
   const playerSide = document.createElement('div');
-  playerSide.className = 'player-team';
+  playerSide.className = 'player-team actor-column';
   const enemySide = document.createElement('div');
-  enemySide.className = 'enemy-team';
+  enemySide.className = 'enemy-team actor-column';
 
   for (let i = 0; i < 3; i++) {
     const p = players[i] || null;
@@ -37,7 +37,6 @@ export function renderCombatants(root, players = [], enemies = [], onSelect) {
 
   container.appendChild(playerSide);
   container.appendChild(enemySide);
-  root.appendChild(container);
 }
 
 function formatStats(entity) {
@@ -50,7 +49,7 @@ function formatStats(entity) {
 
 function createCombatantEl(entity, isPlayer, index) {
   const wrapper = document.createElement('div');
-  wrapper.className = `combatant combat-box actor-slot ${
+  wrapper.className = `combatant combat-box actor-box actor-slot ${
     isPlayer ? 'player' : 'enemy'
   }`;
   wrapper.dataset.index = index;
@@ -75,7 +74,7 @@ function createCombatantEl(entity, isPlayer, index) {
   name.textContent = entity.name || (isPlayer ? 'Player' : 'Enemy');
   wrapper.appendChild(name);
   const hpBar = document.createElement('div');
-  hpBar.className = 'hp-bar';
+  hpBar.className = 'hp-bar actor-hp';
   hpBar.innerHTML = '<div class="hp"></div>';
   wrapper.appendChild(hpBar);
   const stats = document.createElement('div');
@@ -183,6 +182,7 @@ function getTurnLabel(unit) {
 
 export function renderTurnQueue(container, queue = [], active, index = 0) {
   if (!container) return;
+  container.classList.add('speed-log');
   container.innerHTML = '';
   if (!Array.isArray(queue) || queue.length === 0) return;
   const len = queue.length;
@@ -295,7 +295,7 @@ export function renderSkillList(container, skills, onClick) {
   const map = {};
   skills.forEach((skill) => {
     const btn = document.createElement('button');
-    btn.className = 'skill-btn combat-skill-button';
+    btn.className = 'skill-btn combat-skill-button skill-button';
     btn.dataset.id = skill.id;
     const effects = [];
     if (Array.isArray(skill.statuses)) {

--- a/style/combat_ui.css
+++ b/style/combat_ui.css
@@ -1,0 +1,83 @@
+.actor-grid {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding: 4px 12px;
+}
+
+.actor-column {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.actor-box {
+  width: 42px;
+  height: 42px;
+  border: 1px dashed rgba(255, 255, 255, 0.3);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.actor-hp {
+  position: absolute;
+  bottom: -4px;
+  width: 100%;
+  height: 3px;
+  background: red;
+}
+
+.speed-log {
+  width: 100%;
+  padding: 6px;
+  font-size: 14px;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid #555;
+}
+
+.combat-log {
+  width: 90%;
+  max-height: 80px;
+  overflow-y: auto;
+  margin: 12px auto;
+  padding: 6px;
+  background: rgba(0, 0, 0, 0.4);
+  color: white;
+  font-family: monospace;
+  font-size: 12px;
+  border-radius: 6px;
+}
+
+.action-types {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-left: 6px;
+}
+
+.action-button {
+  width: 70px;
+  height: 28px;
+  font-size: 12px;
+}
+
+.skill-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+}
+
+.skill-button {
+  width: 80%;
+  padding: 8px;
+  font-size: 13px;
+  background: #222;
+  color: white;
+  border-radius: 6px;
+  border: 1px solid #555;
+}

--- a/ui/combat_log.js
+++ b/ui/combat_log.js
@@ -3,7 +3,16 @@ import { appendLog } from '../scripts/combat_ui.js';
 let logRoot = null;
 
 export function initCombatLog(root) {
-  logRoot = root;
+  if (!root) return;
+  let el = root.querySelector('#combat-log');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'combat-log';
+    el.className = 'combat-log';
+    root.appendChild(el);
+  }
+  el.innerHTML = '';
+  logRoot = el;
 }
 
 export function combatLog(message, type = 'system') {


### PR DESCRIPTION
## Summary
- add portrait layout styles for mobile combat screen
- insert log container if missing
- add missing class names to combat markup and update skill buttons
- fix combat state init when fewer than 3 actors
- include new stylesheet in page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684da47b688483319f7b43bb6a7147b7