### PR TITLE
Improve asset loading

### DIFF
--- a/__tests__/data_service.test.js
+++ b/__tests__/data_service.test.js
@@ -1,16 +1,24 @@
 /** @jest-environment jsdom */
 import { jest } from '@jest/globals';
 
-let loadJson;
+jest.unstable_mockModule('../scripts/error_prompt.js', () => ({
+  showError: jest.fn()
+}));
+
+let loadJson, errorPrompt;
 const originalFetch = global.fetch;
 
 beforeEach(async () => {
   jest.resetModules();
   ({ loadJson } = await import('../scripts/data_service.js'));
+  errorPrompt = await import('../scripts/error_prompt.js');
 });
 
 afterEach(() => {
   global.fetch = originalFetch;
+  if (errorPrompt && errorPrompt.showError.mockClear) {
+    errorPrompt.showError.mockClear();
+  }
 });
 
 test('throws on network error', async () => {
@@ -23,7 +31,9 @@ test('throws on network error', async () => {
 test('throws on 404 error', async () => {
   global.fetch = jest
     .fn()
-    .mockResolvedValue(new Response('', { status: 404, statusText: 'Not Found' }));
+    .mockResolvedValue(
+      new Response('', { status: 404, statusText: 'Not Found' })
+    );
   await expect(loadJson('missing.json')).rejects.toThrow(
     'File not found: missing.json'
   );
@@ -32,15 +42,21 @@ test('throws on 404 error', async () => {
 test('throws on other HTTP error', async () => {
   global.fetch = jest
     .fn()
-    .mockResolvedValue(new Response('', { status: 500, statusText: 'Server Error' }));
+    .mockResolvedValue(
+      new Response('', { status: 500, statusText: 'Server Error' })
+    );
   await expect(loadJson('server.json')).rejects.toThrow(
     '500 Server Error (server.json)'
   );
 });
 
 test('throws on malformed JSON', async () => {
-  global.fetch = jest.fn().mockResolvedValue(new Response('oops', { status: 200 }));
-  await expect(loadJson('bad.json')).rejects.toThrow('Malformed JSON in bad.json');
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue(new Response('oops', { status: 200 }));
+  await expect(loadJson('bad.json')).rejects.toThrow(
+    'Malformed JSON in bad.json'
+  );
 });
 
 test('returns parsed JSON on success', async () => {
@@ -52,10 +68,25 @@ test('returns parsed JSON on success', async () => {
 
 test('uses fallback on network error', async () => {
   global.fetch = jest.fn().mockRejectedValue(new Error('fail'));
-  await expect(loadJson('path/file.json', { ok: true })).resolves.toEqual({ ok: true });
+  await expect(loadJson('path/file.json', { ok: true })).resolves.toEqual({
+    ok: true
+  });
+  expect(errorPrompt.showError).toHaveBeenCalled();
 });
 
 test('uses fallback on malformed JSON', async () => {
-  global.fetch = jest.fn().mockResolvedValue(new Response('oops', { status: 200 }));
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue(new Response('oops', { status: 200 }));
   await expect(loadJson('bad.json', [])).resolves.toEqual([]);
+  expect(errorPrompt.showError).toHaveBeenCalled();
+});
+
+test('caches successful loads', async () => {
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue(new Response('{"b":2}', { status: 200 }));
+  await expect(loadJson('cache.json')).resolves.toEqual({ b: 2 });
+  await expect(loadJson('cache.json')).resolves.toEqual({ b: 2 });
+  expect(global.fetch).toHaveBeenCalledTimes(1);
 });

--- a/scripts/data_service.js
+++ b/scripts/data_service.js
@@ -1,35 +1,47 @@
+import { showError } from './error_prompt.js';
+
+const cache = new Map();
+
 export async function loadJson(path, fallback) {
+  if (cache.has(path)) {
+    return cache.get(path);
+  }
+
+  function handleError(msg) {
+    if (fallback !== undefined) {
+      console.error(msg);
+      showError(msg);
+      cache.set(path, fallback);
+      return fallback;
+    }
+    throw new Error(msg);
+  }
+
   let res;
   try {
     res = await fetch(path);
   } catch (err) {
-    const msg = `Network error while fetching ${path}: ${err.message}`;
-    if (fallback !== undefined) {
-      console.error(msg);
-      return fallback;
-    }
-    throw new Error(msg);
+    return handleError(`Network error while fetching ${path}: ${err.message}`);
   }
   if (!res.ok) {
     const msg =
       res.status === 404
         ? `File not found: ${path}`
         : `${res.status} ${res.statusText} (${path})`;
-    if (fallback !== undefined) {
-      console.error(msg);
-      return fallback;
-    }
-    throw new Error(msg);
+    return handleError(msg);
   }
   const text = await res.text();
   try {
-    return JSON.parse(text);
+    const data = JSON.parse(text);
+    cache.set(path, data);
+    return data;
   } catch (err) {
-    const msg = `Malformed JSON in ${path}: ${err.message}`;
-    if (fallback !== undefined) {
-      console.error(msg);
-      return fallback;
-    }
-    throw new Error(msg);
+    return handleError(`Malformed JSON in ${path}: ${err.message}`);
+  }
+}
+
+export function preloadJson(path) {
+  if (!cache.has(path)) {
+    loadJson(path).catch(() => {});
   }
 }


### PR DESCRIPTION
## Summary
- add caching and preload to `loadJson`
- surface user-friendly error messages via `showError`
- update unit tests for data service

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e5cfe41648331868577bfbce34f1a