### PR TITLE
Replace XP system with stone-based leveling

### DIFF
--- a/data/enemies.json
+++ b/data/enemies.json
@@ -3,7 +3,9 @@
     "name": "Blaze Hound",
     "element": "fire",
     "hp": 40,
-    "xp": 10,
-    "skills": ["blaze_scratch", "blaze_bite"]
+    "skills": ["blaze_scratch", "blaze_bite"],
+    "drops": [
+      { "item": "small_fire_stone", "quantity": 1, "chance": 0.4 }
+    ]
   }
 }

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
           <button data-cat="items" class="tab selected">Items</button>
           <button data-cat="equipable" class="tab">Equipable Items</button>
           <button data-cat="combat" class="tab">Combat Items</button>
+          <button data-cat="usable" class="tab">Usable Items</button>
           <button data-cat="key" class="tab">Key Items</button>
           <button data-cat="lore" class="tab">Lore Items</button>
         </div>
@@ -211,7 +212,7 @@
           <p><strong>Movement:</strong> Tap or click a ground tile to move. (Ground tiles are light green squares.)</p>
           <p><strong>Interaction:</strong> Double tap or double click a tile to interact.</p>
           <p><strong>NPC (Purple Circle):</strong> Talk to NPCs by interacting. They may give quests, items, or secrets.</p>
-          <p><strong>Enemy (Red Tile):</strong> Interact to enter combat. Defeating enemies grants XP and drops.</p>
+          <p><strong>Enemy (Red Tile):</strong> Interact to enter combat. Defeating enemies may drop stones and loot.</p>
           <p><strong>Water (Blue Tile):</strong> Interacting heals you to full health. Use wisely!</p>
           <p><strong>Stove (Black Tile with red dot):</strong> Cook a random meal to restore full health.</p>
           <p><strong>Chest (Brown Tile):</strong> Open to receive a reward. Some may be locked.</p>

--- a/scripts/chest.js
+++ b/scripts/chest.js
@@ -20,8 +20,8 @@ const chestContents = {
     message: 'You pick up an old coin.'
   },
   'map02:5,5': {
-    item: 'xp_scroll',
-    message: 'You found a shimmering scroll.',
+    item: 'small_fire_stone',
+    message: 'You find a warm fire stone.',
     memoryFlag: 'map02_health_amulet'
   },
   'map02:9,9': {
@@ -35,8 +35,8 @@ const chestContents = {
     memoryFlag: 'empty_chest_seen'
   },
   'map03:10,12': {
-    item: 'xp_scroll',
-    message: 'You feel knowledge flow into you.'
+    item: 'small_fire_stone',
+    message: 'You pick up a small fire stone.'
   },
   'map04:10,11': {
     item: 'mana_gem',
@@ -144,19 +144,19 @@ const chestContents = {
     message: 'Inside rests a sealed scroll etched in ember.'
   },
   'map09_floor03:4,3': {
-    item: 'xp_scroll',
+    item: 'small_fire_stone',
     hpLoss: 10,
-    message: 'A guardian trap drains your strength as you snatch the scroll.'
+    message: 'A guardian trap drains your strength as you snatch the stone.'
   },
   'map09_floor03:9,5': {
-    item: 'xp_potion',
+    item: 'small_fire_stone',
     hpLoss: 10,
-    message: 'Ancient energies lash out as you secure the potion.'
+    message: 'Ancient energies lash out as you secure the stone.'
   },
   'map09_floor03:15,8': {
-    item: 'xp_relic',
+    item: 'small_fire_stone',
     hpLoss: 10,
-    message: 'Cursed fumes seep out as you grasp the relic.'
+    message: 'Cursed fumes seep out as you grasp the stone.'
   }
 };
 

--- a/scripts/combatSystem.js
+++ b/scripts/combatSystem.js
@@ -1,6 +1,6 @@
 import { getSkill } from './skills.js';
 import { getEnemySkill } from './enemy_skills.js';
-import { respawn, gainXP, getTotalStats } from './player.js';
+import { respawn, getTotalStats } from './player.js';
 import { getClassBonuses } from './class_state.js';
 import { getPassive } from './passive_skills.js';
 import { applyDamage } from './logic.js';
@@ -39,9 +39,7 @@ import {
   renderSkillList,
   setSkillDisabledState,
   initLogPanel,
-  showVictoryMessage,
-  showXpGain,
-  showLevelUp
+  showVictoryMessage
 } from './combat_ui.js';
 import {
   initStatuses,
@@ -349,13 +347,6 @@ export async function startCombat(enemy, player) {
         showDialogue(`You obtained ${data.name}!`);
       } else {
         showDialogue('Inventory full for this item');
-      }
-    }
-    if (typeof enemy.xp === 'number') {
-      const leveled = gainXP(enemy.xp);
-      showXpGain(enemy.xp);
-      if (leveled) {
-        showLevelUp(player.level);
       }
     }
   }

