### PR TITLE
Set player name to Yorien

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
     <div id="status-overlay" class="status-overlay">
       <div class="status-content">
         <button class="close-btn">&times;</button>
-        <h2>Player Status</h2>
+        <h2>Yorien Status</h2>
         <div id="status-info"></div>
         <h3>Passive Skills</h3>
         <div id="status-passives"></div>

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -27,6 +27,7 @@ export function updatePassiveEffects() {
 }
 
 export const player = {
+  name: 'Yorien',
   x: 0,
   y: 0,
   hp: 100,

--- a/scripts/status_effect.js
+++ b/scripts/status_effect.js
@@ -13,7 +13,7 @@ export function tickStatusEffects(target, log) {
     }
     if (typeof log === 'function' && target.hp < prevHp) {
       const dmg = prevHp - target.hp;
-      const who = target.isPlayer ? 'You' : target.name || 'Enemy';
+      const who = target.isPlayer ? target.name || 'You' : target.name || 'Enemy';
       log(
         `${who} suffer${target.isPlayer ? '' : 's'} ${dmg} ${st.id.replace('_', ' ')} damage.`
       );
@@ -23,7 +23,7 @@ export function tickStatusEffects(target, log) {
       if (def.remove) def.remove(target);
       target.statuses.splice(i, 1);
       if (typeof log === 'function') {
-        const who = target.isPlayer ? 'You' : target.name || 'Enemy';
+        const who = target.isPlayer ? target.name || 'You' : target.name || 'Enemy';
         log(`${def.name || st.id} fades from ${who}.`);
       }
     }

--- a/ui/main_menu.js
+++ b/ui/main_menu.js
@@ -17,6 +17,7 @@ export function updateMenuStats() {
     ? `<span class="negative" title="${tooltip}">${def}</span>`
     : `<span title="${tooltip}">${def}</span>`;
   el.innerHTML = `
+    <div>Name: ${player.name}</div>
     <div>Level: ${player.level}</div>
     <div>HP: ${player.hp} / ${player.maxHp}</div>
     <div>ATK: ${stats.attack || 0}</div>


### PR DESCRIPTION
## Summary
- Give the player character the name **Yorien**
- Show Yorien's name in status effect messages and main menu
- Update status overlay heading to reflect the new name

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden for @eslint/js)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c2fd5f61248331a29e1a4f18fe07f1