### PR TITLE
Fix localisation syntax errors

### DIFF
--- a/scripts/locales/ar.js
+++ b/scripts/locales/ar.js
@@ -201,7 +201,7 @@ export default {
   'leda.dialogue.how.0': 'فريدريكا...؟',
   'leda.dialogue.how.1': 'رحيل',
   'leda.dialogue.more.text': 'إن وجدتها، فلا تطلب القوة... بل الغاية.',
-  'leda.dialogue.more.0': 'شكراً لك'
+  'leda.dialogue.more.0': 'شكراً لك',
   'frederica.dialogue.start.text': 'أهلاً أيها المسافر. ماذا تريد؟',
   'frederica.dialogue.start.0': 'حدثني عن الكهف.',
   'frederica.dialogue.start.1': 'من هي ليدا؟',

--- a/scripts/locales/ja.js
+++ b/scripts/locales/ja.js
@@ -201,7 +201,7 @@ export default {
   'leda.dialogue.how.0': 'フレデリカ…?',
   'leda.dialogue.how.1': '立ち去る',
   'leda.dialogue.more.text': 'もし彼女を見つけたなら、力ではなく…目的を求めなさい。',
-  'leda.dialogue.more.0': 'ありがとう'
+  'leda.dialogue.more.0': 'ありがとう',
   'frederica.dialogue.start.text': '旅人か。何を求めている？',
   'frederica.dialogue.start.0': '洞窟について教えて。',
   'frederica.dialogue.start.1': 'レダとは？',

--- a/scripts/locales/nl.js
+++ b/scripts/locales/nl.js
@@ -184,8 +184,7 @@ export default {
   'combat.silenced': 'Het zwijgen is je opgelegd!',
   'combat.paralyzed': '{enemy} is verlamd en kan niet handelen!',
   'combat.confused': '{enemy} is verward en aarzelt!',
-  'combat.unstable': '{enemy} wankelt onstabiel!'
-  ,
+  'combat.unstable': '{enemy} wankelt onstabiel!',
   'combat.category.offensive': 'Offensive',
   'combat.category.defensive': 'Defensive',
   'combat.category.items': 'Items',
@@ -210,7 +209,7 @@ export default {
   'leda.dialogue.how.0': 'Frederica...?',
   'leda.dialogue.how.1': 'Weggaan',
   'leda.dialogue.more.text': 'Als je haar vindt, vraag dan niet om macht... maar om doel.',
-  'leda.dialogue.more.0': 'Dank je'
+  'leda.dialogue.more.0': 'Dank je',
   'frederica.dialogue.start.text': 'Ah, een reiziger. Wat zoek je?',
   'frederica.dialogue.start.0': 'Vertel me over de grot.',
   'frederica.dialogue.start.1': 'Wie is Leda?',

--- a/scripts/locales/ru.js
+++ b/scripts/locales/ru.js
@@ -203,7 +203,7 @@ export default {
   'leda.dialogue.how.0': 'Фредерика...?',
   'leda.dialogue.how.1': 'Уйти',
   'leda.dialogue.more.text': 'Если найдёшь её, проси не силу... а цель.',
-  'leda.dialogue.more.0': 'Спасибо'
+  'leda.dialogue.more.0': 'Спасибо',
   'frederica.dialogue.start.text': 'Ах, путник. Что ищешь?',
   'frederica.dialogue.start.0': 'Расскажи о пещере.',
   'frederica.dialogue.start.1': 'Кто такая Леда?',


### PR DESCRIPTION
## Summary
- fix stray comma and missing commas in localisation files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f869d9cb0833194277a8f1f632aec