### PR TITLE
Add mobile combat log

### DIFF
--- a/combat/combat_log.js
+++ b/combat/combat_log.js
@@ -5,10 +5,11 @@ export function initLog(el) {
   if (container) container.innerHTML = '';
 }
 
-export function append(message) {
-  if (!container) return;
-  const div = document.createElement('div');
-  div.textContent = message;
-  container.appendChild(div);
-  container.scrollTop = container.scrollHeight;
+export function log(message) {
+  const logBox = container || document.querySelector('.combat-log');
+  if (!logBox) return;
+  const entry = document.createElement('div');
+  entry.textContent = message;
+  logBox.appendChild(entry);
+  logBox.scrollTop = logBox.scrollHeight;
 }

--- a/scripts/log.js
+++ b/scripts/log.js
@@ -1,8 +1,8 @@
-import { appendLog } from './combat_ui.js';
+import { log } from '../combat/combat_log.js';
 
 export function logAction(actor, skill, target) {
   const actorName = actor?.name || actor?.id || 'Unknown';
   const skillName = skill?.name || skill?.id || 'skill';
   const targetName = target?.name || target?.id || 'Unknown';
-  appendLog(`${actorName} uses ${skillName} on ${targetName}.`);
+  log(`${actorName} uses ${skillName} on ${targetName}.`);
 }

--- a/style/combat_ui.css
+++ b/style/combat_ui.css
@@ -39,16 +39,19 @@
 }
 
 .combat-log {
-  width: 90%;
-  max-height: 80px;
-  overflow-y: auto;
-  margin: 12px auto;
-  padding: 6px;
-  background: rgba(0, 0, 0, 0.4);
+  position: absolute;
+  top: 45%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80%;
+  height: 90px;
+  background: rgba(0, 0, 0, 0.65);
   color: white;
-  font-family: monospace;
-  font-size: 12px;
-  border-radius: 6px;
+  font-size: 0.85rem;
+  padding: 6px 10px;
+  overflow-y: auto;
+  border-radius: 8px;
+  text-align: left;
 }
 
 .action-types {


### PR DESCRIPTION
## Summary
- style the combat log container in combat_ui.css
- provide a log() helper in combat/combat_log.js
- use log() helper from scripts/log.js

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da8f33db48331923e35ae4c8b05bc