### PR TITLE
Add elemental combat system and name Zealer

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -1,6 +1,7 @@
 {
   "blaze_hound": {
     "name": "Blaze Hound",
+    "element": "fire",
     "hp": 40,
     "xp": 10,
     "skills": ["blaze_scratch", "blaze_bite"]

--- a/scripts/elements.js
+++ b/scripts/elements.js
@@ -1,0 +1,17 @@
+const advantages = {
+  fire: 'earth',
+  water: 'fire',
+  earth: 'water'
+};
+
+export function getElementMultiplier(attacker, defender) {
+  if (!attacker || !defender) return 1;
+  if (advantages[attacker] === defender) return 2;
+  if (advantages[defender] === attacker) return 0.5;
+  return 1;
+}
+
+export function formatElement(element) {
+  if (!element) return '';
+  return element.charAt(0).toUpperCase() + element.slice(1);
+}

--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -293,7 +293,7 @@ function handleInventoryItemUse(id) {
   }
   if (used) {
     markItemUsed(id);
-    logMessage(`Player used ${data.name}!`);
+    logMessage(`Zealer used ${data.name}!`);
     updateInventoryUI();
   }
 }

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -34,6 +34,7 @@ export const player = {
   maxHp: 100,
   atk: 15,
   def: 0,
+  element: 'fire',
   level: 1,
   xp: 0,
   xpToNextLevel: 10,
@@ -237,6 +238,7 @@ export function serializePlayer() {
   return {
     x: player.x,
     y: player.y,
+    element: player.element,
     level: player.level,
     xp: player.xp,
     xpToNextLevel: player.xpToNextLevel,
@@ -255,6 +257,7 @@ export function deserializePlayer(data) {
   if (!data) return;
   player.x = data.x ?? player.x;
   player.y = data.y ?? player.y;
+  player.element = data.element ?? player.element;
   player.level = data.level ?? player.level;
   player.xp = data.xp ?? player.xp;
   player.xpToNextLevel = data.xpToNextLevel ?? player.xpToNextLevel;

--- a/scripts/skills.js
+++ b/scripts/skills.js
@@ -14,7 +14,7 @@ const skillDefs = {
     // Basic attack scaled by player ATK
     effect({ damageEnemy, log }) {
       const dealt = damageEnemy(0);
-      log(`Player strikes for ${dealt} damage!`);
+      log(`Zealer strikes for ${dealt} damage!`);
     }
   },
   guard: {
@@ -29,7 +29,7 @@ const skillDefs = {
     source: 'starter',
     effect({ activateGuard, log }) {
       activateGuard();
-      log('Player braces for impact.');
+      log('Zealer braces for impact.');
     }
   },
   heal: {
@@ -44,7 +44,7 @@ const skillDefs = {
     effect({ healPlayer, player, log }) {
       const amount = Math.floor(player.maxHp * 0.2);
       healPlayer(amount);
-      log(`Player heals for ${amount} HP.`);
+      log(`Zealer heals for ${amount} HP.`);
     }
   },
   shieldWall: {


### PR DESCRIPTION
## Summary
- Introduce Fire/Water/Earth elements with advantage multipliers
- Display elements and rename the player to Zealer in combat UI and logs
- Tag Blaze Hound and Zealer as Fire element

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c08020b72c8331926b60c544ce3546