### PR TITLE
Remove unused dialogue data

### DIFF
--- a/data/dialog.json
+++ b/data/dialog.json
@@ -1,5 +1,0 @@
-{
-  "chest_intro_01": "You carefully open the dusty chest...",
-  "enemy_shadow_beast_intro": "A shadowy beast snarls and prepares to strike!",
-  "map01_entry": "The air is thick with mist as you enter the forgotten ruins."
-}

--- a/scripts/dialogue_system.js
+++ b/scripts/dialogue_system.js
@@ -9,26 +9,12 @@ import {
   triggerReroll
 } from './dialogue_state.js';
 import { getQuests, completeQuest } from './quest_state.js';
-import { loadJson } from './data_service.js';
 import { gameState } from './game_state.js';
 import { t } from './i18n.js';
 
-let dialogueLines = {};
-let dataLoaded = false;
-
-async function loadDialogData() {
-  if (dataLoaded) return;
-  try {
-    const data = await loadJson('data/dialog.json');
-    dialogueLines = data;
-  } catch (err) {
-    dialogueLines = {};
-  }
-  dataLoaded = true;
-}
+const dialogueLines = {};
 
 export async function showDialogue(keyOrText, callback = () => {}) {
-  await loadDialogData();
   const raw = dialogueLines[keyOrText] || keyOrText || '';
   const text = raw;
 
@@ -85,7 +71,6 @@ export async function showDialogue(keyOrText, callback = () => {}) {
 }
 
 export async function showDialogueWithChoices(keyOrText, choices = []) {
-  await loadDialogData();
   const raw = dialogueLines[keyOrText] || keyOrText || '';
   const text = raw;
 


### PR DESCRIPTION
## Summary
- drop unused `data/dialog.json`
- stop loading the removed file in `dialogue_system.js`

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5d91d6a48331bb1f2dbef8f866f0