### PR TITLE
Refactor save/load UI handlers

### DIFF
--- a/__tests__/save_load_handlers.test.js
+++ b/__tests__/save_load_handlers.test.js
@@ -1,0 +1,86 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../ui/save_slots_menu.js', () => ({
+  openSaveMenu: jest.fn(),
+  openLoadMenu: jest.fn()
+}));
+
+jest.unstable_mockModule('../scripts/game_state.js', () => ({
+  saveState: jest.fn(),
+  loadState: jest.fn(),
+  gameState: { currentMap: 'map01' }
+}));
+
+jest.unstable_mockModule('../scripts/save_load.js', () => ({
+  saveGame: jest.fn(),
+  loadGame: jest.fn(() => true)
+}));
+
+jest.unstable_mockModule('../ui/inventory_menu.js', () => ({
+  refreshInventoryDisplay: jest.fn()
+}));
+
+jest.unstable_mockModule('../scripts/router.js', () => ({
+  loadMap: jest.fn(() => Promise.resolve({ cols: 3 })),
+  getCurrentMapName: jest.fn(() => 'map01')
+}));
+
+jest.unstable_mockModule('../scripts/fog_system.js', () => ({
+  initFog: jest.fn(),
+  revealAll: jest.fn(),
+  reveal: jest.fn()
+}));
+
+jest.unstable_mockModule('../scripts/map_loader.js', () => ({
+  isFogEnabled: jest.fn(() => false)
+}));
+
+jest.unstable_mockModule('../scripts/player.js', () => ({
+  player: { x: 0, y: 0, maxHp: 100, hp: 50, level: 1 },
+  updateStatsFromLevel: jest.fn()
+}));
+
+jest.unstable_mockModule('../scripts/ui/player_display.js', () => ({
+  updateHpDisplay: jest.fn(),
+  updateXpDisplay: jest.fn()
+}));
+
+jest.unstable_mockModule('../scripts/dialogue_system.js', () => ({
+  showDialogue: jest.fn()
+}));
+
+let handlers, uiMenu, saveLoad, dialogueSys, playerModule;
+
+beforeEach(async () => {
+  jest.resetModules();
+  handlers = await import('../scripts/save_load_handlers.js');
+  uiMenu = await import('../ui/save_slots_menu.js');
+  saveLoad = await import('../scripts/save_load.js');
+  dialogueSys = await import('../scripts/dialogue_system.js');
+  playerModule = await import('../scripts/player.js');
+});
+
+test('handleSave calls openSaveMenu', () => {
+  handlers.handleSave();
+  expect(uiMenu.openSaveMenu).toHaveBeenCalled();
+});
+
+test('handleLoad calls openLoadMenu', () => {
+  handlers.handleLoad();
+  expect(uiMenu.openLoadMenu).toHaveBeenCalled();
+});
+
+test('loadSavedGame loads map and updates stats', async () => {
+  const container = document.createElement('div');
+  const state = { cols: 0 };
+  await handlers.loadSavedGame(1, container, state);
+  expect(saveLoad.loadGame).toHaveBeenCalledWith(1);
+  expect(saveLoad.saveGame).not.toHaveBeenCalled();
+  expect(state.cols).toBe(3);
+  expect(dialogueSys.showDialogue).toHaveBeenCalledWith(
+    'Progress loaded successfully.'
+  );
+  expect(playerModule.updateStatsFromLevel).toHaveBeenCalled();
+});
+

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -37,11 +37,12 @@ import {
   initInventoryMenu
 } from '../ui/inventory_menu.js';
 import '../ui/system_message.js';
+import { initSaveSlotsMenu } from '../ui/save_slots_menu.js';
 import {
-  initSaveSlotsMenu,
-  openSaveMenu,
-  openLoadMenu
-} from '../ui/save_slots_menu.js';
+  handleSave,
+  handleLoad,
+  initSaveLoadEvents
+} from './save_load_handlers.js';
 import { saveState, loadState, gameState } from './game_state.js';
 import { saveGame, loadGame } from './save_load.js';
 import { initMenuBar } from '../ui/menu_bar.js';
