### PR TITLE
fix: guard rollback row in main

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -120,7 +120,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (
     typeof process !== 'undefined' &&
     process.env &&
-    process.env.NODE_ENV !== 'development'
+    process.env.NODE_ENV !== 'development' &&
+    rollbackRow
   ) {
     rollbackRow.style.display = 'none';
   }


### PR DESCRIPTION
## Summary
- prevent crash when rollback row is missing by checking element before accessing style

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b81e72c6c48331a9f1ef68c26e6374