### PR TITLE
Fix settings menu element IDs

### DIFF
--- a/scripts/settings_menu.js
+++ b/scripts/settings_menu.js
@@ -1,9 +1,9 @@
 import { setAutoBattle, isAutoBattle } from './combat_state.js';
 
 export function initSettingsMenu() {
-  const btn = document.getElementById('auto-battle-toggle-settings');
-  const skip = document.getElementById('skip-toggle-settings');
-  const notify = document.getElementById('notify-toggle-settings');
+  const btn = document.getElementById('auto-battle-toggle');
+  const skip = document.getElementById('skip-toggle');
+  const notify = document.getElementById('notify-toggle');
   if (!btn) return;
   function update() {
     btn.textContent = isAutoBattle() ? 'Auto-Battle ON' : 'Auto-Battle OFF';


### PR DESCRIPTION
## Summary
- correct `settings_menu` element IDs

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e6a1072688331b0e96f2c6dffed38