### PR TITLE
Improve mobile combat UI

### DIFF
--- a/style/combat.css
+++ b/style/combat.css
@@ -191,12 +191,13 @@
 
 #battle-overlay .combatant .stats,
 .stat-block {
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   line-height: 1.2;
   margin-top: 4px;
   padding: 2px 4px;
   background: rgba(0, 0, 0, 0.4);
   border-radius: 3px;
+  text-align: center;
   letter-spacing: 0.3px;
   font-family: system-ui, Arial, sans-serif;
 }
@@ -635,10 +636,20 @@
   }
 
   #battle-overlay #combat-log {
+    position: absolute;
+    top: 140px;
+    left: 50%;
+    transform: translateX(-50%);
     width: 90%;
     max-height: 100px;
     overflow-y: auto;
-    margin: 8px auto;
+    font-size: 0.9rem;
+    line-height: 1.3;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 6px 10px;
+    border-radius: 6px;
+    text-align: center;
+    z-index: 10;
   }
 
   #battle-overlay .actions {

--- a/style/combat_ui.css
+++ b/style/combat_ui.css
@@ -85,7 +85,7 @@
   color: white;
   border-radius: 6px;
   border: 1px solid #555;
-  margin-bottom: 8px;
+  margin: 8px auto;
 }
 
 .combatant-label {
@@ -110,6 +110,7 @@
   padding: 2px 4px;
   background: rgba(0, 0, 0, 0.4);
   border-radius: 3px;
+  text-align: center;
   letter-spacing: 0.3px;
   font-family: system-ui, Arial, sans-serif;
   width: 100%;
@@ -118,23 +119,28 @@
 
 /* Auto-battle toggle styling */
 .auto-battle-button {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   padding: 5px 10px;
-  margin: 6px 0;
+  width: 100px;
+  margin-top: 8px;
   border-radius: 4px;
 }
 
 /* Combat log container */
 #combat-log {
-  position: relative;
-  margin: 8px auto;
+  position: absolute;
+  top: 140px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 90%;
   font-size: 0.9rem;
-  background: rgba(0, 0, 0, 0.5);
+  line-height: 1.3;
+  background: rgba(0, 0, 0, 0.6);
   color: white;
   padding: 6px 10px;
   border-radius: 6px;
   text-align: center;
-  width: 90%;
+  z-index: 10;
 }
 
 /* Ensure skill buttons align consistently */
@@ -154,7 +160,7 @@
   }
 
   .auto-battle-button {
-    width: 120px;
+    width: 100px;
     margin-left: auto;
     margin-right: auto;
   }


### PR DESCRIPTION
## Summary
- refine combat log positioning so it no longer overlaps combatants
- tighten skill button margins for easier tapping
- reduce auto-battle button dominance
- center stat block text and shrink font

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_684f314a164c8331b691d86b8e52c4ac