### PR TITLE
Improve docs about GitHub Pages build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,11 @@
 This guide walks through setting up the development environment so you can run
 linting and unit tests locally.
 
+GitHub Pages serves only the static files in this repository (HTML, CSS and
+JavaScript). The Node-based dependencies described below are used solely for
+development tasks like linting and testing and are not part of the deployed
+site.
+
 ## Prerequisites
 
 - **Node.js** v18 or later should be installed on your system. You can obtain it
@@ -17,8 +22,9 @@ npm install
 ```
 
 This command installs ESLint, Prettier, Jest and other packages used during
-development. If a `node_modules` directory already exists, you can refresh it
-with the helper script which favors cached packages:
+development. These tools help maintain code quality but are not included in the
+GitHub Pages deployment. If a `node_modules` directory already exists, you can
+refresh it with the helper script which favors cached packages:
 
 ```bash
 ./scripts/setup_dev.sh

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 - Player stats and leveling
 - Completely client side so it works with GitHub Pages
 
+GitHub Pages serves only these static files. The Node-based tools
+configured in this repository are used solely for development tasks
+like linting and testing. They are not required when the site is
+deployed.
+
 ## Running locally
 
 To work on Grid Quest locally you need Node.js for the lint and test tools and a
@@ -23,6 +28,7 @@ local HTTP server to serve the static assets.
    ```
 
    This sets up ESLint, Prettier and Jest which are used during development.
+   The packages are not part of the static site hosted on GitHub Pages.
 3. Optionally run the checks:
 
    ```bash


### PR DESCRIPTION
## Summary
- clarify that GitHub Pages hosts only static files
- explain that Node-based tools are development-only

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f16d18e7483318c5d4446e22119b6