### PR TITLE
Refine combat fonts for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="style/tile.css" />
     <link rel="stylesheet" href="style/combat.css" />
     <link rel="stylesheet" href="style/combat_ui.css" />
+    <link rel="stylesheet" href="style/mobile.css" />
     <link rel="stylesheet" href="style/inventory.css" />
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
   </head>

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -70,7 +70,7 @@ function createCombatantEl(entity, isPlayer, index) {
   }
   wrapper.appendChild(portrait);
   const name = document.createElement('div');
-  name.className = 'name';
+  name.className = 'name combatant-label';
   name.textContent = entity.name || (isPlayer ? 'Player' : 'Enemy');
   wrapper.appendChild(name);
   const hpBar = document.createElement('div');
@@ -78,7 +78,7 @@ function createCombatantEl(entity, isPlayer, index) {
   hpBar.innerHTML = '<div class="hp"></div>';
   wrapper.appendChild(hpBar);
   const stats = document.createElement('div');
-  stats.className = 'stats';
+  stats.className = 'stats stat-block';
   stats.textContent = formatStats(entity);
   wrapper.appendChild(stats);
   const status = document.createElement('div');

--- a/style/combat.css
+++ b/style/combat.css
@@ -107,6 +107,20 @@
   margin-bottom: 5px;
 }
 
+#battle-overlay .combatant .name,
+.combatant-label {
+  font-size: clamp(0.85rem, 1.5vw, 1rem);
+  font-weight: 500;
+  text-align: center;
+  padding: 2px 4px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.3);
+  color: white;
+  line-height: 1.2;
+  letter-spacing: 0.3px;
+  font-family: system-ui, Arial, sans-serif;
+}
+
 #battle-overlay .enemy-icon[data-tier='spawn'] {
   color: #e74c3c;
 }
@@ -175,9 +189,16 @@
   border-radius: 3px;
 }
 
-#battle-overlay .combatant .stats {
-  font-size: 12px;
-  margin-top: 2px;
+#battle-overlay .combatant .stats,
+.stat-block {
+  font-size: 0.85rem;
+  line-height: 1.2;
+  margin-top: 4px;
+  padding: 2px 4px;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 3px;
+  letter-spacing: 0.3px;
+  font-family: system-ui, Arial, sans-serif;
 }
 
 #battle-overlay .intro-text {

--- a/style/combat_ui.css
+++ b/style/combat_ui.css
@@ -12,13 +12,15 @@
 }
 
 .actor-box {
-  width: 42px;
-  height: 42px;
+  width: 40px;
+  height: 40px;
   border: 1px dashed rgba(255, 255, 255, 0.3);
   position: relative;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+  overflow: hidden;
 }
 
 .actor-hp {
@@ -83,4 +85,32 @@
   color: white;
   border-radius: 6px;
   border: 1px solid #555;
+}
+
+.combatant-label {
+  font-size: clamp(0.75rem, 1.2vw, 1rem);
+  font-weight: 500;
+  text-align: center;
+  padding: 2px 4px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.3);
+  color: white;
+  line-height: 1.2;
+  letter-spacing: 0.3px;
+  font-family: system-ui, Arial, sans-serif;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.stat-block {
+  font-size: 0.85rem;
+  line-height: 1.2;
+  margin-top: 4px;
+  padding: 2px 4px;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 3px;
+  letter-spacing: 0.3px;
+  font-family: system-ui, Arial, sans-serif;
+  width: 100%;
+  box-sizing: border-box;
 }

--- a/style/mobile.css
+++ b/style/mobile.css
@@ -1,0 +1,13 @@
+/* Mobile overrides for combat UI */
+@media (max-width: 768px) {
+  .combatant-label {
+    font-size: 0.8rem;
+    padding: 2px;
+  }
+
+  .stat-block {
+    font-size: 0.75rem;
+    padding: 2px;
+    margin-top: 4px;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak combatant box layout and add styles for name and stats
- apply new combat text classes in JS
- load mobile-specific stylesheet for combat UI
- add responsive font overrides for combat elements

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dea257c9c833189cbb8be111f749a