### PR TITLE
Add cracked crystal skills with guard check

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -818,6 +818,8 @@
     "intro": "Fragments stir as a Cracked Crystal Sentry emerges!",
     "portrait": "💠",
     "skills": [
+      "crystal_fortify",
+      "shatter_pulse",
       "refract_crack",
       "prism_crack"
     ],

--- a/enemies/cracked_crystal_sentry.js
+++ b/enemies/cracked_crystal_sentry.js
@@ -4,7 +4,7 @@ export const cracked_crystal_sentry = {
   hp: 300,
   stats: { attack: 4, defense: 5 },
   xp: 100,
-  skills: ['refract_crack', 'prism_crack'],
+  skills: ['crystal_fortify', 'shatter_pulse', 'refract_crack', 'prism_crack'],
   behavior: 'balanced',
   description: 'A damaged sentry whose fractures shimmer with unstable energy.',
   drops: [{ item: 'prism_fragment', quantity: 1 }]

--- a/info_data/enemies.json
+++ b/info_data/enemies.json
@@ -85,7 +85,7 @@
     "map": "Map07 Maze",
     "location": "14,8",
     "drops": "Prism Fragment",
-    "skills": "refract_crack, prism_crack"
+    "skills": "crystal_fortify, shatter_pulse, refract_crack, prism_crack"
   },
   {
     "id": "pain_lattice",

--- a/scripts/combat_system.js
+++ b/scripts/combat_system.js
@@ -343,6 +343,7 @@ export async function startCombat(enemy, player) {
   function activateGuard(target = player) {
     if (target) {
       target.guarding = true;
+      target.hasGuard = true;
     }
   }
 

--- a/scripts/enemy_skills.js
+++ b/scripts/enemy_skills.js
@@ -489,6 +489,40 @@ export const enemySkills = {
       log(`${enemy.name} unleashes a prism crack for ${applied} damage!`);
     }
   },
+  crystal_fortify: {
+    id: 'crystal_fortify',
+    name: 'Crystal Fortify',
+    icon: '🛡️',
+    description: 'Permanently increases own Defense by 2.',
+    category: 'defensive',
+    cooldown: 0,
+    aiType: 'buff',
+    targetType: 'self',
+    range: 'single',
+    effect({ enemy, log }) {
+      enemy.stats.defense = (enemy.stats.defense || 0) + 2;
+      log(`${enemy.name} reinforces its crystalline shell!`);
+    }
+  },
+  shatter_pulse: {
+    id: 'shatter_pulse',
+    name: 'Shatter Pulse',
+    icon: '💎',
+    description: 'Deals 100 damage and permanently lowers Defense by 30.',
+    category: 'offensive',
+    cooldown: 10,
+    aiType: 'damage',
+    targetType: 'enemy',
+    range: 'single',
+    effect({ player, damagePlayer, log }) {
+      const baseDmg = 100;
+      const dmg = player.hasGuard ? Math.floor(baseDmg / 2) : baseDmg;
+      const applied = damagePlayer(dmg);
+      player.stats.defense = (player.stats.defense || 0) - 30;
+      log(`${player.name} is hit by a brutal pulse for ${applied} damage!`);
+      log(`${player.name}'s defense is shattered by 30!`);
+    }
+  },
   neural_lash: {
     id: 'neural_lash',
     name: 'Neural Lash',

--- a/scripts/logic.js
+++ b/scripts/logic.js
@@ -23,9 +23,10 @@ export function calculateDamage(attacker, target, baseDamage) {
 
 export function applyDamage(target, amount) {
   let dmg = amount;
-  if (target.guarding) {
+  if (target.guarding || target.hasGuard) {
     dmg = Math.floor(dmg / 2);
     target.guarding = false;
+    target.hasGuard = false;
   }
   if (typeof target.damageTakenMod === 'number') {
     dmg *= target.damageTakenMod;

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -55,6 +55,7 @@ export const player = {
   tempAttack: 0,
   hasTemplePassive: false,
   guarding: false,
+  hasGuard: false,
   statuses: [],
   isPlayer: true
 };

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -65,6 +65,7 @@ const skillDefs = {
       } else if (caster) {
         caster.guarding = true;
       }
+      if (caster) caster.hasGuard = true;
       log('Player braces for impact.');
     }
   },


### PR DESCRIPTION
## Summary
- add **Crystal Fortify** and **Shatter Pulse** enemy skills
- grant cracked_crystal_sentry these skills
- track guard status via `hasGuard` and apply it to damage logic
- include new skills in enemy data files

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68504d41eee483319fa4cf15300352a5