### PR TITLE
feat: add optional zoom controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - Quests with an in game log
 - Player stats and leveling
 - Completely client side so it works with GitHub Pages
+- Optional zoom controls for the game grid
 
 ## Running locally
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
   </head>
   <body>
     <div id="game-grid"></div>
+    <div id="zoom-controls" class="zoom-controls">
+      <button id="zoom-in">+</button>
+      <button id="zoom-out">-</button>
+    </div>
     <div id="menu-bar">
       <div class="tab settings-tab">Settings</div>
       <div class="tab menu-tab">Menu</div>
@@ -152,6 +156,9 @@
         </label>
         <label class="setting-row">
           <input type="checkbox" id="dialogue-toggle" /> Dialogue Animation
+        </label>
+        <label class="setting-row">
+          <input type="checkbox" id="zoom-toggle" /> Zoom Controls
         </label>
         <label class="setting-row">
           Language

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -56,6 +56,7 @@ import { loadLanguage } from './language_loader.js';
 import { initGreeting } from '../ui/greeting.js';
 import { startGame } from './startGame.js';
 import { rollbackTo } from './rollback.js';
+import { initZoom, setZoomEnabled } from './zoom.js';
 
 // Inventory contents are managed in inventory.js
 
@@ -65,6 +66,7 @@ const gridState = { cols: 0 };
 
 document.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('game-grid');
+  initZoom(container);
   // Prevent double-tap zoom on mobile devices
   document.addEventListener(
     'touchstart',
@@ -110,6 +112,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const colorblindToggle = document.getElementById('colorblind-toggle');
   const labelToggle = document.getElementById('label-toggle');
   const dialogueToggle = document.getElementById('dialogue-toggle');
+  const zoomToggle = document.getElementById('zoom-toggle');
   const langSelect = document.getElementById('language-select');
   const centerToggle = document.getElementById('center-toggle');
   const resetBtn = document.getElementById('reset-settings');
@@ -191,9 +194,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   colorblindToggle.checked = settings.colorblind;
   labelToggle.checked = settings.tileLabels;
   dialogueToggle.checked = settings.dialogueAnim;
+  zoomToggle.checked = settings.zoom;
   langSelect.value = settings.language;
   centerToggle.checked = settings.centerMode;
   loadLanguage(settings.language);
+  setZoomEnabled(settings.zoom);
 
   router.init(container, player);
   initMobileCenter(container);
@@ -302,6 +307,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     saveSettings(settings);
   });
 
+  zoomToggle.addEventListener('change', () => {
+    settings.zoom = zoomToggle.checked;
+    setZoomEnabled(settings.zoom);
+    saveSettings(settings);
+  });
+
   langSelect.addEventListener('change', () => {
     settings.language = langSelect.value;
     saveSettings(settings);
@@ -325,9 +336,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       colorblindToggle.checked = settings.colorblind;
       labelToggle.checked = settings.tileLabels;
       dialogueToggle.checked = settings.dialogueAnim;
+      zoomToggle.checked = settings.zoom;
       langSelect.value = settings.language;
       centerToggle.checked = settings.centerMode;
       loadLanguage(settings.language);
+      setZoomEnabled(settings.zoom);
     }
   });
 

--- a/scripts/zoom.js
+++ b/scripts/zoom.js
@@ -1,0 +1,33 @@
+let level = 1;
+const classes = ['scale-small', 'scale-medium', 'scale-large'];
+let grid;
+
+function apply() {
+  if (!grid) return;
+  grid.classList.remove(...classes);
+  grid.classList.add(classes[level]);
+}
+
+function change(delta) {
+  level = Math.min(2, Math.max(0, level + delta));
+  apply();
+}
+
+export function initZoom(container) {
+  grid = container;
+  apply();
+  const zoomIn = document.getElementById('zoom-in');
+  const zoomOut = document.getElementById('zoom-out');
+  zoomIn?.addEventListener('click', () => change(1));
+  zoomOut?.addEventListener('click', () => change(-1));
+}
+
+export function setZoomEnabled(enabled) {
+  const controls = document.getElementById('zoom-controls');
+  if (!controls) return;
+  controls.style.display = enabled ? 'flex' : 'none';
+  if (!enabled) {
+    level = 1;
+    apply();
+  }
+}

--- a/settings_data.js
+++ b/settings_data.js
@@ -27,6 +27,10 @@ export default {
     default: true,
     description: 'Type out dialogue text'
   },
+  zoom: {
+    default: true,
+    description: 'Enable zoom controls'
+  },
   language: {
     default: 'en',
     description: 'UI language code'

--- a/style/layout.css
+++ b/style/layout.css
@@ -85,6 +85,21 @@ body {
   animation: none !important;
 }
 
+#zoom-controls {
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+  z-index: 1000;
+}
+
+#zoom-controls button {
+  width: 32px;
+  height: 32px;
+}
+
 .tile {
   width: 32px;
   height: 32px;


### PR DESCRIPTION
## Summary
- add settings toggle for zoom controls
- implement zoom in/out buttons and scaling classes
- document optional grid zoom feature

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c060723eac83319b3dd5624d96543b