### PR TITLE
Add stats button to bottom bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
       <div class="tab settings-tab">Settings</div>
       <div class="tab menu-tab">Menu</div>
       <div class="tab inventory-tab">Inventory</div>
+      <div class="tab stats-tab">Stats</div>
       <div class="tab save-tab">Save</div>
       <div class="tab load-tab">Load</div>
     </div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -94,6 +94,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const questsOverlay = document.getElementById('quest-log-overlay');
   const questsClose = questsOverlay.querySelector('.close-btn');
   const statusTab = document.querySelector('.status-tab');
+  const statsTab = document.querySelector('.stats-tab');
   const nullTab = document.querySelector('.null-tab');
   const statusOverlay = document.getElementById('status-overlay');
   const statusClose = statusOverlay?.querySelector('.close-btn');
@@ -220,6 +221,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (e.target === questsOverlay) toggleQuestLog();
   });
   if (statusTab) statusTab.addEventListener('click', toggleStatusPanel);
+  if (statsTab) statsTab.addEventListener('click', toggleStatusPanel);
   if (statusClose) statusClose.addEventListener('click', toggleStatusPanel);
   if (statusOverlay) {
     statusOverlay.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- Add 'Stats' tab to the bottom menu for quick access to the status overlay
- Wire new Stats tab to existing status panel toggle in main script

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1e3d7f97c833197c674f76e33f952