### PR TITLE
Add water NPC Hadoukai to map002

### DIFF
--- a/data/maps/map002.json
+++ b/data/maps/map002.json
@@ -381,7 +381,11 @@
       "G",
       "G",
       "G",
-      "G",
+      {
+        "type": "N",
+        "npc": "hadoukai",
+        "element": "water"
+      },
       "G",
       "F"
     ],

--- a/scripts/npc/hadoukai.js
+++ b/scripts/npc/hadoukai.js
@@ -1,0 +1,13 @@
+import { showDialogue } from '../dialogueSystem.js';
+
+const lines = [
+  'The tides whisper secrets to those who listen.',
+  'Ripples carry news from distant shores.',
+  'Still waters reflect the wanderer\'s soul.'
+];
+
+export function interact() {
+  const line = lines[Math.floor(Math.random() * lines.length)];
+  showDialogue(line);
+}
+

--- a/scripts/npc/index.js
+++ b/scripts/npc/index.js
@@ -1,7 +1,9 @@
 import * as imuku from './imuku.js';
 import * as braga from './braga.js';
+import * as hadoukai from './hadoukai.js';
 
 export const npcModules = {
   imuku,
   braga,
+  hadoukai,
 };

--- a/scripts/npcInfo.js
+++ b/scripts/npcInfo.js
@@ -103,6 +103,11 @@ export const npcInfoList = [
     id: 'braga',
     name: 'Braga',
     description: 'A flame-touched wanderer with a fondness for sparks.'
+  },
+  {
+    id: 'hadoukai',
+    name: 'Hadoukai',
+    description: 'A serene traveler attuned to flowing water.'
   }
 ];
 

--- a/scripts/npc_data.js
+++ b/scripts/npc_data.js
@@ -82,6 +82,13 @@ export const npcAppearance = {
     border: '#ff6666',
     displayTitle: 'Braga',
     dialogueScale: 1
+  },
+  hadoukai: {
+    nameColor: '#6699ff',
+    font: 'serif',
+    border: '#6699ff',
+    displayTitle: 'Hadoukai',
+    dialogueScale: 1
   }
 };
 
@@ -89,7 +96,8 @@ export const npcElements = {
   krealer: 'fire',
   lioran: 'water',
   imuku: 'earth',
-  braga: 'fire'
+  braga: 'fire',
+  hadoukai: 'water'
 };
 
 export const npcData = {


### PR DESCRIPTION
## Summary
- Place water NPC Hadoukai at map002 coordinate (8,27)
- Implement Hadoukai NPC with placeholder dialogue
- Register Hadoukai in NPC registry and metadata

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c0adb872048331b7b38a2d5510e5c9