### PR TITLE
Fix no-items visibility

### DIFF
--- a/scripts/combat_system.js
+++ b/scripts/combat_system.js
@@ -177,6 +177,7 @@ export async function startCombat(enemy, player) {
   const offensiveContainer = overlay.querySelector('.offensive-skill-buttons');
   const defensiveContainer = overlay.querySelector('.defensive-skill-buttons');
   const itemContainer = overlay.querySelector('.item-buttons');
+  const itemsTabBtn = overlay.querySelector('.items-tab');
   const autoBtn = overlay.querySelector('#auto-battle-toggle');
   const logEl = overlay.querySelector('.log');
   const log = initLogPanel(overlay, enemy.name, player.name || 'Player');
@@ -401,7 +402,11 @@ export async function startCombat(enemy, player) {
     const items = getItemsByCategory('combat');
     if (items.length === 0) {
       const msg = document.createElement('div');
-      msg.textContent = 'No usable items';
+      msg.classList.add('no-items-message');
+      msg.textContent = t('combat.no_items');
+      if (!itemsTabBtn?.classList.contains('selected')) {
+        msg.classList.add('hidden');
+      }
       itemContainer.appendChild(msg);
       return;
     }

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -228,6 +228,8 @@ export function setupTabs(overlay) {
     offTabBtn.classList.add('selected');
     defTabBtn.classList.remove('selected');
     itemsTabBtn.classList.remove('selected');
+    const msg = itemContainer.querySelector('.no-items-message');
+    if (msg) msg.classList.add('hidden');
   }
 
   function showDefensive() {
@@ -237,6 +239,8 @@ export function setupTabs(overlay) {
     defTabBtn.classList.add('selected');
     offTabBtn.classList.remove('selected');
     itemsTabBtn.classList.remove('selected');
+    const msg = itemContainer.querySelector('.no-items-message');
+    if (msg) msg.classList.add('hidden');
   }
 
   function showItems() {
@@ -246,6 +250,11 @@ export function setupTabs(overlay) {
     itemsTabBtn.classList.add('selected');
     offTabBtn.classList.remove('selected');
     defTabBtn.classList.remove('selected');
+    const msg = itemContainer.querySelector('.no-items-message');
+    if (msg) {
+      const hasItems = itemContainer.querySelectorAll('button').length > 0;
+      msg.classList.toggle('hidden', hasItems);
+    }
   }
 
   offTabBtn.addEventListener('click', showOffensive);

--- a/scripts/locales/ar.js
+++ b/scripts/locales/ar.js
@@ -162,6 +162,7 @@ export default {
   'combat.defeat.player': 'لقد هُزمت...',
   'combat.item.curseBlock': 'اللعنة تمنعك من استخدام الأدوات!',
   'combat.item.use': '{user} يستخدم {item}!',
+  'combat.no_items': 'No usable items',
   'combat.reflect': 'تم عكس الضرر!',
   'combat.sacredCounter': 'الرد المقدس يفعل!',
   'combat.silenced': 'حالة الصمت تمنعك من الفعل!',

--- a/scripts/locales/en.js
+++ b/scripts/locales/en.js
@@ -169,6 +169,7 @@ export default {
   'combat.defeat.player': 'You were defeated...',
   'combat.item.curseBlock': 'A curse prevents you from using items!',
   'combat.item.use': '{user} uses {item}!',
+  'combat.no_items': 'No usable items',
   'combat.reflect': 'Reflected the damage back!',
   'combat.sacredCounter': 'Sacred Counter retaliates!',
   'combat.silenced': 'Silenced! Cannot act.',

--- a/scripts/locales/ja.js
+++ b/scripts/locales/ja.js
@@ -162,6 +162,7 @@ export default {
   'combat.defeat.player': 'あなたは倒れた…',
   'combat.item.curseBlock': '呪いでアイテムが使えない！',
   'combat.item.use': '{user}は{item}を使った！',
+  'combat.no_items': 'No usable items',
   'combat.reflect': 'ダメージを跳ね返した！',
   'combat.sacredCounter': '聖なる反撃が発動！',
   'combat.silenced': '沈黙状態で行動できない！',

--- a/scripts/locales/nl.js
+++ b/scripts/locales/nl.js
@@ -170,6 +170,7 @@ export default {
   'combat.defeat.player': 'Je bent verslagen...',
   'combat.item.curseBlock': 'Een vloek verhindert het gebruik van items!',
   'combat.item.use': '{user} gebruikt {item}!',
+  'combat.no_items': 'No usable items',
   'combat.reflect': 'Schade werd teruggekaatst!',
   'combat.sacredCounter': 'Heilige Tegenstoot slaat terug!',
   'combat.silenced': 'Het zwijgen is je opgelegd!',

--- a/scripts/locales/ru.js
+++ b/scripts/locales/ru.js
@@ -164,6 +164,7 @@ export default {
   'combat.defeat.player': 'Вы проиграли...',
   'combat.item.curseBlock': 'Проклятие не даёт использовать предметы!',
   'combat.item.use': '{user} использует {item}!',
+  'combat.no_items': 'No usable items',
   'combat.reflect': 'Урон отражён обратно!',
   'combat.sacredCounter': 'Священный отпор наносит удар!',
   'combat.silenced': 'Немота не даёт действовать!',


### PR DESCRIPTION
## Summary
- ensure `No usable items` only visible on Items tab
- hide the message on other tabs
- add `combat.no_items` localization key in all language files

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f3f20e3148331bbedb6a01c306187