### PR TITLE
Add drop chance check for loot

### DIFF
--- a/scripts/combat_system.js
+++ b/scripts/combat_system.js
@@ -375,6 +375,9 @@ export async function startCombat(enemy, player) {
     if (!list.length) return;
     await loadItems();
     for (const drop of list) {
+      if (drop.chance !== undefined && Math.random() >= drop.chance) {
+        continue;
+      }
       const data = getItemData(drop.item);
       if (!data) continue;
       const success = addItemToInventory({


### PR DESCRIPTION
## Summary
- use drop chance when giving enemy loot

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504acb8944833196d1fdc5ec25b78e