### PR TITLE
Fix chest cutting persistence

### DIFF
--- a/__tests__/cut_chest_persistence.test.js
+++ b/__tests__/cut_chest_persistence.test.js
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+import { jest } from '@jest/globals';
+
+let markChestAsCut,
+  setCutChests,
+  getCutChests,
+  setOpenedChests,
+  getOpenedChests,
+  saveGame,
+  loadGame;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({
+    markChestAsCut,
+    setCutChests,
+    getCutChests,
+    setOpenedChests,
+    getOpenedChests
+  } = await import('../scripts/chest.js'));
+  ({ saveGame, loadGame } = await import('../scripts/save_load.js'));
+  localStorage.clear();
+  setOpenedChests([]);
+  setCutChests([]);
+});
+
+test('cut chests remain removed after saving and loading', () => {
+  const chestId = 'map01:10,5';
+  markChestAsCut(chestId);
+  expect(getCutChests()).toContain(chestId);
+
+  saveGame(1);
+
+  setCutChests([]);
+  setOpenedChests([]);
+  expect(getCutChests()).not.toContain(chestId);
+
+  const loaded = loadGame(1);
+  expect(loaded).toBe(true);
+  expect(getCutChests()).toContain(chestId);
+  expect(getOpenedChests()).not.toContain(chestId);
+});

--- a/data/items.json
+++ b/data/items.json
@@ -433,10 +433,10 @@
   },
   "wood": {
     "name": "Wood",
-    "description": "Material gathered from old objects.",
+    "description": "A sturdy piece of lumber, could be useful.",
+    "icon": "🪵",
     "type": "material",
     "stackLimit": 99,
-    "icon": "🪵",
-    "category": "crafting"
+    "category": "general"
   }
 }

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -1,4 +1,4 @@
-import { gameState } from './game_state.js';
+import { gameState, saveState } from './game_state.js';
 import { addItem, giveItem } from './inventory.js';
 import { updateInventoryUI } from './inventory_ui.js';
 import { giveRelic, setMemory } from './dialogue_state.js';
@@ -215,4 +215,21 @@ export function setOpenedChests(list) {
 
 export function getOpenedChests() {
   return Array.from(gameState.openedChests);
+}
+
+export function markChestAsCut(id) {
+  if (!id) return;
+  gameState.cutChests.add(id);
+  if (gameState.openedChests.has(id)) {
+    gameState.openedChests.delete(id);
+  }
+  saveState();
+}
+
+export function setCutChests(list) {
+  gameState.cutChests = new Set(list || []);
+}
+
+export function getCutChests() {
+  return Array.from(gameState.cutChests);
 }

--- a/scripts/dialogue/chest_opened.js
+++ b/scripts/dialogue/chest_opened.js
@@ -1,6 +1,8 @@
 import { giveItem } from '../inventory.js';
 import { removeChest } from '../map.js';
 import { showDialogue } from '../dialogue_system.js';
+import { markChestAsCut } from '../chest.js';
+import { getCurrentMapName } from '../router.js';
 
 export function createOpenedChestDialogue(x, y) {
   return [
@@ -14,6 +16,7 @@ export function createOpenedChestDialogue(x, y) {
           onChoose: async () => {
             removeChest(x, y);
             await giveItem('wood', 1);
+            markChestAsCut(`${getCurrentMapName()}:${x},${y}`);
             showDialogue('You salvage wood from the old chest.');
           }
         },

--- a/scripts/game_state.js
+++ b/scripts/game_state.js
@@ -5,6 +5,7 @@ import { logMessage } from './message_log.js';
 export const gameState = {
   currentMap: '',
   openedChests: new Set(),
+  cutChests: new Set(),
   defeatedEnemies: new Set(),
   environment: 'clear',
   isDead: false,
@@ -17,6 +18,7 @@ export function serializeGameState() {
   return {
     currentMap: gameState.currentMap,
     openedChests: Array.from(gameState.openedChests),
+    cutChests: Array.from(gameState.cutChests),
     defeatedEnemies: Array.from(gameState.defeatedEnemies),
     settings: gameState.settings
   };
@@ -26,6 +28,7 @@ export function deserializeGameState(data) {
   if (!data) return;
   gameState.currentMap = data.currentMap || '';
   gameState.openedChests = new Set(data.openedChests || []);
+  gameState.cutChests = new Set(data.cutChests || []);
   gameState.defeatedEnemies = new Set(data.defeatedEnemies || []);
   gameState.settings = data.settings || {};
 }

--- a/scripts/items/items.json
+++ b/scripts/items/items.json
@@ -14,5 +14,13 @@
     "description": "An old but functional axe. It can break apart worn-down objects.",
     "type": "key",
     "key": true
+  },
+  "wood": {
+    "name": "Wood",
+    "description": "A sturdy piece of lumber, could be useful.",
+    "icon": "🪵",
+    "type": "material",
+    "stackLimit": 99,
+    "category": "general"
   }
 }

--- a/scripts/map_loader.js
+++ b/scripts/map_loader.js
@@ -98,6 +98,16 @@ export async function loadMap(name) {
         }
       }
     }
+
+    for (let y = 0; y < data.grid.length; y++) {
+      for (let x = 0; x < data.grid[y].length; x++) {
+        const cell = data.grid[y][x];
+        if (!cell) continue;
+        if ((cell.type === 'C' || cell.type === 'c') && gameState.cutChests.has(`${name}:${x},${y}`)) {
+          data.grid[y][x] = { type: 'G' };
+        }
+      }
+    }
   } catch (err) {
     console.error(err);
     throw err;


### PR DESCRIPTION
## Summary
- add wood item metadata
- track cut chests in save data
- persist cut chests when using the Cut option
- filter out cut chests when loading maps
- test cut chest persistence

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a1208c5c8331b31f82fe2cfae689