### PR TITLE
Add tests for new modules

### DIFF
--- a/__tests__/ai_logic.test.js
+++ b/__tests__/ai_logic.test.js
@@ -1,0 +1,22 @@
+import { chooseBestSkill } from '../scripts/ai_logic.js';
+
+test('returns null for empty skills', () => {
+  expect(chooseBestSkill([])).toBeNull();
+});
+
+test('filters on cooldown skills', () => {
+  const skills = [{ id: 'fire' }, { id: 'heal_self' }];
+  const onCd = (s) => s.id === 'heal_self';
+  const result = chooseBestSkill(skills, null, onCd);
+  expect(result.id).toBe('fire');
+});
+
+test('prioritizes healing then buff then attack', () => {
+  const skills = [
+    { id: 'slash', category: 'offensive' },
+    { id: 'heal_spell', name: 'Heal Spell' },
+    { id: 'defend', category: 'defensive' }
+  ];
+  const result = chooseBestSkill(skills);
+  expect(result.id).toBe('heal_spell');
+});

--- a/__tests__/i18n.test.js
+++ b/__tests__/i18n.test.js
@@ -1,0 +1,28 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../scripts/logger.js', () => ({
+  logWarn: jest.fn()
+}));
+
+let t, setLanguage, logWarn;
+
+beforeEach(async () => {
+  jest.resetModules();
+  localStorage.clear();
+  ({ t, setLanguage } = await import('../scripts/i18n.js'));
+  ({ logWarn } = await import('../scripts/logger.js'));
+});
+
+test('returns translated string with variables', () => {
+  setLanguage('en');
+  const res = t('status.remaining', { turns: 3 });
+  expect(res).toBe('3 turn(s) remaining');
+});
+
+test('logs warning and returns placeholder when key missing', () => {
+  setLanguage('en');
+  const res = t('missing.key');
+  expect(res).toBe('[Missing Translation]');
+  expect(logWarn).toHaveBeenCalledWith('Translation Missing', { key: 'missing.key' });
+});

--- a/__tests__/logger.test.js
+++ b/__tests__/logger.test.js
@@ -1,0 +1,34 @@
+/** @jest-environment node */
+import { logInfo, logWarn } from '../scripts/logger.js';
+
+describe('logger', () => {
+  let infoSpy, warnSpy;
+  beforeEach(() => {
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  test('logInfo outputs JSON with level info', () => {
+    logInfo('hello', { foo: 1 });
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const entry = JSON.parse(infoSpy.mock.calls[0][0]);
+    expect(entry.level).toBe('info');
+    expect(entry.message).toBe('hello');
+    expect(entry.foo).toBe(1);
+    expect(entry.timestamp).toBeDefined();
+  });
+
+  test('logWarn outputs JSON with level warn', () => {
+    logWarn('oops', { bar: 2 });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const entry = JSON.parse(warnSpy.mock.calls[0][0]);
+    expect(entry.level).toBe('warn');
+    expect(entry.message).toBe('oops');
+    expect(entry.bar).toBe(2);
+    expect(entry.timestamp).toBeDefined();
+  });
+});

--- a/__tests__/rollback.test.js
+++ b/__tests__/rollback.test.js
@@ -1,0 +1,50 @@
+import { jest } from '@jest/globals';
+
+const existsSync = jest.fn();
+const copySync = jest.fn();
+let logInfo, logWarn;
+
+jest.unstable_mockModule('fs-extra', () => ({
+  default: { existsSync, copySync },
+  existsSync,
+  copySync
+}));
+
+jest.unstable_mockModule('../scripts/logger.js', () => ({
+  logInfo: jest.fn(),
+  logWarn: jest.fn()
+}));
+
+let rollbackTo;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ rollbackTo } = await import('../scripts/rollback.js'));
+  ({ logInfo, logWarn } = await import('../scripts/logger.js'));
+  existsSync.mockReset();
+  copySync.mockReset();
+});
+
+test('logs warning when executed in browser', async () => {
+  global.window = {};
+  ({ rollbackTo } = await import('../scripts/rollback.js'));
+  await rollbackTo('v1');
+  expect(logWarn).toHaveBeenCalledWith('Rollback is not supported in the browser.');
+  delete global.window;
+});
+
+test('logs error when version missing', async () => {
+  existsSync.mockReturnValue(false);
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  await rollbackTo('v1');
+  expect(errorSpy).toHaveBeenCalledWith('Version v1 does not exist.');
+  expect(copySync).not.toHaveBeenCalled();
+  errorSpy.mockRestore();
+});
+
+test('copies files and logs info when version exists', async () => {
+  existsSync.mockReturnValue(true);
+  await rollbackTo('v1');
+  expect(copySync).toHaveBeenCalled();
+  expect(logInfo).toHaveBeenCalledWith('Rolled back to version v1');
+});


### PR DESCRIPTION
## Summary
- add unit tests for the new logger helper
- cover rollback logic and AI skill choice
- test internationalisation helper behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7b6fa834833180a7d209518d2751