### PR TITLE
Remove obsolete skills from cracked crystal sentry

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -819,9 +819,7 @@
     "portrait": "💠",
     "skills": [
       "crystal_fortify",
-      "shatter_pulse",
-      "refract_crack",
-      "prism_crack"
+      "shatter_pulse"
     ],
     "behavior": "balanced",
     "drops": [

--- a/enemies/cracked_crystal_sentry.js
+++ b/enemies/cracked_crystal_sentry.js
@@ -4,7 +4,7 @@ export const cracked_crystal_sentry = {
   hp: 300,
   stats: { attack: 4, defense: 5 },
   xp: 100,
-  skills: ['crystal_fortify', 'shatter_pulse', 'refract_crack', 'prism_crack'],
+  skills: ['crystal_fortify', 'shatter_pulse'],
   behavior: 'balanced',
   description: 'A damaged sentry whose fractures shimmer with unstable energy.',
   drops: [{ item: 'prism_fragment', quantity: 1 }]

--- a/info_data/enemies.json
+++ b/info_data/enemies.json
@@ -85,7 +85,7 @@
     "map": "Map07 Maze",
     "location": "14,8",
     "drops": "Prism Fragment",
-    "skills": "crystal_fortify, shatter_pulse, refract_crack, prism_crack"
+    "skills": "crystal_fortify, shatter_pulse"
   },
   {
     "id": "pain_lattice",

--- a/scripts/combat_system.js
+++ b/scripts/combat_system.js
@@ -867,14 +867,14 @@ export async function startCombat(enemy, player) {
     const special = isElite(enemy) || isBoss(enemy);
 
     if (enemy.id === 'cracked_crystal_sentry') {
-      enemy.prismCooldown = enemy.prismCooldown || 0;
-      if (enemy.prismCooldown > 0) enemy.prismCooldown--;
+      enemy.shatterCooldown = enemy.shatterCooldown || 0;
+      if (enemy.shatterCooldown > 0) enemy.shatterCooldown--;
       const currentDef = enemy.stats?.defense || 0;
-      if (currentDef >= 30 && enemy.prismCooldown === 0) {
-        skill = getEnemySkill('prism_crack');
-        enemy.prismCooldown = skill.cooldown;
+      if (currentDef >= 30 && enemy.shatterCooldown === 0) {
+        skill = getEnemySkill('shatter_pulse');
+        enemy.shatterCooldown = skill.cooldown;
       } else {
-        skill = getEnemySkill('refract_crack');
+        skill = getEnemySkill('crystal_fortify');
       }
     } else if (enemy.id === 'crystal_sentry') {
       const currentDef = enemy.stats?.defense || 0;

--- a/scripts/enemy_skills.js
+++ b/scripts/enemy_skills.js
@@ -456,39 +456,6 @@ export const enemySkills = {
       log(`${enemy.name}'s facets harden! (+1 defense)`);
     }
   },
-  refract_crack: {
-    id: 'refract_crack',
-    name: 'Refract Crack',
-    icon: '🔷',
-    description: 'Permanently increases defense by 2.',
-    category: 'defensive',
-    cost: 0,
-    cooldown: 0,
-    aiType: 'buff',
-    targetType: 'enemy',
-    range: 'single',
-    effect({ enemy, log }) {
-      enemy.stats.defense = (enemy.stats?.defense || 0) + 2;
-      log(`${enemy.name}'s cracked shards realign! (+2 defense)`);
-    }
-  },
-  prism_crack: {
-    id: 'prism_crack',
-    name: 'Prism Crack',
-    icon: '🔶',
-    description: 'Crushing prism blast for 100 damage that lowers defense by 30.',
-    category: 'offensive',
-    cost: 0,
-    cooldown: 10,
-    aiType: 'damage',
-    targetType: 'enemy',
-    range: 'single',
-    effect({ enemy, damagePlayer, log }) {
-      const applied = damagePlayer(100);
-      enemy.stats.defense = (enemy.stats?.defense || 0) - 30;
-      log(`${enemy.name} unleashes a prism crack for ${applied} damage!`);
-    }
-  },
   crystal_fortify: {
     id: 'crystal_fortify',
     name: 'Crystal Fortify',


### PR DESCRIPTION
## Summary
- drop outdated skills from `cracked_crystal_sentry`
- remove old abilities from JSON enemy data
- clean up info entries
- update AI logic for the enemy
- delete unused `refract_crack` and `prism_crack` definitions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6850501c9dcc83318a04a2565e3f7d7a