### PR TITLE
Add phone coordinates setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,9 @@
           <input type="checkbox" id="coords-toggle" /> Grid Coordinates
         </label>
         <label class="setting-row">
+          <input type="checkbox" id="coords-phone-toggle" /> Coordinates (phone)
+        </label>
+        <label class="setting-row">
           Movement Speed
           <select id="move-speed">
             <option value="slow">Slow</option>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -104,6 +104,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const settingsOverlay = document.getElementById('settings-overlay');
   const settingsClose = settingsOverlay.querySelector('.close-btn');
   const coordsToggle = document.getElementById('coords-toggle');
+  const phoneCoordsToggle = document.getElementById('coords-phone-toggle');
   const moveSelect = document.getElementById('move-speed');
   const combatSelect = document.getElementById('combat-speed');
   const colorblindToggle = document.getElementById('colorblind-toggle');
@@ -183,6 +184,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   settings = loadSettings();
   applySettings(settings);
   coordsToggle.checked = settings.gridCoordinates;
+  phoneCoordsToggle.checked = settings.phoneCoordinates;
   moveSelect.value = settings.movementSpeed;
   combatSelect.value = settings.combatSpeed;
   colorblindToggle.checked = settings.colorblind;
@@ -266,6 +268,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     saveSettings(settings);
   });
 
+  phoneCoordsToggle.addEventListener('change', () => {
+    settings.phoneCoordinates = phoneCoordsToggle.checked;
+    applySettings(settings);
+    saveSettings(settings);
+  });
+
   moveSelect.addEventListener('change', () => {
     settings.movementSpeed = moveSelect.value;
     saveSettings(settings);
@@ -310,6 +318,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       saveSettings(settings);
       applySettings(settings);
       coordsToggle.checked = settings.gridCoordinates;
+      phoneCoordsToggle.checked = settings.phoneCoordinates;
       moveSelect.value = settings.movementSpeed;
       combatSelect.value = settings.combatSpeed;
       colorblindToggle.checked = settings.colorblind;

--- a/scripts/settingsManager.js
+++ b/scripts/settingsManager.js
@@ -32,6 +32,11 @@ export function applySettings(settings) {
   } else {
     grid.classList.remove('show-labels');
   }
+  if (settings.phoneCoordinates) {
+    grid.classList.add('show-coords');
+  } else {
+    grid.classList.remove('show-coords');
+  }
 
   const tiles = grid.querySelectorAll('.tile');
   tiles.forEach((t) => {
@@ -41,6 +46,11 @@ export function applySettings(settings) {
       t.title = `(${x},${y})`;
     } else {
       t.removeAttribute('title');
+    }
+    if (settings.phoneCoordinates) {
+      t.dataset.coords = `(${x},${y})`;
+    } else {
+      delete t.dataset.coords;
     }
   });
 }

--- a/settings_data.js
+++ b/settings_data.js
@@ -3,6 +3,10 @@ export default {
     default: false,
     description: 'Show (x, y) when hovering over a tile'
   },
+  phoneCoordinates: {
+    default: false,
+    description: 'Show (x, y) on each tile'
+  },
   movementSpeed: {
     default: 'normal',
     description: 'Player tile transition speed'

--- a/style/layout.css
+++ b/style/layout.css
@@ -1148,6 +1148,19 @@ body {
   text-align: center;
 }
 
+#game-grid.show-coords .tile::before {
+  content: attr(data-coords);
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 10px;
+  line-height: 12px;
+  text-align: center;
+}
+
 #game-grid.colorblind .trap-light {
   background-color: #dca;
 }


### PR DESCRIPTION
## Summary
- add "Coordinates (phone)" toggle to settings UI
- show coordinates on each tile when enabled for touch devices
- support new setting in manager, main logic, and styles

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for @eslint/js)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b6d457e6f88331883a820dcc622f60