### PR TITLE
Improve combat UI mobile layout

### DIFF
--- a/style/combat_ui.css
+++ b/style/combat_ui.css
@@ -78,13 +78,14 @@
 }
 
 .skill-button {
-  width: 80%;
+  min-width: 90%;
   padding: 8px;
-  font-size: 13px;
+  font-size: 0.85rem;
   background: #222;
   color: white;
   border-radius: 6px;
   border: 1px solid #555;
+  margin-bottom: 8px;
 }
 
 .combatant-label {
@@ -103,9 +104,9 @@
 }
 
 .stat-block {
-  font-size: 0.85rem;
-  line-height: 1.2;
-  margin-top: 4px;
+  font-size: 0.75rem;
+  line-height: 1.1;
+  margin: 6px 0 0 0;
   padding: 2px 4px;
   background: rgba(0, 0, 0, 0.4);
   border-radius: 3px;
@@ -117,20 +118,23 @@
 
 /* Auto-battle toggle styling */
 .auto-battle-button {
-  font-size: 1rem;
-  padding: 8px 16px;
+  font-size: 0.75rem;
+  padding: 5px 10px;
+  margin: 6px 0;
   border-radius: 4px;
 }
 
 /* Combat log container */
 #combat-log {
-  margin-top: 10px;
+  position: relative;
+  margin: 8px auto;
   font-size: 0.9rem;
-  padding: 6px 10px;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.5);
   color: white;
+  padding: 6px 10px;
   border-radius: 6px;
   text-align: center;
+  width: 90%;
 }
 
 /* Ensure skill buttons align consistently */
@@ -139,15 +143,23 @@
 }
 
 @media (max-width: 768px) {
+  .stat-block,
+  .skill-button,
   .auto-battle-button {
-    font-size: 0.85rem;
-    padding: 6px 12px;
-    border-radius: 6px;
-    margin-bottom: 8px;
+    font-size: 0.75rem;
+  }
+
+  .stat-block {
+    max-width: 60px;
+  }
+
+  .auto-battle-button {
+    width: 120px;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   .skill-button {
     width: 100%;
-    margin-bottom: 6px;
   }
 }

--- a/style/mobile.css
+++ b/style/mobile.css
@@ -7,7 +7,9 @@
 
   .stat-block {
     font-size: 0.75rem;
+    line-height: 1.1;
     padding: 2px;
-    margin-top: 4px;
+    margin: 6px 0 0 0;
+    max-width: 60px;
   }
 }


### PR DESCRIPTION
## Summary
- tweak stat block, skill and auto-battle button styles
- reposition combat log and update styling
- add mobile-specific sizing rules

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx prettier -w style/combat_ui.css style/mobile.css`


------
https://chatgpt.com/codex/tasks/task_e_684f2a377fe88331bb2c340c1fcc3584