### PR TITLE
Remove dialogue skip prompt

### DIFF
--- a/scripts/dialogue_system.js
+++ b/scripts/dialogue_system.js
@@ -37,13 +37,9 @@ export async function showDialogue(keyOrText, callback = () => {}) {
   overlay.innerHTML = `
     <div class="dialogue-box">
       <div class="dialogue-text"></div>
-      <div class="dialogue-advance">\u2192</div>
     </div>`;
   document.body.appendChild(overlay);
   const textEl = overlay.querySelector('.dialogue-text');
-  const advance = overlay.querySelector('.dialogue-advance');
-  advance.textContent = t('dialogue.skip');
-  advance.style.display = 'none';
 
   let index = 0;
   const speed = gameState.settings?.dialogueAnim === false ? 0 : 30; // ms per character
@@ -54,7 +50,6 @@ export async function showDialogue(keyOrText, callback = () => {}) {
       index++;
       setTimeout(typeNext, speed);
     } else {
-      advance.style.display = 'block';
       overlay.querySelector('.dialogue-box').classList.add('finished');
     }
   }
@@ -65,7 +60,6 @@ export async function showDialogue(keyOrText, callback = () => {}) {
       if (gameState.settings?.tapToSkip === false) return;
       textEl.textContent = text;
       index = text.length;
-      advance.style.display = 'block';
       overlay.querySelector('.dialogue-box').classList.add('finished');
     } else {
       cleanup();

--- a/scripts/locales/ar.js
+++ b/scripts/locales/ar.js
@@ -53,7 +53,6 @@ export default {
   'inventory.unequip': 'إزالة',
   'inventory.use': 'استخدام',
   'inventory.reroll': 'إعادة',
-  'dialogue.skip': 'اضغط للتخطي',
   'status.regen': 'Regeneration',
   'status.fortify': 'Fortify',
   'status.defense_boost': 'Defense Boost',

--- a/scripts/locales/en.js
+++ b/scripts/locales/en.js
@@ -53,7 +53,6 @@ export default {
   'inventory.unequip': 'Unequip',
   'inventory.use': 'Use',
   'inventory.reroll': 'Reroll',
-  'dialogue.skip': 'Tap to skip',
   'status.regen': 'Regeneration',
   'status.fortify': 'Fortify',
   'status.defense_boost': 'Defense Boost',

--- a/scripts/locales/ja.js
+++ b/scripts/locales/ja.js
@@ -53,7 +53,6 @@ export default {
   'inventory.unequip': '外す',
   'inventory.use': '使用',
   'inventory.reroll': 'リロール',
-  'dialogue.skip': 'タップしてスキップ',
   'status.regen': 'Regeneration',
   'status.fortify': 'Fortify',
   'status.defense_boost': 'Defense Boost',

--- a/scripts/locales/nl.js
+++ b/scripts/locales/nl.js
@@ -53,7 +53,6 @@ export default {
   'inventory.unequip': 'Uittrekken',
   'inventory.use': 'Gebruik',
   'inventory.reroll': 'Hertrek',
-  'dialogue.skip': 'Tik om over te slaan',
   'status.regen': 'Regeneration',
   'status.fortify': 'Fortify',
   'status.defense_boost': 'Defense Boost',

--- a/scripts/locales/ru.js
+++ b/scripts/locales/ru.js
@@ -53,7 +53,6 @@ export default {
   'inventory.unequip': 'Снять',
   'inventory.use': 'Использовать',
   'inventory.reroll': 'Перебросить',
-  'dialogue.skip': 'Нажмите, чтобы пропустить',
   'status.regen': 'Regeneration',
   'status.fortify': 'Fortify',
   'status.defense_boost': 'Defense Boost',

--- a/style/layout.css
+++ b/style/layout.css
@@ -808,23 +808,6 @@ body {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.7);
 }
 
-.dialogue-advance {
-  position: absolute;
-  right: 10px;
-  bottom: 6px;
-  font-size: 20px;
-  animation: blink 1s steps(1) infinite;
-}
-
-.dialogue-box:not(.finished) .dialogue-advance {
-  display: none;
-}
-
-@keyframes blink {
-  50% {
-    opacity: 0;
-  }
-}
 
 .dialogue-choices {
   margin-top: 12px;


### PR DESCRIPTION
## Summary
- remove the dialog skip element and CSS
- drop `dialogue.skip` translations

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684f591f82ac8331abceae96aec17b03