### PR TITLE
Enable opened chest salvage

### DIFF
--- a/__tests__/opened_chest_behavior.test.js
+++ b/__tests__/opened_chest_behavior.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 import { isWalkable, isInteractable } from '../scripts/tile_type.js';
 
-it('opened chest tile behaves like a wall', () => {
+it('opened chest tile remains blocked but interactable', () => {
   expect(isWalkable('c')).toBe(false);
-  expect(isInteractable('c')).toBe(false);
+  expect(isInteractable('c')).toBe(true);
 });

--- a/data/items.json
+++ b/data/items.json
@@ -422,5 +422,13 @@
     "icon": "✨",
     "category": "key",
     "consumable": false
+  },
+  "wood": {
+    "name": "Wood",
+    "description": "Material gathered from old objects.",
+    "type": "material",
+    "stackLimit": 99,
+    "icon": "🪵",
+    "category": "crafting"
   }
 }

--- a/scripts/dialogue/chest_opened.js
+++ b/scripts/dialogue/chest_opened.js
@@ -1,0 +1,26 @@
+import { giveItem } from '../inventory.js';
+import { removeChest } from '../map.js';
+import { showDialogue } from '../dialogue_system.js';
+
+export function createOpenedChestDialogue(x, y) {
+  return [
+    {
+      text: 'Chest is already opened',
+      options: [
+        {
+          label: 'Cut',
+          condition: (state) => (state.inventory['rusty_axe'] || 0) > 0,
+          goto: null,
+          onChoose: async () => {
+            removeChest(x, y);
+            await giveItem('wood', 1);
+            showDialogue('You salvage wood from the old chest.');
+          }
+        },
+        { label: 'Leave', goto: null }
+      ]
+    }
+  ];
+}
+
+export default createOpenedChestDialogue;

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -47,3 +47,13 @@ export function handleEnemyDefeat(x, y) {
     router.drawPlayer(player, container, router.getCols());
   }
 }
+
+export function removeChest(x, y) {
+  const grid = getCurrentGrid();
+  const container = document.getElementById('game-grid');
+  if (!grid || !container) return;
+  if (!grid[y] || !grid[y][x]) return;
+  grid[y][x] = { type: 'G' };
+  renderGrid(grid, container, getCurrentEnvironment(), isFogEnabled());
+  router.drawPlayer(player, container, router.getCols());
+}

--- a/scripts/tile_definitions.js
+++ b/scripts/tile_definitions.js
@@ -9,7 +9,7 @@ export const TILE_INFO = {
     color: '#b08d57',
     shape: 'square',
     walkable: false,
-    interactable: false
+    interactable: true
   },
   D: { color: '#5a381e', shape: 'square', walkable: false, interactable: true },
   N: { color: '#9b59b6', shape: 'circle', walkable: false, interactable: true },

--- a/scripts/tile_type.js
+++ b/scripts/tile_type.js
@@ -11,7 +11,7 @@ export const TILE_DEFS = {
   C: { walkable: false, interactable: true, description: 'Chest' },
   c: {
     walkable: false,
-    interactable: false,
+    interactable: true,
     description: 'Opened Chest'
   },
   D: { walkable: false, interactable: true, description: 'Door' },
@@ -33,12 +33,13 @@ export function isInteractable(symbol) {
   return TILE_DEFS[symbol]?.interactable ?? false;
 }
 
-import { showDialogue } from './dialogue_system.js';
+import { showDialogue, startDialogueTree } from './dialogue_system.js';
 import { t } from './i18n.js';
 import { healFull, healToFull } from './player.js';
 import { applyDamage } from './logic.js';
 import { triggerDarkTrap, triggerFireTrap } from './trap_logic.js';
 import { getCurrentGrid } from './map_loader.js';
+import createOpenedChestDialogue from './dialogue/chest_opened.js';
 
 export async function onStepEffect(symbol, player, x, y) {
   const grid = getCurrentGrid();
@@ -187,8 +188,12 @@ export async function onInteractEffect(
           tile.opened = true;
         }
       } else {
-        showDialogue(t('message.chest_empty'));
+        startDialogueTree(createOpenedChestDialogue(x, y));
       }
+      break;
+    }
+    case 'c': {
+      startDialogueTree(createOpenedChestDialogue(x, y));
       break;
     }
     case 'W': {


### PR DESCRIPTION
## Summary
- make opened chest tiles interactable
- add `wood` item
- enable chest cutting via new dialogue
- add helper to remove chest tile from maps
- update tests for opened chest tiles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850551fa3988331aa007a9565106017