--- a/scripts/combat_ui.js
+++ b/scripts/combat_ui.js
@@ -163,10 +163,6 @@ export function showVictoryMessage() {
   appendLog('Victory!');
 }
 
-export function showXpGain(amount) {
-  appendLog(`Gained ${amount} XP`);
-}
-
 export function showLevelUp(level) {
   appendLog(`Level Up! Now level ${level}`);
 }

--- a/scripts/inventory_ui.js
+++ b/scripts/inventory_ui.js
@@ -7,7 +7,7 @@ import {
   getItemsByCategory,
   consumeItem
 } from './inventory.js';
-import { player, getTotalStats, gainXP } from './player.js';
+import { player, getTotalStats } from './player.js';
 import {
   useHealthPotion,
   useDefensePotion,
@@ -82,7 +82,7 @@ export async function updateInventoryUI() {
       def < 0
         ? `<span class="negative" title="${tooltip}">Defense: ${def}</span>`
         : `<span title="${tooltip}">Defense: ${def}</span>`;
-    statsEl.innerHTML = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}  Attack: ${stats.attack || 0}  ${defHtml}`;
+    statsEl.innerHTML = `Level: ${player.level}  Attack: ${stats.attack || 0}  ${defHtml}`;
   }
   let cat = currentCategory;
   if (cat === 'items') cat = ['general', 'crafting'];
@@ -147,7 +147,7 @@ export async function updateInventoryUI() {
     }
 
     const baseData = getItemData(item.id);
-    if (baseData && baseData.category === 'combat') {
+    if (baseData && (baseData.category === 'combat' || baseData.category === 'usable')) {
       const ubtn = document.createElement('button');
       ubtn.classList.add('equip-btn');
       ubtn.textContent = 'Use';
@@ -313,6 +313,5 @@ export function toggleInventoryView() {
 document.addEventListener('inventoryUpdated', updateInventoryUI);
 document.addEventListener('playerDefenseChanged', updateInventoryUI);
 document.addEventListener('playerHpChanged', updateInventoryUI);
-document.addEventListener('playerXpChanged', updateInventoryUI);
 document.addEventListener('playerLevelUp', updateInventoryUI);
 document.addEventListener('relicsUpdated', updateInventoryUI);

--- a/scripts/item_data.js
+++ b/scripts/item_data.js
@@ -44,48 +44,19 @@ export const itemData = {
     icon: '🧪',
     useInCombat: true
   },
-  xp_scroll: {
-    id: 'xp_scroll',
-    name: 'XP Scroll',
-    description: 'Use to gain 25 experience.',
+  small_fire_stone: {
+    id: 'small_fire_stone',
+    name: 'Small Fire Stone',
+    description: 'A faintly warm stone that Zealer can use to level up.',
     type: 'consumable',
     tags: ['items'],
-    category: 'general',
+    category: 'usable',
     consumable: true,
     stackLimit: 99,
-    icon: '📜',
-    use() {
-      import('./player.js').then((m) => m.gainXP(25));
-    }
-  },
-  xp_potion: {
-    id: 'xp_potion',
-    name: 'XP Potion',
-    description: 'Use in battle to gain 50 XP.',
-    type: 'consumable',
-    tags: ['combat'],
-    category: 'combat',
-    consumable: true,
-    stackLimit: 5,
-    icon: '🧪',
-    useInCombat: true,
-    use() {
-      import('./player.js').then((m) => m.gainXP(50));
-    }
-  },
-  xp_relic: {
-    id: 'xp_relic',
-    name: 'XP Relic',
-    description: 'Grants 100 XP when used from your pack.',
-    type: 'consumable',
-    tags: ['items'],
-    category: 'general',
-    consumable: true,
-    stackLimit: 1,
-    icon: '🔮',
+    icon: '🔥',
     inventoryOnly: true,
     use() {
-      import('./player.js').then((m) => m.gainXP(100));
+      import('./player.js').then((m) => m.levelUp());
     }
   },
   empty_note: {

--- a/scripts/loot_table.js
+++ b/scripts/loot_table.js
@@ -6,7 +6,12 @@ export async function getEnemyDrops(id) {
   if (!table) table = await loadEnemyData();
   const data = table[id];
   if (!data) return [];
-  if (Array.isArray(data.drops)) return data.drops;
-  if (data.drop) return [data.drop];
-  return [];
+  const results = [];
+  const roll = (d) => {
+    const chance = typeof d.chance === 'number' ? d.chance : 1;
+    if (Math.random() < chance) results.push(d);
+  };
+  if (Array.isArray(data.drops)) data.drops.forEach(roll);
+  else if (data.drop) roll(data.drop);
+  return results;
 }

--- a/scripts/menu/status.js
+++ b/scripts/menu/status.js
@@ -64,7 +64,7 @@ export function updateStatusPanel() {
     row.addEventListener('mouseleave', hideItemTooltip);
     equipList.appendChild(row);
   }
-  info.textContent = `Level: ${player.level}  XP: ${player.xp}/${player.xpToNextLevel}`;
+  info.textContent = `Level: ${player.level}`;
   (player.passives || []).forEach(id => {
     const p = defs[id];
     if (!p) return;
@@ -91,7 +91,6 @@ export function toggleStatusPanel() {
 
 document.addEventListener('passivesUpdated', updateStatusPanel);
 document.addEventListener('playerHpChanged', updateStatusPanel);
-document.addEventListener('playerXpChanged', updateStatusPanel);
 document.addEventListener('playerLevelUp', updateStatusPanel);
 document.addEventListener('equipmentChanged', updateStatusPanel);
 document.addEventListener('equipmentCrafted', updateStatusPanel);

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -36,8 +36,6 @@ export const player = {
   def: 0,
   element: 'fire',
   level: 1,
-  xp: 0,
-  xpToNextLevel: 10,
   classId: getChosenClass() || null,
   stats: {
     attack: 0,
@@ -176,7 +174,6 @@ export function resetTempStats() {
 
 export function levelUp() {
   player.level += 1;
-  player.xpToNextLevel = Math.floor(player.xpToNextLevel * 1.5);
   updateStatsFromLevel();
   player.hp = player.maxHp;
   const unlocked = unlockPassivesForLevel(player.level);
@@ -190,45 +187,11 @@ export function levelUp() {
   document.dispatchEvent(
     new CustomEvent('playerLevelUp', { detail: { level: player.level } })
   );
-  document.dispatchEvent(
-    new CustomEvent('playerXpChanged', {
-      detail: {
-        xp: player.xp,
-        level: player.level,
-        xpToNext: player.xpToNextLevel
-      }
-    })
-  );
-}
-
-export function gainXP(amount) {
-  if (typeof amount !== 'number' || amount <= 0) return false;
-  player.xp += amount;
-  let leveled = false;
-  while (player.xp >= player.xpToNextLevel) {
-    player.xp -= player.xpToNextLevel;
-    levelUp();
-    leveled = true;
-  }
-  if (!leveled) {
-    document.dispatchEvent(
-      new CustomEvent('playerXpChanged', {
-        detail: {
-          xp: player.xp,
-          level: player.level,
-          xpToNext: player.xpToNextLevel
-        }
-      })
-    );
-  }
-  return leveled;
 }
 
 export function getPlayerSummary() {
   return {
     level: player.level,
-    xp: player.xp,
-    xpToNextLevel: player.xpToNextLevel,
     classId: player.classId,
     passives: Array.isArray(player.passives) ? [...player.passives] : []
   };
@@ -240,8 +203,6 @@ export function serializePlayer() {
     y: player.y,
     element: player.element,
     level: player.level,
-    xp: player.xp,
-    xpToNextLevel: player.xpToNextLevel,
     stats: {
       attack: player.stats?.attack || 0,
       defense: player.stats?.defense || 0
@@ -259,8 +220,6 @@ export function deserializePlayer(data) {
   player.y = data.y ?? player.y;
   player.element = data.element ?? player.element;
   player.level = data.level ?? player.level;
-  player.xp = data.xp ?? player.xp;
-  player.xpToNextLevel = data.xpToNextLevel ?? player.xpToNextLevel;
   if (data.stats) {
     if (!player.stats) player.stats = { attack: 0, defense: 0 };
     player.stats.attack = data.stats.attack ?? player.stats.attack;

--- a/scripts/startGame.js
+++ b/scripts/startGame.js
@@ -108,7 +108,6 @@ export async function startGame(container, settings, state) {
     });
     document.addEventListener('playerDefenseChanged', updateDefenseDisplay);
     document.addEventListener('playerHpChanged', updateHpDisplay);
-    document.addEventListener('playerXpChanged', updateXpDisplay);
     document.addEventListener('playerLevelUp', updateXpDisplay);
     document.addEventListener('passivesUpdated', () => {
       updateHpDisplay();

--- a/scripts/ui/playerDisplay.js
+++ b/scripts/ui/playerDisplay.js
@@ -4,12 +4,12 @@ import { getRelicBonuses } from '../relic_state.js';
 
 let hpDisplay;
 let defenseDisplay;
-let xpDisplay;
+let levelDisplay;
 
 export function initPlayerDisplay() {
   hpDisplay = document.getElementById('hp-display');
   defenseDisplay = document.getElementById('defense-display');
-  xpDisplay = document.getElementById('xp-display');
+  levelDisplay = document.getElementById('xp-display');
 }
 
 export function updateHpDisplay() {
@@ -32,7 +32,7 @@ export function updateDefenseDisplay() {
 }
 
 export function updateXpDisplay() {
-  if (xpDisplay) {
-    xpDisplay.textContent = `Level: ${player.level} XP: ${player.xp}/${player.xpToNextLevel}`;
+  if (levelDisplay) {
+    levelDisplay.textContent = `Level: ${player.level}`;
   }
 }

--- a/ui/main_menu.js
+++ b/ui/main_menu.js
@@ -18,7 +18,6 @@ export function updateMenuStats() {
     : `<span title="${tooltip}">${def}</span>`;
   el.innerHTML = `
     <div>Level: ${player.level}</div>
-    <div>XP: ${player.xp} / ${player.xpToNextLevel}</div>
     <div>HP: ${player.hp} / ${player.maxHp}</div>
     <div>ATK: ${stats.attack || 0}</div>
     <div>DEF: ${defHtml}</div>
@@ -93,7 +92,6 @@ export function initMainMenu() {
 
   document.addEventListener('inventoryUpdated', updateNullButton);
   document.addEventListener('playerHpChanged', updateMenuStats);
-  document.addEventListener('playerXpChanged', updateMenuStats);
   document.addEventListener('playerLevelUp', updateMenuStats);
   document.addEventListener('equipmentChanged', updateMenuStats);
 }


### PR DESCRIPTION
## Summary
- Remove XP fields and gain mechanics in favor of stone-based leveling
- Add Small Fire Stone usable item and new inventory category for usable items
- Let Blaze Hound drop Small Fire Stone with 40% chance and support probabilistic enemy drops

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: @eslint/js package missing, install attempt 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c087c203a083319b989cbaa61cf9b3