### PR TITLE
Improve combat layout for landscape screens

### DIFF
--- a/style/combat.css
+++ b/style/combat.css
@@ -689,3 +689,27 @@
     text-align: center;
   }
 }
+
+@media screen and (orientation: landscape) and (min-aspect-ratio: 4/3) {
+  #battle-overlay .combatants {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    margin: 0 20px;
+  }
+
+  #battle-overlay .actor-column {
+    flex-direction: column;
+    justify-content: space-evenly;
+  }
+
+  #battle-overlay #combat-log {
+    position: relative;
+    order: 3;
+    margin: 10px auto 20px auto;
+    max-width: 70%;
+    font-size: 1rem;
+  }
+}

--- a/style/combat_ui.css
+++ b/style/combat_ui.css
@@ -169,3 +169,22 @@
     width: 100%;
   }
 }
+
+@media (orientation: landscape) and (min-aspect-ratio: 4/3) {
+  .skill-panel {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    width: 300px;
+    margin: 0 auto;
+  }
+
+  .auto-battle-button {
+    margin: 10px auto 20px auto;
+  }
+
+  .stat-block {
+    font-size: 0.85rem;
+    line-height: 1.2;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak combat layout for wide screens
- adjust combat UI elements for horizontal orientation

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f37f84d3483318e14017bcca4b8cc