@@ -118,52 +119,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const centerToggle = document.getElementById('center-toggle');
   const resetBtn = document.getElementById('reset-settings');
 
-  function handleSave() {
-    openSaveMenu();
-  }
-
-  function handleLoad() {
-    openLoadMenu();
-  }
-
-  async function performLoad(slot) {
-    loadState();
-    if (!loadGame(slot)) {
-      showDialogue('No save found.');
-      return;
-    }
-    refreshInventoryDisplay();
-    const mapName = gameState.currentMap || 'map01';
-    try {
-      const { cols: newCols } = await router.loadMap(mapName);
-      gridState.cols = newCols;
-      initFog(container, gridState.cols, isFogEnabled());
-      if (isFogEnabled()) {
-        if (router.getCurrentMapName() === 'map01') {
-          revealAll();
-        } else {
-          reveal(player.x, player.y);
-        }
-      }
-      updateStatsFromLevel();
-      player.hp = Math.min(player.hp, player.maxHp);
-      updateHpDisplay();
-      updateXpDisplay();
-      showDialogue('Progress loaded successfully.');
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  document.addEventListener('saveSlot', (e) => {
-    saveState();
-    saveGame(e.detail.slot);
-    showDialogue('Game Saved.');
-  });
-
-  document.addEventListener('loadSlot', (e) => {
-    performLoad(e.detail.slot);
-  });
+  initSaveLoadEvents(container, gridState);
 
   initMenuBar(handleSave, handleLoad);
   initMainMenu();

--- a/scripts/save_load_handlers.js
+++ b/scripts/save_load_handlers.js
@@ -1,0 +1,59 @@
+import { saveState, loadState, gameState } from './game_state.js';
+import { saveGame, loadGame } from './save_load.js';
+import { initFog, reveal, revealAll } from './fog_system.js';
+import { isFogEnabled } from './map_loader.js';
+import { refreshInventoryDisplay } from '../ui/inventory_menu.js';
+import { player, updateStatsFromLevel } from './player.js';
+import { updateHpDisplay, updateXpDisplay } from './ui/player_display.js';
+import { openSaveMenu, openLoadMenu } from '../ui/save_slots_menu.js';
+import { showDialogue } from './dialogue_system.js';
+import * as router from './router.js';
+
+export function handleSave() {
+  openSaveMenu();
+}
+
+export function handleLoad() {
+  openLoadMenu();
+}
+
+export async function loadSavedGame(slot, container, gridState) {
+  loadState();
+  if (!loadGame(slot)) {
+    showDialogue('No save found.');
+    return;
+  }
+  refreshInventoryDisplay();
+  const mapName = gameState.currentMap || 'map01';
+  try {
+    const { cols: newCols } = await router.loadMap(mapName);
+    gridState.cols = newCols;
+    initFog(container, gridState.cols, isFogEnabled());
+    if (isFogEnabled()) {
+      if (router.getCurrentMapName() === 'map01') {
+        revealAll();
+      } else {
+        reveal(player.x, player.y);
+      }
+    }
+    updateStatsFromLevel();
+    player.hp = Math.min(player.hp, player.maxHp);
+    updateHpDisplay();
+    updateXpDisplay();
+    showDialogue('Progress loaded successfully.');
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+export function initSaveLoadEvents(container, gridState) {
+  document.addEventListener('saveSlot', (e) => {
+    saveState();
+    saveGame(e.detail.slot);
+    showDialogue('Game Saved.');
+  });
+
+  document.addEventListener('loadSlot', (e) => {
+    loadSavedGame(e.detail.slot, container, gridState);
+  });
+}


### PR DESCRIPTION
## Summary
- extract save/load menu logic from `main.js`
- initialize save/load events through new module
- test UI handlers

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `@eslint/js` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f0ee612cc83319ab6b215b9d6f98c