### PR TITLE
Fix guard skill damage reduction

### DIFF
--- a/__tests__/guard_skill.test.js
+++ b/__tests__/guard_skill.test.js
@@ -1,0 +1,24 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let getSkill, applyDamage;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ getSkill } = await import('../scripts/skills.js'));
+  ({ applyDamage } = await import('../scripts/logic.js'));
+});
+
+test('guard halves the next damage and resets flag', () => {
+  const guard = getSkill('guard');
+  const player = { name: 'Hero', hp: 20, guarding: false };
+  const log = jest.fn();
+
+  guard.effect({ caster: player, activateGuard: t => (t.guarding = true), log });
+
+  const dealt = applyDamage(player, 10);
+
+  expect(dealt).toBe(5);
+  expect(player.hp).toBe(15);
+  expect(player.guarding).toBe(false);
+});

--- a/scripts/combat_system.js
+++ b/scripts/combat_system.js
@@ -67,11 +67,7 @@ import {
   removeNegativeStatusLogged
 } from './status_logic.js';
 import { updateSkillDisableState } from './skill_ui.js';
-import {
-  applyEffect as applyStatusEffect,
-  removeStatus as removeStatusEffect,
-  tickStatusEffects
-} from './status_effect.js';
+import { tickStatusEffects } from './status_effect.js';
 import { getStatusEffect } from './status_effects.js';
 import { initEnemyState } from './enemy.js';
 import { combatState, initCombatState } from './combat_state.js';
@@ -344,8 +340,10 @@ export async function startCombat(enemy, player) {
     log(t('combat.heal', { target: 'Player', amount }));
   }
 
-  function activateGuard() {
-    applyStatusEffect(player, 'guarded', 2);
+  function activateGuard(target = player) {
+    if (target) {
+      target.guarding = true;
+    }
   }
 
   function activateShieldBlock() {
@@ -516,6 +514,7 @@ export async function startCombat(enemy, player) {
     );
     discoverSkill(skill.id);
     const result = skill.effect({
+      caster: player,
       damageEnemy,
       healPlayer,
       activateGuard,

--- a/scripts/logic.js
+++ b/scripts/logic.js
@@ -23,6 +23,10 @@ export function calculateDamage(attacker, target, baseDamage) {
 
 export function applyDamage(target, amount) {
   let dmg = amount;
+  if (target.guarding) {
+    dmg = Math.floor(dmg / 2);
+    target.guarding = false;
+  }
   if (typeof target.damageTakenMod === 'number') {
     dmg *= target.damageTakenMod;
   }

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -54,6 +54,7 @@ export const player = {
   tempDefense: 0,
   tempAttack: 0,
   hasTemplePassive: false,
+  guarding: false,
   statuses: [],
   isPlayer: true
 };

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -59,8 +59,12 @@ const skillDefs = {
     cost: 0,
     cooldown: 0,
     source: 'starter',
-    effect({ activateGuard, log }) {
-      activateGuard();
+    effect({ caster, activateGuard, log }) {
+      if (typeof activateGuard === 'function') {
+        activateGuard(caster);
+      } else if (caster) {
+        caster.guarding = true;
+      }
       log('Player braces for impact.');
     }
   },


### PR DESCRIPTION
## Summary
- add `guarding` flag to player data
- activate the flag via `activateGuard` and update `skills.js`
- halve damage in `applyDamage` when guarding
- add unit test for guard damage reduction

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850408a06188331a018be980653526b