### PR TITLE
Add Ronington enemy with fire skills

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -555,6 +555,30 @@
       }
     ]
   },
+  "ronington": {
+    "name": "Ronington",
+    "hp": 70,
+    "stats": {
+      "attack": 5,
+      "defense": 0,
+      "speed": 7
+    },
+    "xp": 12,
+    "description": "A fiery baby dragon with surprising agility.",
+    "intro": "A young dragon snorts sparks at your approach!",
+    "portrait": "🐲",
+    "skills": [
+      "flame_nip",
+      "ember_puff",
+      "tail_spark"
+    ],
+    "behavior": "aggressive",
+    "drops": [
+      { "item": "baby_dragon_scale", "quantity": 1 },
+      { "item": "gem", "quantity": 1, "chance": 0.3 }
+    ],
+    "script": "enemies/ronington.js"
+  },
   "pain_lattice": {
     "name": "Pain Lattice",
     "hp": 70,

--- a/enemies/ronington.js
+++ b/enemies/ronington.js
@@ -1,0 +1,16 @@
+export const ronington = {
+  id: 'ronington',
+  name: 'Ronington',
+  hp: 70,
+  stats: { attack: 5, defense: 0, speed: 7 },
+  xp: 12,
+  skills: ['flame_nip', 'ember_puff', 'tail_spark'],
+  behavior: 'aggressive',
+  description: 'A fiery baby dragon with surprising agility.',
+  drops: [
+    { item: 'baby_dragon_scale', quantity: 1 },
+    { item: 'gem', quantity: 1, chance: 0.3 }
+  ]
+};
+
+export default ronington;

--- a/scripts/enemy_skills.js
+++ b/scripts/enemy_skills.js
@@ -1102,6 +1102,57 @@ export const enemySkills = {
       log(`${enemy.name} binds you with earth for ${applied} damage!`);
     }
   },
+  flame_nip: {
+    id: 'flame_nip',
+    name: 'Flame Nip',
+    icon: '🐲',
+    description: 'A quick fiery bite. No cooldown.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 0,
+    aiType: 'damage',
+    effect({ enemy, damagePlayer, log }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = atk + 2;
+      const applied = damagePlayer(dmg);
+      log(`${enemy.name} bites with flame for ${applied} damage!`);
+    }
+  },
+  ember_puff: {
+    id: 'ember_puff',
+    name: 'Ember Puff',
+    icon: '🔥',
+    description: 'Scorches the foe, chance to burn. 5-turn cooldown.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 5,
+    aiType: 'damage',
+    applies: ['burn'],
+    statuses: [{ target: 'player', id: 'burn', duration: 3 }],
+    effect({ enemy, damagePlayer, applyStatus, log }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = atk + 4;
+      const applied = damagePlayer(dmg);
+      applyStatus('player', 'burn', 3);
+      log(`${enemy.name} breathes embers for ${applied} damage!`);
+    }
+  },
+  tail_spark: {
+    id: 'tail_spark',
+    name: 'Tail Spark',
+    icon: '💥',
+    description: 'Tail flick with a fiery spark. 5-turn cooldown.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 5,
+    aiType: 'damage',
+    effect({ enemy, damagePlayer, log }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = atk + 6;
+      const applied = damagePlayer(dmg);
+      log(`${enemy.name} lashes out with a blazing tail! (${applied} damage)`);
+    }
+  },
   resolve_break: {
     id: 'resolve_break',
     name: 'Resolve Break',

--- a/scripts/items/general.js
+++ b/scripts/items/general.js
@@ -273,6 +273,32 @@ export const generalItems = {
     "stackLimit": 99,
     "icon": "🌫️"
   },
+  "baby_dragon_scale": {
+    "id": "baby_dragon_scale",
+    "name": "Baby Dragon Scale",
+    "description": "A small yet sturdy scale from a young dragon.",
+    "type": "material",
+    "tags": [
+      "items"
+    ],
+    "category": "general",
+    "consumable": true,
+    "stackLimit": 99,
+    "icon": "🐲"
+  },
+  "gem": {
+    "id": "gem",
+    "name": "Gem",
+    "description": "A luminous gem dropped by the fire-dragonling Ronington.",
+    "type": "material",
+    "tags": [
+      "items"
+    ],
+    "category": "general",
+    "consumable": true,
+    "stackLimit": 99,
+    "icon": "💎"
+  },
   "echo_crystal": {
     "id": "echo_crystal",
     "name": "Echo Crystal",


### PR DESCRIPTION
## Summary
- add Ronington baby dragon enemy definition
- implement flame_nip, ember_puff and tail_spark enemy skills
- include Ronington data entry and drops
- define baby_dragon_scale and gem items

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68501cd6f038833199157545e90b7851