### PR TITLE
Localize strike, guard, heal skill names

### DIFF
--- a/scripts/locales/ar.js
+++ b/scripts/locales/ar.js
@@ -174,5 +174,11 @@ export default {
   'combat.auto.toggle': 'Toggle Auto-Battle',
   'combat.auto.on': 'Auto-Battle ON',
   'combat.auto.off': 'Auto-Battle OFF',
-  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.'
+  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.',
+  'skill.strike.name': 'ضربة',
+  'skill.strike.description': 'يسبب ضررًا يعادل قوة الهجوم.',
+  'skill.guard.name': 'حراسة',
+  'skill.guard.description': 'تقليل الضرر من الهجوم التالي بنسبة 50٪.',
+  'skill.heal.name': 'شفاء',
+  'skill.heal.description': 'استعادة 20٪ من نقاط الحياة القصوى. وقت التهدئة: 3'
 };

--- a/scripts/locales/en.js
+++ b/scripts/locales/en.js
@@ -182,5 +182,11 @@ export default {
   'combat.auto.toggle': 'Toggle Auto-Battle',
   'combat.auto.on': 'Auto-Battle ON',
   'combat.auto.off': 'Auto-Battle OFF',
-  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.'
+  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.',
+  'skill.strike.name': 'Strike',
+  'skill.strike.description': 'Deal damage equal to your Attack stat.',
+  'skill.guard.name': 'Guard',
+  'skill.guard.description': 'Reduce damage from the next attack by 50%.',
+  'skill.heal.name': 'Heal',
+  'skill.heal.description': 'Restore 20% of your max HP. Cooldown: 3'
 };

--- a/scripts/locales/ja.js
+++ b/scripts/locales/ja.js
@@ -174,5 +174,11 @@ export default {
   'combat.auto.toggle': 'Toggle Auto-Battle',
   'combat.auto.on': 'Auto-Battle ON',
   'combat.auto.off': 'Auto-Battle OFF',
-  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.'
+  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.',
+  'skill.strike.name': '一撃',
+  'skill.strike.description': '攻撃力に等しいダメージを与える。',
+  'skill.guard.name': '防御',
+  'skill.guard.description': '次の攻撃からのダメージを50％軽減。',
+  'skill.heal.name': '回復',
+  'skill.heal.description': '最大HPの20%を回復。クールダウン: 3'
 };

--- a/scripts/locales/nl.js
+++ b/scripts/locales/nl.js
@@ -183,5 +183,11 @@ export default {
   'combat.auto.toggle': 'Toggle Auto-Battle',
   'combat.auto.on': 'Auto-Battle ON',
   'combat.auto.off': 'Auto-Battle OFF',
-  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.'
+  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.',
+  'skill.strike.name': 'Slaan',
+  'skill.strike.description': 'Breng schade toe gelijk aan je Aanval-statistiek.',
+  'skill.guard.name': 'Blokkeer',
+  'skill.guard.description': 'Verminder schade van de volgende aanval met 50%.',
+  'skill.heal.name': 'Genezen',
+  'skill.heal.description': 'Herstel 20% van je maximale HP. Aflopende tijd: 3'
 };

--- a/scripts/locales/ru.js
+++ b/scripts/locales/ru.js
@@ -176,5 +176,11 @@ export default {
   'combat.auto.toggle': 'Toggle Auto-Battle',
   'combat.auto.on': 'Auto-Battle ON',
   'combat.auto.off': 'Auto-Battle OFF',
-  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.'
+  'combat.skill.strike.description': 'Deal damage equal to your Attack stat.',
+  'skill.strike.name': 'Удар',
+  'skill.strike.description': 'Наносит урон, равный вашей атаке.',
+  'skill.guard.name': 'Блок',
+  'skill.guard.description': 'Уменьшает урон от следующей атаки на 50%.',
+  'skill.heal.name': 'Лечение',
+  'skill.heal.description': 'Восстанавливает 20% от макс. HP. Перезарядка: 3'
 };

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -1,12 +1,17 @@
 // Defines skill data and manages unlocking/lookup
 import { applyDamage } from './logic.js';
+import { t } from './i18n.js';
 
 const skillDefs = {
   strike: {
     id: 'strike',
-    name: 'Strike',
+    get name() {
+      return t('skill.strike.name');
+    },
     icon: '⚔️',
-    description: 'Deal damage equal to your Attack stat.',
+    get description() {
+      return t('skill.strike.description');
+    },
     targetType: 'enemy',
     range: 'single',
     category: 'offensive',
@@ -40,9 +45,13 @@ const skillDefs = {
   },
   guard: {
     id: 'guard',
-    name: 'Guard',
+    get name() {
+      return t('skill.guard.name');
+    },
     icon: '🛡️',
-    description: 'Reduce damage from the next attack by 50%.',
+    get description() {
+      return t('skill.guard.description');
+    },
     targetType: 'self',
     range: 'single',
     category: 'defensive',
@@ -57,9 +66,13 @@ const skillDefs = {
   },
   heal: {
     id: 'heal',
-    name: 'Heal',
+    get name() {
+      return t('skill.heal.name');
+    },
     icon: '✨',
-    description: 'Restore 20% of your max HP.',
+    get description() {
+      return t('skill.heal.description');
+    },
     targetType: 'self',
     range: 'single',
     category: 'defensive',


### PR DESCRIPTION
## Summary
- add strike/guard/heal translation keys to all locales
- fetch translations via `t()` in skills.js

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3ca3e08083319098258db13c821c