### PR TITLE
Add elemental NPC colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
         <div class="howto-scroll">
           <p><strong>Movement:</strong> Tap or click a ground tile to move. (Ground tiles are light green squares.)</p>
           <p><strong>Interaction:</strong> Double tap or double click a tile to interact.</p>
-          <p><strong>NPC (Purple Circle):</strong> Talk to NPCs by interacting. They may give quests, items, or secrets.</p>
+          <p><strong>NPCs:</strong> Red circles mark fire NPCs, blue circles mark water NPCs, and green circles mark earth NPCs. Interact with any of them to start a dialogue.</p>
           <p><strong>Enemy (Red Tile):</strong> Interact to enter combat. Defeating enemies may drop stones and loot.</p>
           <p><strong>Water (Blue Tile):</strong> Interacting heals you to full health. Use wisely!</p>
           <p><strong>Stove (Black Tile with red dot):</strong> Cook a random meal to restore full health.</p>

--- a/scripts/grid.js
+++ b/scripts/grid.js
@@ -42,6 +42,7 @@ export function renderGrid(
           break;
         case 'N':
           div.classList.add('npc', 'blocked');
+          if (cell.element) div.classList.add(cell.element);
           if (cell.npc) div.dataset.npc = cell.npc;
           break;
         case 'echo':

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -2,6 +2,7 @@ import * as router from './router.js';
 import { renderGrid } from './grid.js';
 import { player } from './player.js';
 import { getCurrentGrid, getCurrentEnvironment, isFogEnabled } from './mapLoader.js';
+import { npcElements } from './npc_data.js';
 
 /**
  * Move the player to a given map and coordinates.
@@ -15,12 +16,12 @@ export async function movePlayerTo(mapId, coords) {
   return cols;
 }
 
-export function spawnNpc(x, y, id) {
+export function spawnNpc(x, y, id, element = npcElements[id]) {
   const grid = getCurrentGrid();
   const container = document.getElementById('game-grid');
   if (!grid || !container) return;
   if (!grid[y] || !grid[y][x]) return;
-  grid[y][x] = { type: 'N', npc: id };
+  grid[y][x] = { type: 'N', npc: id, element };
   renderGrid(grid, container, getCurrentEnvironment(), isFogEnabled());
   router.drawPlayer(player, container, router.getCols());
 }

--- a/scripts/npc_data.js
+++ b/scripts/npc_data.js
@@ -78,6 +78,12 @@ export const npcAppearance = {
   }
 };
 
+export const npcElements = {
+  krealer: 'fire',
+  lioran: 'water',
+  imuku: 'earth'
+};
+
 export const npcData = {
   first_memory: {
     name: 'Echo of a Name',

--- a/style/layout.css
+++ b/style/layout.css
@@ -123,6 +123,18 @@ body {
   background: #9b59b6;
 }
 
+.npc.fire {
+  background: #e74c3c;
+}
+
+.npc.water {
+  background: #3498db;
+}
+
+.npc.earth {
+  background: #2ecc71;
+}
+
 .echo {
   background: #95a5a6;
 }


### PR DESCRIPTION
## Summary
- Add CSS for fire (red), water (blue), and earth (green) NPCs
- Render element-specific NPC classes and map IDs to elements
- Document elemental NPC colors in game instructions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a067d5c48331a311fbac884b25bf