### PR TITLE
Improve JSON asset error handling

### DIFF
--- a/__tests__/data_service.test.js
+++ b/__tests__/data_service.test.js
@@ -26,6 +26,7 @@ test('throws on network error', async () => {
   await expect(loadJson('path/file.json')).rejects.toThrow(
     'Network error while fetching path/file.json: boom'
   );
+  expect(errorPrompt.showError).toHaveBeenCalled();
 });
 
 test('throws on 404 error', async () => {
@@ -37,6 +38,7 @@ test('throws on 404 error', async () => {
   await expect(loadJson('missing.json')).rejects.toThrow(
     'File not found: missing.json'
   );
+  expect(errorPrompt.showError).toHaveBeenCalled();
 });
 
 test('throws on other HTTP error', async () => {
@@ -48,6 +50,7 @@ test('throws on other HTTP error', async () => {
   await expect(loadJson('server.json')).rejects.toThrow(
     '500 Server Error (server.json)'
   );
+  expect(errorPrompt.showError).toHaveBeenCalled();
 });
 
 test('throws on malformed JSON', async () => {
@@ -57,6 +60,7 @@ test('throws on malformed JSON', async () => {
   await expect(loadJson('bad.json')).rejects.toThrow(
     'Malformed JSON in bad.json'
   );
+  expect(errorPrompt.showError).toHaveBeenCalled();
 });
 
 test('returns parsed JSON on success', async () => {

--- a/scripts/data_service.js
+++ b/scripts/data_service.js
@@ -8,9 +8,9 @@ export async function loadJson(path, fallback) {
   }
 
   function handleError(msg) {
+    console.error(msg);
+    showError(msg);
     if (fallback !== undefined) {
-      console.error(msg);
-      showError(msg);
       cache.set(path, fallback);
       return fallback;
     }

--- a/scripts/dialogue_system.js
+++ b/scripts/dialogue_system.js
@@ -9,7 +9,6 @@ import {
   triggerReroll
 } from './dialogue_state.js';
 import { getQuests, completeQuest } from './quest_state.js';
-import { showError } from './error_prompt.js';
 import { loadJson } from './data_service.js';
 import { gameState } from './game_state.js';
 import { t } from './i18n.js';
@@ -24,7 +23,6 @@ async function loadDialogData() {
     dialogueLines = data;
   } catch (err) {
     dialogueLines = {};
-    showError(err.message || 'Failed to load dialogue');
   }
   dataLoaded = true;
 }

--- a/scripts/enemy.js
+++ b/scripts/enemy.js
@@ -1,5 +1,4 @@
 import { gameState } from './game_state.js';
-import { showError } from './error_prompt.js';
 import { loadJson } from './data_service.js';
 
 let enemyData = {};
@@ -11,7 +10,6 @@ export async function loadEnemyData() {
     enemyData = data;
   } catch (err) {
     enemyData = {};
-    showError(err.message || 'Failed to load enemies');
   }
   return enemyData;
 }

--- a/scripts/forge.js
+++ b/scripts/forge.js
@@ -1,5 +1,4 @@
 import { loadJson } from './data_service.js';
-import { showError } from './error_prompt.js';
 import { inventory, removeItem, addItem } from './inventory.js';
 import { getItemData } from './item_loader.js';
 import { getItemDisplayName } from './inventory.js';
@@ -17,7 +16,6 @@ export async function loadUpgradeData() {
     upgrades = data;
   } catch (err) {
     upgrades = {};
-    showError(err.message || 'Failed to load upgrade data');
   }
   loaded = true;
   return upgrades;

--- a/scripts/item_loader.js
+++ b/scripts/item_loader.js
@@ -1,5 +1,4 @@
 import { loadJson } from './data_service.js';
-import { showError } from './error_prompt.js';
 import { itemData } from './item_data.js';
 
 let items = {};
@@ -11,7 +10,6 @@ export async function loadItems() {
     items = { ...data, ...itemData };
   } catch (err) {
     items = { ...itemData };
-    showError(err.message || 'Failed to load items');
   }
   return items;
 }

--- a/scripts/map_loader.js
+++ b/scripts/map_loader.js
@@ -1,4 +1,3 @@
-import { showError } from './error_prompt.js';
 import { loadJson } from './data_service.js';
 import {
   markForkVisited,
@@ -101,7 +100,6 @@ export async function loadMap(name) {
     }
   } catch (err) {
     console.error(err);
-    showError(err.message || `Failed to load map ${name}`);
     throw err;
   }
   currentEnvironment = data.environment || 'clear';

--- a/scripts/quest_state.js
+++ b/scripts/quest_state.js
@@ -1,6 +1,5 @@
 import { dialogueMemory, hasMemory, setMemory } from './dialogue_state.js';
 import { loadJson } from './data_service.js';
-import { showError } from './error_prompt.js';
 
 const state = {
   quests: {},
@@ -19,7 +18,6 @@ export async function loadQuestData() {
     state.data = data;
   } catch (err) {
     state.data = {};
-    showError(err.message || 'Failed to load quests');
   }
   state.loaded = true;
   return state.data;

--- a/scripts/relic_state.js
+++ b/scripts/relic_state.js
@@ -1,5 +1,4 @@
 import { loadJson } from './data_service.js';
-import { showError } from './error_prompt.js';
 
 const STORAGE_KEY = 'gridquest.relics';
 
@@ -50,7 +49,6 @@ export async function loadRelics() {
     relicState.data = data;
   } catch (err) {
     relicState.data = {};
-    showError(err.message || 'Failed to load relics');
   }
   return relicState.data;
 }

--- a/ui/info_menu.js
+++ b/ui/info_menu.js
@@ -1,10 +1,8 @@
 import { loadJson as loadJsonFile } from '../scripts/data_service.js';
-import { showError } from '../scripts/error_prompt.js';
 
 export async function loadJson(name) {
   const data = await loadJsonFile(`info_data/${name}`, null);
   if (data === null) {
-    showError(`Failed to load info_data/${name}`);
     return [];
   }
   return data;


### PR DESCRIPTION
## Summary
- surface JSON load errors to the user directly in `loadJson`
- remove duplicate `showError` calls in game modules
- update tests for new error prompt behavior

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684e93400bfc8331b017bcbe59833ae2