### PR TITLE
Refactor combat utilities

### DIFF
--- a/__tests__/cooldown_manager.test.js
+++ b/__tests__/cooldown_manager.test.js
@@ -1,0 +1,9 @@
+import { tickCooldowns } from '../scripts/cooldown_manager.js';
+
+test('tickCooldowns decrements positive values', () => {
+  const cds = { fire: 2, ice: 0, wind: -1 };
+  tickCooldowns(cds);
+  expect(cds.fire).toBe(1);
+  expect(cds.ice).toBe(0);
+  expect(cds.wind).toBe(-1);
+});

--- a/__tests__/skill_ui.test.js
+++ b/__tests__/skill_ui.test.js
@@ -1,0 +1,31 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../scripts/combat_ui.js', () => ({
+  setSkillDisabledState: jest.fn()
+}));
+
+let updateSkillDisableState, combatUi;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ updateSkillDisableState } = await import('../scripts/skill_ui.js'));
+  combatUi = await import('../scripts/combat_ui.js');
+});
+
+test('updateSkillDisableState passes silenced flag', () => {
+  const player = { statuses: [{ id: 'silence', remaining: 1 }] };
+  const btns = {};
+  const lookup = {};
+  const cds = { x: 1 };
+  updateSkillDisableState(btns, lookup, player, cds);
+  expect(combatUi.setSkillDisabledState).toHaveBeenCalledWith(btns, lookup, true, cds);
+});
+
+test('updateSkillDisableState handles no silence', () => {
+  const player = { statuses: [] };
+  const btns = {};
+  const lookup = {};
+  updateSkillDisableState(btns, lookup, player);
+  expect(combatUi.setSkillDisabledState).toHaveBeenCalledWith(btns, lookup, false, {});
+});

--- a/__tests__/status_logic.test.js
+++ b/__tests__/status_logic.test.js
@@ -1,0 +1,47 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let applyStatusLogged,
+  removeStatusLogged,
+  removeNegativeStatusLogged;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({
+    applyStatusLogged,
+    removeStatusLogged,
+    removeNegativeStatusLogged
+  } = await import('../scripts/status_logic.js'));
+});
+
+test('applyStatusLogged adds status and logs', () => {
+  const target = { statuses: [], isPlayer: true };
+  const logger = jest.fn();
+  applyStatusLogged(target, 'regen', 2, logger);
+  expect(target.statuses[0].id).toBe('regen');
+  expect(logger).toHaveBeenCalled();
+});
+
+test('removeStatusLogged removes status and logs', () => {
+  const target = { statuses: [{ id: 'regen', remaining: 1 }], isPlayer: true };
+  const logger = jest.fn();
+  removeStatusLogged(target, 'regen', logger);
+  expect(target.statuses.length).toBe(0);
+  expect(logger).toHaveBeenCalled();
+});
+
+test('removeNegativeStatusLogged removes negative statuses', () => {
+  const target = {
+    statuses: [
+      { id: 'poisoned', remaining: 2 },
+      { id: 'regen', remaining: 1 }
+    ],
+    isPlayer: true
+  };
+  const logger = jest.fn();
+  const removed = removeNegativeStatusLogged(target, null, logger);
+  expect(removed).toContain('poisoned');
+  expect(target.statuses.length).toBe(1);
+  expect(target.statuses[0].id).toBe('regen');
+  expect(logger).toHaveBeenCalled();
+});

--- a/scripts/cooldown_manager.js
+++ b/scripts/cooldown_manager.js
@@ -1,0 +1,7 @@
+export function tickCooldowns(cooldowns = {}) {
+  Object.keys(cooldowns).forEach((id) => {
+    if (cooldowns[id] > 0) {
+      cooldowns[id] -= 1;
+    }
+  });
+}

--- a/scripts/skill_ui.js
+++ b/scripts/skill_ui.js
@@ -1,0 +1,8 @@
+import { hasStatus } from './status_manager.js';
+import { setSkillDisabledState } from './combat_ui.js';
+
+export function updateSkillDisableState(buttonMap, skillLookup, player, cooldowns = {}) {
+  const silenced =
+    hasStatus(player, 'silence') || hasStatus(player, 'silenced');
+  setSkillDisabledState(buttonMap, skillLookup, silenced, cooldowns);
+}

--- a/scripts/status_logic.js
+++ b/scripts/status_logic.js
@@ -1,0 +1,33 @@
+import { applyEffect, removeStatus } from './status_effect.js';
+import { removeNegativeStatus } from './status_manager.js';
+import { t } from './i18n.js';
+
+export function applyStatusLogged(target, id, duration = 1, log) {
+  applyEffect(target, id, duration);
+  if (typeof log === 'function') {
+    const name = t(`status.${id}`);
+    const who = target.isPlayer ? 'Player' : target.name || 'Enemy';
+    log(t('combat.status.apply', { target: who, status: name, turns: duration }));
+  }
+}
+
+export function removeStatusLogged(target, id, log) {
+  removeStatus(target, id);
+  if (typeof log === 'function') {
+    const name = t(`status.${id}`);
+    const who = target.isPlayer ? 'Player' : target.name || 'Enemy';
+    log(t('combat.status.expire', { status: name, target: who }));
+  }
+}
+
+export function removeNegativeStatusLogged(target, ids, log) {
+  const removed = removeNegativeStatus(target, ids);
+  if (typeof log === 'function') {
+    removed.forEach((r) => {
+      const name = t(`status.${r}`);
+      const who = target.isPlayer ? 'Player' : target.name || 'Enemy';
+      log(t('combat.status.expire', { status: name, target: who }));
+    });
+  }
+  return removed;
+}


### PR DESCRIPTION
## Summary
- split helper code from `combat_system.js`
- manage cooldowns in new `cooldown_manager.js`
- centralize status logging helpers
- factor out skill UI disabling logic
- add Jest unit tests for new modules

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e552b66e88331987a2c8b6f0c07f0