### PR TITLE
Fix missing combat log panel

### DIFF
--- a/scripts/combat_system.js
+++ b/scripts/combat_system.js
@@ -124,6 +124,15 @@ export async function startCombat(enemy, player) {
     Array.isArray(player) ? player : [player],
     Array.isArray(enemy) ? enemy : [enemy]
   );
+  // Re-insert the combat log panel that renderCombatants() removed
+  const combatantsEl = overlay.querySelector('.combatants');
+  if (combatantsEl) {
+    const logPanel = document.createElement('div');
+    logPanel.id = 'combat-log';
+    logPanel.className = 'log combat-log hidden';
+    const enemyTeam = combatantsEl.querySelector('.enemy-team');
+    combatantsEl.insertBefore(logPanel, enemyTeam);
+  }
   resetBossPhase(enemy.id);
   if (enemy.id === 'echo_absolute') setPhase(1);
   document.dispatchEvent(new CustomEvent('combatStarted'));


### PR DESCRIPTION
## Summary
- ensure the combat log element is restored after calling `renderCombatants`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684de8c85d60833196bbc63460c44853