### PR TITLE
Improve mobile combat UI responsiveness

### DIFF
--- a/scripts/combat_system.js
+++ b/scripts/combat_system.js
@@ -109,7 +109,7 @@ export async function startCombat(enemy, player) {
         enemy.intro || 'A shadowy beast snarls and prepares to strike!'
       }</div>
       <div class="actions hidden">
-        <button id="auto-battle-toggle" class="auto-battle-btn" data-i18n="combat.auto.toggle">${t('combat.auto.toggle')}</button>
+        <button id="auto-battle-toggle" class="auto-battle-btn auto-battle-button" data-i18n="combat.auto.toggle">${t('combat.auto.toggle')}</button>
         <div class="action-tabs action-types">
           <button class="offensive-tab combat-skill-category action-button selected" data-i18n="combat.category.offensive">${t('combat.category.offensive')}</button>
           <button class="defensive-tab combat-skill-category action-button" data-i18n="combat.category.defensive">${t('combat.category.defensive')}</button>

--- a/style/combat_ui.css
+++ b/style/combat_ui.css
@@ -114,3 +114,40 @@
   width: 100%;
   box-sizing: border-box;
 }
+
+/* Auto-battle toggle styling */
+.auto-battle-button {
+  font-size: 1rem;
+  padding: 8px 16px;
+  border-radius: 4px;
+}
+
+/* Combat log container */
+#combat-log {
+  margin-top: 10px;
+  font-size: 0.9rem;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.4);
+  color: white;
+  border-radius: 6px;
+  text-align: center;
+}
+
+/* Ensure skill buttons align consistently */
+.skill-button {
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .auto-battle-button {
+    font-size: 0.85rem;
+    padding: 6px 12px;
+    border-radius: 6px;
+    margin-bottom: 8px;
+  }
+
+  .skill-button {
+    width: 100%;
+    margin-bottom: 6px;
+  }
+}

--- a/ui/combat/combat_layout.css
+++ b/ui/combat/combat_layout.css
@@ -91,6 +91,12 @@
   margin: 0 auto 4px;
 }
 
+.auto-battle-button {
+  font-size: 1rem;
+  padding: 8px 16px;
+  border-radius: 4px;
+}
+
 .auto-battle-btn.disabled {
   opacity: 0.5;
 }
@@ -141,5 +147,12 @@
     text-align: center;
     margin-left: auto;
     margin-right: auto;
+  }
+
+  .auto-battle-button {
+    font-size: 0.85rem;
+    padding: 6px 12px;
+    border-radius: 6px;
+    margin-bottom: 8px;
   }
 }

--- a/ui/combat/combat_layout.js
+++ b/ui/combat/combat_layout.js
@@ -53,7 +53,7 @@ export function createCombatLayout() {
   const actions = document.createElement('div');
   actions.className = 'actions';
   actions.innerHTML = `
-    <button id="auto-battle-toggle" class="auto-battle-btn">Auto-Battle OFF</button>
+    <button id="auto-battle-toggle" class="auto-battle-btn auto-battle-button">Auto-Battle OFF</button>
     <div class="action-tabs">
       <button class="offensive-tab combat-skill-category">Offensive</button>
       <button class="defensive-tab combat-skill-category">Defensive</button>


### PR DESCRIPTION
## Summary
- add `.auto-battle-button` class in layout markup
- tweak auto-battle button styles and make responsive
- enhance combat log styling
- keep skill buttons aligned on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e67c0b4cc833193c1732c53134bb6