### PR TITLE
Add Blaze Hound enemy

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -1,1 +1,8 @@
-{}
+{
+  "blaze_hound": {
+    "name": "Blaze Hound",
+    "hp": 40,
+    "xp": 10,
+    "skills": ["blaze_scratch", "blaze_bite"]
+  }
+}

--- a/data/maps/map001.json
+++ b/data/maps/map001.json
@@ -175,7 +175,10 @@
       "G",
       "G",
       "G",
-      "G",
+      {
+        "type": "E",
+        "enemyId": "blaze_hound"
+      },
       "G",
       "G",
       "G",

--- a/scripts/enemy_skills.js
+++ b/scripts/enemy_skills.js
@@ -985,6 +985,43 @@ export const enemySkills = {
       log(`${enemy.name} stomps the ground for ${applied} damage!`);
     }
   },
+  blaze_scratch: {
+    id: 'blaze_scratch',
+    name: 'Blaze Scratch',
+    icon: '🔥',
+    description: 'A fiery swipe dealing 5 damage.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 0,
+    aiType: 'damage',
+    effect({ enemy, damagePlayer, log }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = 5 + atk + (enemy.tempAttack || 0);
+      const applied = damagePlayer(dmg);
+      log(`${enemy.name} scorches you with a scratch for ${applied} damage!`);
+    }
+  },
+  blaze_bite: {
+    id: 'blaze_bite',
+    name: 'Blaze Bite',
+    icon: '🔥',
+    description:
+      'Bite for 5 fire damage with a 50% chance to absorb the damage dealt.',
+    category: 'offensive',
+    cost: 0,
+    cooldown: 0,
+    aiType: 'damage',
+    effect({ enemy, damagePlayer, log }) {
+      const atk = enemy.stats?.attack || 0;
+      const dmg = 5 + atk + (enemy.tempAttack || 0);
+      const applied = damagePlayer(dmg);
+      log(`${enemy.name} bites for ${applied} fire damage!`);
+      if (Math.random() < 0.5) {
+        enemy.hp = Math.min(enemy.maxHp || Infinity, enemy.hp + applied);
+        log(`${enemy.name} absorbs the flames and heals for ${applied}!`);
+      }
+    }
+  },
 };
 
 export function getEnemySkill(id) {


### PR DESCRIPTION
## Summary
- add Blaze Hound enemy data and skills
- spawn Blaze Hound on map001 at (5,3)

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c074974e9c8331915f9325920c111f