### PR TITLE
Fix mobile skill filter

### DIFF
--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -255,6 +255,13 @@ export function setupTabs(overlay) {
       itemContainer.classList.remove('hidden');
     }
 
+    const allButtons = overlay.querySelectorAll('.skill-btn');
+    allButtons.forEach((btn) => {
+      const cat = btn.dataset.category;
+      const show = tab !== 'items' && cat === tab;
+      btn.classList.toggle('hidden', !show);
+    });
+
     offTabBtn.classList.toggle('selected', tab === 'offensive');
     defTabBtn.classList.toggle('selected', tab === 'defensive');
     itemsTabBtn.classList.toggle('selected', tab === 'items');
@@ -309,6 +316,7 @@ export function renderSkillList(container, skills, onClick) {
     const btn = document.createElement('button');
     btn.className = 'skill-btn combat-skill-button skill-button';
     btn.dataset.id = skill.id;
+    if (skill.category) btn.dataset.category = skill.category;
     const effects = [];
     if (Array.isArray(skill.statuses)) {
       skill.statuses.forEach((s) => {

--- a/style/combat.css
+++ b/style/combat.css
@@ -688,6 +688,10 @@
     margin: 6px auto;
     text-align: center;
   }
+  /* Ensure hidden panels stay hidden on small screens */
+  #battle-overlay .tab-panel.hidden {
+    display: none !important;
+  }
 }
 
 @media screen and (orientation: landscape) and (min-aspect-ratio: 4/3) {


### PR DESCRIPTION
## Summary
- ensure hidden combat panels stay hidden when mobile layout CSS applies
- filter skill buttons by category when switching combat tabs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685089309fa083318a237f57276ae060