### PR TITLE
Fix missing guard skill translation

### DIFF
--- a/scripts/locales/ar.js
+++ b/scripts/locales/ar.js
@@ -184,6 +184,8 @@ export default {
   'combat.auto.on': 'Auto-Battle ON',
   'combat.auto.off': 'Auto-Battle OFF',
   'combat.skill.strike.description': 'Deal damage equal to your Attack stat.',
+  'combat.skill.guard.description': 'تقليل الضرر من الهجوم التالي بنسبة 50٪.',
+  'combat.skill.heal.description': 'استعادة 20٪ من نقاط الحياة القصوى. وقت التهدئة: 3',
   'skill.strike.name': 'ضربة',
   'skill.strike.description': 'يسبب ضررًا يعادل قوة الهجوم.',
   'skill.guard.name': 'حراسة',

--- a/scripts/locales/en.js
+++ b/scripts/locales/en.js
@@ -191,6 +191,8 @@ export default {
   'combat.auto.on': 'Auto-Battle ON',
   'combat.auto.off': 'Auto-Battle OFF',
   'combat.skill.strike.description': 'Deal damage equal to your Attack stat.',
+  'combat.skill.guard.description': 'Reduce damage from the next attack by 50%.',
+  'combat.skill.heal.description': 'Restore 20% of your max HP. Cooldown: 3',
   'skill.strike.name': 'Strike',
   'skill.strike.description': 'Deal damage equal to your Attack stat.',
   'skill.guard.name': 'Guard',

--- a/scripts/locales/ja.js
+++ b/scripts/locales/ja.js
@@ -184,6 +184,8 @@ export default {
   'combat.auto.on': 'Auto-Battle ON',
   'combat.auto.off': 'Auto-Battle OFF',
   'combat.skill.strike.description': 'Deal damage equal to your Attack stat.',
+  'combat.skill.guard.description': '次の攻撃からのダメージを50％軽減。',
+  'combat.skill.heal.description': '最大HPの20%を回復。クールダウン: 3',
   'skill.strike.name': '一撃',
   'skill.strike.description': '攻撃力に等しいダメージを与える。',
   'skill.guard.name': '防御',

--- a/scripts/locales/nl.js
+++ b/scripts/locales/nl.js
@@ -192,6 +192,8 @@ export default {
   'combat.auto.on': 'Auto-Battle ON',
   'combat.auto.off': 'Auto-Battle OFF',
   'combat.skill.strike.description': 'Deal damage equal to your Attack stat.',
+  'combat.skill.guard.description': 'Verminder schade van de volgende aanval met 50%.',
+  'combat.skill.heal.description': 'Herstel 20% van je maximale HP. Aflopende tijd: 3',
   'skill.strike.name': 'Slaan',
   'skill.strike.description': 'Breng schade toe gelijk aan je Aanval-statistiek.',
   'skill.guard.name': 'Blokkeer',

--- a/scripts/locales/ru.js
+++ b/scripts/locales/ru.js
@@ -186,6 +186,8 @@ export default {
   'combat.auto.on': 'Auto-Battle ON',
   'combat.auto.off': 'Auto-Battle OFF',
   'combat.skill.strike.description': 'Deal damage equal to your Attack stat.',
+  'combat.skill.guard.description': 'Уменьшает урон от следующей атаки на 50%.',
+  'combat.skill.heal.description': 'Восстанавливает 20% от макс. HP. Перезарядка: 3',
   'skill.strike.name': 'Удар',
   'skill.strike.description': 'Наносит урон, равный вашей атаке.',
   'skill.guard.name': 'Блок',


### PR DESCRIPTION
## Summary
- add `combat.skill.guard.description` to each locale
- also add `combat.skill.heal.description` so tooltips have coverage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685011549b108331a3adbae9e8a1b576